### PR TITLE
Enable msvc build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@ modules.order
 Module.symvers
 Mkfile.old
 dkms.conf
+
+# IDE Files
+CMakeLists.txt.user

--- a/3rdparty/ezxml/ezxml.c
+++ b/3rdparty/ezxml/ezxml.c
@@ -27,7 +27,9 @@
 #include <stdarg.h>
 #include <string.h>
 #include <ctype.h>
+#ifndef _WIN32
 #include <unistd.h>
+#endif
 #include <sys/types.h>
 #ifndef EZXML_NOMMAP
 #include <sys/mman.h>
@@ -655,10 +657,10 @@ ezxml_t ezxml_parse_fd(int fd)
 // a wrapper for ezxml_parse_fd that accepts a file name
 ezxml_t ezxml_parse_file(const char *file)
 {
-    int fd = open(file, O_RDONLY, 0);
-    ezxml_t xml = ezxml_parse_fd(fd);
+    FILE* fp = fopen(file, "r");
+    ezxml_t xml = ezxml_parse_fp(fp);
     
-    if (fd >= 0) close(fd);
+    if (fp != 0) fclose(fp);
     return xml;
 }
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,7 @@ endif()
 add_library(${target_name} SHARED ${SRCFILES})
 
 target_compile_definitions(${target_name} PUBLIC HAVE_MEMMOVE=1 EZXML_NOMMAP)
+target_compile_definitions(${target_name} PRIVATE FMI4C_DLLEXPORT)
 
 target_include_directories(${target_name} PUBLIC include)
 target_include_directories(${target_name} PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/3rdparty>)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,7 @@ target_compile_definitions(${target_name} PUBLIC HAVE_MEMMOVE=1 EZXML_NOMMAP)
 target_include_directories(${target_name} PRIVATE src)
 target_include_directories(${target_name} PUBLIC include)
 target_include_directories(${target_name} PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/3rdparty>)
+target_include_directories(${target_name} PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/3rdparty/zlib-1.2.6>)
 
 target_link_libraries(${target_name} PRIVATE ${CMAKE_DL_LIBS}) # for libdl on Linux
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,9 +6,30 @@ set(target_name fmi4c)
 
 option(BUILD_DOCUMENTATION "Build Doxygen documentation" OFF)
 option(BUILD_TEST "Build test executable" OFF)
+option(USE_INCLUDED_ZLIB "Use the included zlib (statically linked) even if a system version is available" OFF)
 
 if (${BUILD_DOCUMENTATION})
     add_subdirectory(doc)
+endif()
+
+if(NOT USE_INCLUDED_ZLIB)
+    find_package(ZLIB MODULE)
+endif()
+# If zlib can not be found in the system, then build local version
+if (NOT ZLIB_FOUND)
+    set(zlib_dir "3rdparty/zlib-1.2.6")
+    message(STATUS "Using included ZLIB: ${zlib_dir}")
+    # Build as static lib as it will be used only internally in fmi4c
+    set(BUILD_SHARED_LIBS OFF)
+    # Must use position independent code if intend to include static zlib into shared (dll) fmi4c lib
+    set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+    # Add bundled sources, (EXCLUDE_FROM_ALL prevents zlib from being installed with fmi4c)
+    add_subdirectory(${zlib_dir} EXCLUDE_FROM_ALL)
+    # We highjack the zlib target from the original build system, but it does not have the include directory properties set, so lets add them here
+    set_target_properties(zlib PROPERTIES
+                               INTERFACE_INCLUDE_DIRECTORIES "${CMAKE_CURRENT_LIST_DIR}/${zlib_dir};${CMAKE_CURRENT_BINARY_DIR}/${zlib_dir}")
+    # Use alias to match name that find-module uses
+    add_library(ZLIB::ZLIB ALIAS zlib)
 endif()
 
 set(SRCFILES
@@ -30,20 +51,8 @@ set(SRCFILES
     3rdparty/minizip/ioapi.c
     3rdparty/minizip/mztools.c
     3rdparty/minizip/unzip.c
-    3rdparty/zlib-1.2.6/crc32.c
-    3rdparty/zlib-1.2.6/inflate.c
-    3rdparty/zlib-1.2.6/adler32.c
-    3rdparty/zlib-1.2.6/inftrees.c
-    3rdparty/zlib-1.2.6/inffast.c
-    3rdparty/zlib-1.2.6/zutil.c
-    3rdparty/zlib-1.2.6/gzwrite.c
-    3rdparty/zlib-1.2.6/gzlib.c
-    3rdparty/zlib-1.2.6/deflate.c
-    3rdparty/zlib-1.2.6/trees.c
     3rdparty/ezxml/ezxml.c
     3rdparty/ezxml/ezxml.h)
-
-
 if (WIN32)
     SET(SRCFILES ${SRCFILES} 3rdparty/minizip/iowin32.c)
 endif()
@@ -52,16 +61,17 @@ add_library(${target_name} SHARED ${SRCFILES})
 
 target_compile_definitions(${target_name} PUBLIC HAVE_MEMMOVE=1 EZXML_NOMMAP)
 
-target_include_directories(${target_name} PRIVATE src)
 target_include_directories(${target_name} PUBLIC include)
 target_include_directories(${target_name} PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/3rdparty>)
-target_include_directories(${target_name} PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/3rdparty/zlib-1.2.6>)
+target_include_directories(${target_name} PRIVATE src)
 
-target_link_libraries(${target_name} PRIVATE ${CMAKE_DL_LIBS}) # for libdl on Linux
+# Internal dependecy (PRIVATE) on zlib and ${CMAKE_DL_LIBS}) for libdl on Linux
+target_link_libraries(${target_name} PRIVATE ZLIB::ZLIB ${CMAKE_DL_LIBS})
 
 install(TARGETS ${target_name}
         RUNTIME DESTINATION bin
-        LIBRARY DESTINATION lib)
+        LIBRARY DESTINATION lib
+        ARCHIVE DESTINATION lib)
 install(DIRECTORY include
         DESTINATION .)
 install(DIRECTORY 3rdparty/fmi

--- a/include/fmi4c.h
+++ b/include/fmi4c.h
@@ -1,16 +1,6 @@
 #ifndef FMIC_H
 #define FMIC_H
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <stdbool.h>
-#include <stdint.h>
-
-#ifdef _WIN32
-#include <direct.h>
-#include <windows.h>
-#endif
-
 #include "fmi4c_types.h"
 #include "fmi4c_types_fmi1.h"
 #include "fmi4c_types_fmi2.h"
@@ -19,6 +9,14 @@
 #include "fmi4c_functions_fmi2.h"
 #include "fmi4c_functions_fmi3.h"
 #include "fmi4c_public.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#ifdef _WIN32
+#include <direct.h>
+#include <windows.h>
+#endif
 
 #undef fmiVersion
 

--- a/include/fmi4c.h
+++ b/include/fmi4c.h
@@ -192,68 +192,68 @@ FMI4C_DLLAPI fmi2Status fmi2SetBoolean(fmiHandle* fmu, const fmi2ValueReference 
 FMI4C_DLLAPI fmi2Status fmi2SetString(fmiHandle* fmu, const fmi2ValueReference valueReferences[], size_t nValueReferences, const fmi2String values[]);
 
 FMI4C_DLLAPI fmi2Status fmi2GetFMUstate(fmiHandle* fmu,
-                                          fmi2FMUstate* FMUstate);
+                                        fmi2FMUstate* FMUstate);
 FMI4C_DLLAPI fmi2Status fmi2SetFMUstate(fmiHandle* fmu,
-                                          fmi2FMUstate FMUstate);
+                                        fmi2FMUstate FMUstate);
 FMI4C_DLLAPI fmi2Status fmi2FreeFMUstate(fmiHandle* fmu,
-                                           fmi2FMUstate* FMUstate);
+                                         fmi2FMUstate* FMUstate);
 FMI4C_DLLAPI fmi2Status fmi2SerializedFMUstateSize(fmiHandle* fmu,
-                                                     fmi2FMUstate FMUstate,
-                                                     size_t* size);
+                                                   fmi2FMUstate FMUstate,
+                                                   size_t* size);
 FMI4C_DLLAPI fmi2Status fmi2SerializeFMUstate(fmiHandle* fmu,
-                                                fmi2FMUstate FMUstate,
-                                                fmi2Byte serializedState[],
-                                                size_t size);
+                                              fmi2FMUstate FMUstate,
+                                              fmi2Byte serializedState[],
+                                              size_t size);
 FMI4C_DLLAPI fmi2Status fmi2DeSerializeFMUstate(fmiHandle* fmu,
-                                                  const fmi2Byte serializedState[],
-                                                  size_t size,
-                                                  fmi2FMUstate* FMUstate);
+                                                const fmi2Byte serializedState[],
+                                                size_t size,
+                                                fmi2FMUstate* FMUstate);
 
 FMI4C_DLLAPI fmi2Status fmi2GetDirectionalDerivative(fmiHandle* fmu,
-                                                       const fmi2ValueReference unknownReferences[],
-                                                       size_t nUnknown,
-                                                       const fmi2ValueReference knownReferences[],
-                                                       size_t nKnown,
-                                                       const fmi2Real dvKnown[],
-                                                       fmi2Real dvUnknown[]);
+                                                     const fmi2ValueReference unknownReferences[],
+                                                     size_t nUnknown,
+                                                     const fmi2ValueReference knownReferences[],
+                                                     size_t nKnown,
+                                                     const fmi2Real dvKnown[],
+                                                     fmi2Real dvUnknown[]);
 
 FMI4C_DLLAPI fmi2Status fmi2EnterEventMode(fmiHandle* fmu);
 FMI4C_DLLAPI fmi2Status fmi2NewDiscreteStates(fmiHandle* fmu, fmi2EventInfo* eventInfo);
 FMI4C_DLLAPI fmi2Status fmi2EnterContinuousTimeMode(fmiHandle* fmu);
 FMI4C_DLLAPI fmi2Status fmi2CompletedIntegratorStep(fmiHandle* fmu,
-                                                      fmi2Boolean noSetFMUStatePriorToCurrentPoint,
-                                                      fmi2Boolean* enterEventMode,
-                                                      fmi2Boolean* terminateSimulation);
+                                                    fmi2Boolean noSetFMUStatePriorToCurrentPoint,
+                                                    fmi2Boolean* enterEventMode,
+                                                    fmi2Boolean* terminateSimulation);
 
 FMI4C_DLLAPI fmi2Status fmi2SetTime(fmiHandle* fmu,
-                                      fmi2Real time);
+                                    fmi2Real time);
 FMI4C_DLLAPI fmi2Status fmi2SetContinuousStates(fmiHandle* fmu,
-                                                  const fmi2Real x[],
-                                                  size_t nx);
+                                                const fmi2Real x[],
+                                                size_t nx);
 
 FMI4C_DLLAPI fmi2Status fmi2GetDerivatives(fmiHandle* fmu,
-                                             fmi2Real derivatives[],
-                                             size_t nx);
+                                           fmi2Real derivatives[],
+                                           size_t nx);
 FMI4C_DLLAPI fmi2Status fmi2GetEventIndicators(fmiHandle* fmu,
-                                                 fmi2Real eventIndicators[],
-                                                 size_t ni);
+                                               fmi2Real eventIndicators[],
+                                               size_t ni);
 FMI4C_DLLAPI fmi2Status fmi2GetContinuousStates(fmiHandle* fmu,
-                                                  fmi2Real x[],
-                                                  size_t nx);
+                                                fmi2Real x[],
+                                                size_t nx);
 FMI4C_DLLAPI fmi2Status fmi2GetNominalsOfContinuousStates(fmiHandle* fmu,
-                                                            fmi2Real x_nominal[],
-                                                            size_t nx);
+                                                          fmi2Real x_nominal[],
+                                                          size_t nx);
 
 FMI4C_DLLAPI fmi2Status fmi2SetRealInputDerivatives(fmiHandle* fmu,
+                                                    const fmi2ValueReference vr[],
+                                                    size_t nvr,
+                                                    const fmi2Integer order[],
+                                                    const fmi2Real value[]);
+FMI4C_DLLAPI fmi2Status fmi2GetRealOutputDerivatives (fmiHandle* fmu,
                                                       const fmi2ValueReference vr[],
                                                       size_t nvr,
                                                       const fmi2Integer order[],
-                                                      const fmi2Real value[]);
-FMI4C_DLLAPI fmi2Status fmi2GetRealOutputDerivatives (fmiHandle* fmu,
-                                                        const fmi2ValueReference vr[],
-                                                        size_t nvr,
-                                                        const fmi2Integer order[],
-                                                        fmi2Real value[]);
+                                                      fmi2Real value[]);
 
 FMI4C_DLLAPI fmi2Status fmi2DoStep(fmiHandle *fmu, fmi2Real, fmi2Real, fmi2Boolean);
 FMI4C_DLLAPI fmi2Status fmi2CancelStep(fmiHandle* fmu);
@@ -325,175 +325,175 @@ FMI4C_DLLAPI int fmi3GetNumberOfDisplayUnits(fmi3UnitHandle *unit);
 FMI4C_DLLAPI void fmi3GetDisplayUnitByIndex(fmi3UnitHandle *unit, int id, const char **name, double *factor, double *offset, bool *inverse);
 
 FMI4C_DLLAPI void fmi3GetFloat64Type(fmiHandle* fmu,
-                                       const char* name,
-                                       const char** description,
-                                       const char** quantity,
-                                       const char** unit,
-                                       const char** displayUnit,
-                                       bool* relativeQuantity,
-                                       bool* unbounded,
-                                       double* min,
-                                       double* max,
-                                       double* nominal);
+                                     const char* name,
+                                     const char** description,
+                                     const char** quantity,
+                                     const char** unit,
+                                     const char** displayUnit,
+                                     bool* relativeQuantity,
+                                     bool* unbounded,
+                                     double* min,
+                                     double* max,
+                                     double* nominal);
 FMI4C_DLLAPI void fmi3GetFloat32Type(fmiHandle* fmu,
-                                       const char* name,
-                                       const char** description,
-                                       const char** quantity,
-                                       const char** unit,
-                                       const char** displayUnit,
-                                       bool* relativeQuantity,
-                                       bool* unbounded,
-                                       double* min,
-                                       double* max,
-                                       double* nominal);
+                                     const char* name,
+                                     const char** description,
+                                     const char** quantity,
+                                     const char** unit,
+                                     const char** displayUnit,
+                                     bool* relativeQuantity,
+                                     bool* unbounded,
+                                     double* min,
+                                     double* max,
+                                     double* nominal);
 FMI4C_DLLAPI void fmi3GetInt64Type(fmiHandle *fmu,
-                                     const char *name,
-                                     const char** description,
-                                     const char** quantity,
-                                     double* min,
-                                     double* max);
+                                   const char *name,
+                                   const char** description,
+                                   const char** quantity,
+                                   double* min,
+                                   double* max);
 FMI4C_DLLAPI void fmi3GetInt32Type(fmiHandle *fmu,
-                                     const char *name,
-                                     const char** description,
-                                     const char** quantity,
-                                     double* min,
-                                     double* max);
+                                   const char *name,
+                                   const char** description,
+                                   const char** quantity,
+                                   double* min,
+                                   double* max);
 FMI4C_DLLAPI void fmi3GetInt16Type(fmiHandle *fmu,
-                                     const char *name,
-                                     const char** description,
-                                     const char** quantity,
-                                     double* min,
-                                     double* max);
+                                   const char *name,
+                                   const char** description,
+                                   const char** quantity,
+                                   double* min,
+                                   double* max);
 FMI4C_DLLAPI void fmi3GetInt8Type(fmiHandle *fmu,
-                                     const char *name,
-                                     const char** description,
-                                     const char** quantity,
-                                     double* min,
-                                     double* max);
+                                  const char *name,
+                                  const char** description,
+                                  const char** quantity,
+                                  double* min,
+                                  double* max);
 FMI4C_DLLAPI void fmi3GetUInt64Type(fmiHandle *fmu,
-                                     const char *name,
-                                     const char** description,
-                                     const char** quantity,
-                                     double* min,
-                                     double* max);
+                                    const char *name,
+                                    const char** description,
+                                    const char** quantity,
+                                    double* min,
+                                    double* max);
 FMI4C_DLLAPI void fmi3GetUInt32Type(fmiHandle *fmu,
-                                     const char *name,
-                                     const char** description,
-                                     const char** quantity,
-                                     double* min,
-                                     double* max);
+                                    const char *name,
+                                    const char** description,
+                                    const char** quantity,
+                                    double* min,
+                                    double* max);
 FMI4C_DLLAPI void fmi3GetUInt16Type(fmiHandle *fmu,
-                                     const char *name,
-                                     const char** description,
-                                     const char** quantity,
-                                     double* min,
-                                     double* max);
+                                    const char *name,
+                                    const char** description,
+                                    const char** quantity,
+                                    double* min,
+                                    double* max);
 FMI4C_DLLAPI void fmi3GetUInt8Type(fmiHandle *fmu,
-                                     const char *name,
-                                     const char** description,
-                                     const char** quantity,
-                                     double* min,
-                                     double* max);
+                                   const char *name,
+                                   const char** description,
+                                   const char** quantity,
+                                   double* min,
+                                   double* max);
 FMI4C_DLLAPI void fmi3GetBooleanType(fmiHandle *fmu,
-                                       const char *name,
-                                       const char **description);
-FMI4C_DLLAPI void fmi3GetStringType(fmiHandle *fmu,
-                                      const char *name,
-                                      const char **description);
-FMI4C_DLLAPI void fmi3GetBinaryType(fmiHandle *fmu,
-                                      const char *name,
-                                      const char **description,
-                                      const char **mimeType,
-                                      uint32_t *maxSize);
-FMI4C_DLLAPI void fmi3GetEnumerationType(fmiHandle *fmu,
-                                           const char *name,
-                                           const char **description,
-                                           const char **quantity,
-                                           int64_t *min,
-                                           int64_t *max,
-                                           int *numberOfItems);
-FMI4C_DLLAPI void fmi3GetEnumerationItem(fmiHandle *fmu,
-                                           const char *typeName,
-                                           int itemId,
-                                           const char **itemName,
-                                           int64_t *value,
-                                           const char **description);
-FMI4C_DLLAPI void fmi3GetClockType(fmiHandle *fmu,
                                      const char *name,
-                                     const char **description,
-                                     bool *canBeDeactivated,
-                                     uint32_t *priority,
-                                     fmi3IntervalVariability *intervalVariability,
-                                     float *intervalDecimal,
-                                     float *shiftDecimal,
-                                     bool *supportsFraction,
-                                     uint64_t *resolution,
-                                     uint64_t *intervalCounter,
-                                     uint64_t *shiftCounter);
+                                     const char **description);
+FMI4C_DLLAPI void fmi3GetStringType(fmiHandle *fmu,
+                                    const char *name,
+                                    const char **description);
+FMI4C_DLLAPI void fmi3GetBinaryType(fmiHandle *fmu,
+                                    const char *name,
+                                    const char **description,
+                                    const char **mimeType,
+                                    uint32_t *maxSize);
+FMI4C_DLLAPI void fmi3GetEnumerationType(fmiHandle *fmu,
+                                         const char *name,
+                                         const char **description,
+                                         const char **quantity,
+                                         int64_t *min,
+                                         int64_t *max,
+                                         int *numberOfItems);
+FMI4C_DLLAPI void fmi3GetEnumerationItem(fmiHandle *fmu,
+                                         const char *typeName,
+                                         int itemId,
+                                         const char **itemName,
+                                         int64_t *value,
+                                         const char **description);
+FMI4C_DLLAPI void fmi3GetClockType(fmiHandle *fmu,
+                                   const char *name,
+                                   const char **description,
+                                   bool *canBeDeactivated,
+                                   uint32_t *priority,
+                                   fmi3IntervalVariability *intervalVariability,
+                                   float *intervalDecimal,
+                                   float *shiftDecimal,
+                                   bool *supportsFraction,
+                                   uint64_t *resolution,
+                                   uint64_t *intervalCounter,
+                                   uint64_t *shiftCounter);
 
 FMI4C_DLLAPI int fmi3GetNumberOfLogCategories(fmiHandle *fmu);
 FMI4C_DLLAPI void fmi3GetLogCategory(fmiHandle *fmu, int id, const char **name, const char **description);
 
 FMI4C_DLLAPI int fmi3GetNumberOfModelStructureOutputs(fmiHandle *fmu);
 FMI4C_DLLAPI void fmi3GetModelStructureOutput(fmiHandle *fmu,
-                                      int id,
-                                      fmi3ValueReference *vr,
-                                      int *numberOfDependencies,
-                                      bool *dependencyKindsDefined);
+                                              int id,
+                                              fmi3ValueReference *vr,
+                                              int *numberOfDependencies,
+                                              bool *dependencyKindsDefined);
 FMI4C_DLLAPI fmi3ValueReference fmi3GetModelStructureOutputDependency(fmiHandle *fmu,
-                                                          int outputId,
-                                                          int dependencyId);
+                                                                      int outputId,
+                                                                      int dependencyId);
 FMI4C_DLLAPI fmi3ValueReference fmi3GetModelStructureOutputDependencyKind(fmiHandle *fmu,
-                                                              int outputId,
-                                                              int dependencyId);
+                                                                          int outputId,
+                                                                          int dependencyId);
 FMI4C_DLLAPI int fmi3GetNumberOfModelStructureContinuousStateDerivatives(fmiHandle *fmu);
 FMI4C_DLLAPI void fmi3GetModelStructureContinuousStateDerivative(fmiHandle *fmu,
-                                      int id,
-                                      fmi3ValueReference *vr,
-                                      int *numberOfDependencies,
-                                      bool *dependencyKindsDefined);
+                                                                 int id,
+                                                                 fmi3ValueReference *vr,
+                                                                 int *numberOfDependencies,
+                                                                 bool *dependencyKindsDefined);
 FMI4C_DLLAPI fmi3ValueReference fmi3GetModelStructureContinuousStateDerivativeDependency(fmiHandle *fmu,
-                                                          int derId,
-                                                          int dependencyId);
+                                                                                         int derId,
+                                                                                         int dependencyId);
 FMI4C_DLLAPI fmi3ValueReference fmi3GetModelStructureContinuousStateDerivativeDependencyKind(fmiHandle *fmu,
-                                                              int derId,
-                                                              int dependencyId);
+                                                                                             int derId,
+                                                                                             int dependencyId);
 FMI4C_DLLAPI int fmi3GetNumberOfModelStructureClockedStates(fmiHandle *fmu);
 FMI4C_DLLAPI void fmi3GetModelStructureClockedState(fmiHandle *fmu,
-                                      int id,
-                                      fmi3ValueReference *vr,
-                                      int *numberOfDependencies,
-                                      bool *dependencyKindsDefined);
+                                                    int id,
+                                                    fmi3ValueReference *vr,
+                                                    int *numberOfDependencies,
+                                                    bool *dependencyKindsDefined);
 FMI4C_DLLAPI fmi3ValueReference fmi3GetModelStructureClockedStateDependency(fmiHandle *fmu,
-                                                          int clockId,
-                                                          int dependencyId);
+                                                                            int clockId,
+                                                                            int dependencyId);
 FMI4C_DLLAPI fmi3ValueReference fmi3GetModelStructureClockedStateDependencyKind(fmiHandle *fmu,
-                                                              int clockId,
-                                                              int dependencyId);
+                                                                                int clockId,
+                                                                                int dependencyId);
 FMI4C_DLLAPI int fmi3GetNumberOfModelStructureInitialUnknowns(fmiHandle *fmu);
 FMI4C_DLLAPI void fmi3GetModelStructureInitialUnknown(fmiHandle *fmu,
-                                      int id,
-                                      fmi3ValueReference *vr,
-                                      int *numberOfDependencies,
-                                      bool *dependencyKindsDefined);
+                                                      int id,
+                                                      fmi3ValueReference *vr,
+                                                      int *numberOfDependencies,
+                                                      bool *dependencyKindsDefined);
 FMI4C_DLLAPI fmi3ValueReference fmi3GetModelStructureInitialUnknownDependency(fmiHandle *fmu,
-                                                          int unknownId,
-                                                          int dependencyId);
+                                                                              int unknownId,
+                                                                              int dependencyId);
 FMI4C_DLLAPI fmi3ValueReference fmi3ModelStructureGetInitialUnknownDependencyKind(fmiHandle *fmu,
-                                                              int unknownId,
-                                                              int dependencyId);
+                                                                                  int unknownId,
+                                                                                  int dependencyId);
 FMI4C_DLLAPI int fmi3GetNumberOfModelStructureEventIndicators(fmiHandle *fmu);
 FMI4C_DLLAPI void fmi3GetModelStructureEventIndicator(fmiHandle *fmu,
-                                      int id,
-                                      fmi3ValueReference *vr,
-                                      int *numberOfDependencies,
-                                      bool *dependencyKindsDefined);
+                                                      int id,
+                                                      fmi3ValueReference *vr,
+                                                      int *numberOfDependencies,
+                                                      bool *dependencyKindsDefined);
 FMI4C_DLLAPI fmi3ValueReference fmi3GetModelStructureEventIndicatorDependency(fmiHandle *fmu,
-                                                          int indicatorId,
-                                                          int dependencyId);
+                                                                              int indicatorId,
+                                                                              int dependencyId);
 FMI4C_DLLAPI fmi3ValueReference fmi3GetModelStructureEventIndicatorDependencyKind(fmiHandle *fmu,
-                                                              int indicatorId,
-                                                              int dependencyId);
+                                                                                  int indicatorId,
+                                                                                  int dependencyId);
 
 FMI4C_DLLAPI const char* fmi3GetModelIdentifier(fmiHandle* fmu);
 FMI4C_DLLAPI bool fmi3GetNeedsExecutionTool(fmiHandle* fmu);
@@ -514,47 +514,47 @@ FMI4C_DLLAPI bool fmi3GetRecommendedIntermediateInputSmoothness(fmiHandle* fmu);
 FMI4C_DLLAPI bool fmi3GetNeedsCompletedIntegratorStep(fmiHandle* fmu);
 
 FMI4C_DLLAPI bool fmi3InstantiateCoSimulation(fmiHandle *fmu,
-                             fmi3Boolean                    visible,
-                             fmi3Boolean                    loggingOn,
-                             fmi3Boolean                    eventModeUsed,
-                             fmi3Boolean                    earlyReturnAllowed,
-                             const fmi3ValueReference       requiredIntermediateVariables[],
-                             size_t                         nRequiredIntermediateVariables,
-                             fmi3InstanceEnvironment        instanceEnvironment,
-                             fmi3CallbackLogMessage         logMessage,
-                             fmi3CallbackIntermediateUpdate intermediateUpdate);
+                                              fmi3Boolean                    visible,
+                                              fmi3Boolean                    loggingOn,
+                                              fmi3Boolean                    eventModeUsed,
+                                              fmi3Boolean                    earlyReturnAllowed,
+                                              const fmi3ValueReference       requiredIntermediateVariables[],
+                                              size_t                         nRequiredIntermediateVariables,
+                                              fmi3InstanceEnvironment        instanceEnvironment,
+                                              fmi3CallbackLogMessage         logMessage,
+                                              fmi3CallbackIntermediateUpdate intermediateUpdate);
 
 FMI4C_DLLAPI bool fmi3InstantiateModelExchange(fmiHandle *fmu,
-                                                 fmi3Boolean                visible,
-                                                 fmi3Boolean                loggingOn,
-                                                 fmi3InstanceEnvironment    instanceEnvironment,
-                                                 fmi3CallbackLogMessage     logMessage);
+                                               fmi3Boolean                visible,
+                                               fmi3Boolean                loggingOn,
+                                               fmi3InstanceEnvironment    instanceEnvironment,
+                                               fmi3CallbackLogMessage     logMessage);
 
 FMI4C_DLLAPI const char* fmi3GetVersion(fmiHandle *fmu);
 
 FMI4C_DLLAPI fmi3Status fmi3SetDebugLogging(fmiHandle *fmu,
-                           fmi3Boolean loggingOn,
-                           size_t nCategories,
-                           const fmi3String categories[]);
+                                            fmi3Boolean loggingOn,
+                                            size_t nCategories,
+                                            const fmi3String categories[]);
 
 FMI4C_DLLAPI fmi3Status fmi3GetFloat64(fmiHandle *fmu,
-                      const fmi3ValueReference valueReferences[],
-                      size_t nValueReferences,
-                      fmi3Float64 values[],
-                      size_t nValues);
+                                       const fmi3ValueReference valueReferences[],
+                                       size_t nValueReferences,
+                                       fmi3Float64 values[],
+                                       size_t nValues);
 
 FMI4C_DLLAPI fmi3Status fmi3SetFloat64(fmiHandle *fmu,
-                      const fmi3ValueReference valueReferences[],
-                      size_t nValueReferences,
-                      fmi3Float64 values[],
-                      size_t nValues);
+                                       const fmi3ValueReference valueReferences[],
+                                       size_t nValueReferences,
+                                       fmi3Float64 values[],
+                                       size_t nValues);
 
 FMI4C_DLLAPI fmi3Status fmi3EnterInitializationMode(fmiHandle *fmu,
-                                   fmi3Boolean toleranceDefined,
-                                   fmi3Float64 tolerance,
-                                   fmi3Float64 startTime,
-                                   fmi3Boolean stopTimeDefined,
-                                   fmi3Float64 stopTime);
+                                                    fmi3Boolean toleranceDefined,
+                                                    fmi3Float64 tolerance,
+                                                    fmi3Float64 startTime,
+                                                    fmi3Boolean stopTimeDefined,
+                                                    fmi3Float64 stopTime);
 
 FMI4C_DLLAPI fmi3Status fmi3ExitInitializationMode(fmiHandle *fmu);
 
@@ -563,191 +563,191 @@ FMI4C_DLLAPI fmi3Status fmi3Terminate(fmiHandle *fmu);
 FMI4C_DLLAPI void fmi3FreeInstance(fmiHandle *fmu);
 
 FMI4C_DLLAPI fmi3Status fmi3DoStep(fmiHandle *fmu,
-                  fmi3Float64 currentCommunicationPoint,
-                  fmi3Float64 communicationStepSize,
-                  fmi3Boolean noSetFMUStatePriorToCurrentPoint,
-                  fmi3Boolean *eventEncountered,
-                  fmi3Boolean *terminateSimulation,
-                  fmi3Boolean *earlyReturn,
-                  fmi3Float64 *lastSuccessfulTime);
+                                   fmi3Float64 currentCommunicationPoint,
+                                   fmi3Float64 communicationStepSize,
+                                   fmi3Boolean noSetFMUStatePriorToCurrentPoint,
+                                   fmi3Boolean *eventEncountered,
+                                   fmi3Boolean *terminateSimulation,
+                                   fmi3Boolean *earlyReturn,
+                                   fmi3Float64 *lastSuccessfulTime);
 
 FMI4C_DLLAPI fmi3Status fmi3EnterEventMode(fmiHandle *fmu,
-                                                 fmi3Boolean stepEvent,
-                                                 fmi3Boolean stateEvent,
-                                                 const fmi3Int32 rootsFound[],
-                                                 size_t nEventIndicators,
-                                                 fmi3Boolean timeEvent);
+                                           fmi3Boolean stepEvent,
+                                           fmi3Boolean stateEvent,
+                                           const fmi3Int32 rootsFound[],
+                                           size_t nEventIndicators,
+                                           fmi3Boolean timeEvent);
 
 FMI4C_DLLAPI fmi3Status fmi3Reset(fmiHandle *fmu);
 
 FMI4C_DLLAPI fmi3Status fmi3GetFloat32(fmiHandle *fmu,
-                                             const fmi3ValueReference valueReferences[],
-                                             size_t nValueReferences,
-                                             fmi3Float32 values[],
-                                             size_t nValues);
+                                       const fmi3ValueReference valueReferences[],
+                                       size_t nValueReferences,
+                                       fmi3Float32 values[],
+                                       size_t nValues);
 
 FMI4C_DLLAPI fmi3Status fmi3GetInt8(fmiHandle *fmu,
-                                          const fmi3ValueReference valueReferences[],
-                                          size_t nValueReferences,
-                                          fmi3Int8 values[],
-                                          size_t nValues);
+                                    const fmi3ValueReference valueReferences[],
+                                    size_t nValueReferences,
+                                    fmi3Int8 values[],
+                                    size_t nValues);
 
 FMI4C_DLLAPI fmi3Status fmi3GetUInt8(fmiHandle *fmu,
-                                           const fmi3ValueReference valueReferences[],
-                                           size_t nValueReferences,
-                                           fmi3UInt8 values[],
-                                           size_t nValues);
+                                     const fmi3ValueReference valueReferences[],
+                                     size_t nValueReferences,
+                                     fmi3UInt8 values[],
+                                     size_t nValues);
 
 FMI4C_DLLAPI fmi3Status fmi3GetInt16(fmiHandle *fmu,
-                                           const fmi3ValueReference valueReferences[],
-                                           size_t nValueReferences,
-                                           fmi3Int16 values[],
-                                           size_t nValues);
+                                     const fmi3ValueReference valueReferences[],
+                                     size_t nValueReferences,
+                                     fmi3Int16 values[],
+                                     size_t nValues);
 
 FMI4C_DLLAPI fmi3Status fmi3GetUInt16(fmiHandle *fmu,
-                                            const fmi3ValueReference valueReferences[],
-                                            size_t nValueReferences,
-                                            fmi3UInt16 values[],
-                                            size_t nValues);
+                                      const fmi3ValueReference valueReferences[],
+                                      size_t nValueReferences,
+                                      fmi3UInt16 values[],
+                                      size_t nValues);
 
 FMI4C_DLLAPI fmi3Status fmi3GetInt32(fmiHandle *fmu,
-                                           const fmi3ValueReference valueReferences[],
-                                           size_t nValueReferences,
-                                           fmi3Int32 values[],
-                                           size_t nValues);
+                                     const fmi3ValueReference valueReferences[],
+                                     size_t nValueReferences,
+                                     fmi3Int32 values[],
+                                     size_t nValues);
 
 FMI4C_DLLAPI fmi3Status fmi3GetUInt32(fmiHandle *fmu,
-                                            const fmi3ValueReference valueReferences[],
-                                            size_t nValueReferences,
-                                            fmi3UInt32 values[],
-                                            size_t nValues);
+                                      const fmi3ValueReference valueReferences[],
+                                      size_t nValueReferences,
+                                      fmi3UInt32 values[],
+                                      size_t nValues);
 
 FMI4C_DLLAPI fmi3Status fmi3GetInt64(fmiHandle *fmu,
-                                           const fmi3ValueReference valueReferences[],
-                                           size_t nValueReferences,
-                                           fmi3Int64 values[],
-                                           size_t nValues);
+                                     const fmi3ValueReference valueReferences[],
+                                     size_t nValueReferences,
+                                     fmi3Int64 values[],
+                                     size_t nValues);
 
 FMI4C_DLLAPI fmi3Status fmi3GetUInt64(fmiHandle *fmu,
-                                            const fmi3ValueReference valueReferences[],
-                                            size_t nValueReferences,
-                                            fmi3UInt64 values[],
-                                            size_t nValues);
+                                      const fmi3ValueReference valueReferences[],
+                                      size_t nValueReferences,
+                                      fmi3UInt64 values[],
+                                      size_t nValues);
 
 FMI4C_DLLAPI fmi3Status fmi3GetBoolean(fmiHandle *fmu,
-                                             const fmi3ValueReference valueReferences[],
-                                             size_t nValueReferences,
-                                             fmi3Boolean values[],
-                                             size_t nValues);
+                                       const fmi3ValueReference valueReferences[],
+                                       size_t nValueReferences,
+                                       fmi3Boolean values[],
+                                       size_t nValues);
 
 FMI4C_DLLAPI fmi3Status fmi3GetString(fmiHandle *fmu,
-                                            const fmi3ValueReference valueReferences[],
-                                            size_t nValueReferences,
-                                            fmi3String values[],
-                                            size_t nValues);
+                                      const fmi3ValueReference valueReferences[],
+                                      size_t nValueReferences,
+                                      fmi3String values[],
+                                      size_t nValues);
 
 FMI4C_DLLAPI fmi3Status fmi3GetBinary(fmiHandle *fmu,
-                                            const fmi3ValueReference valueReferences[],
-                                            size_t nValueReferences,
-                                            size_t valueSizes[],
-                                            fmi3Binary values[],
-                                            size_t nValues);
+                                      const fmi3ValueReference valueReferences[],
+                                      size_t nValueReferences,
+                                      size_t valueSizes[],
+                                      fmi3Binary values[],
+                                      size_t nValues);
 
 FMI4C_DLLAPI fmi3Status fmi3GetClock(fmiHandle *fmu,
-                                           const fmi3ValueReference valueReferences[],
-                                           size_t nValueReferences,
-                                           fmi3Clock values[]);
+                                     const fmi3ValueReference valueReferences[],
+                                     size_t nValueReferences,
+                                     fmi3Clock values[]);
 
 FMI4C_DLLAPI fmi3Status fmi3SetFloat32(fmiHandle *fmu,
-                                             const fmi3ValueReference valueReferences[],
-                                             size_t nValueReferences,
-                                             const fmi3Float32 values[],
-                                             size_t nValues);
+                                       const fmi3ValueReference valueReferences[],
+                                       size_t nValueReferences,
+                                       const fmi3Float32 values[],
+                                       size_t nValues);
 
 FMI4C_DLLAPI fmi3Status fmi3SetInt8(fmiHandle *fmu,
-                                          const fmi3ValueReference valueReferences[],
-                                          size_t nValueReferences,
-                                          const fmi3Int8 values[],
-                                          size_t nValues);
+                                    const fmi3ValueReference valueReferences[],
+                                    size_t nValueReferences,
+                                    const fmi3Int8 values[],
+                                    size_t nValues);
 
 FMI4C_DLLAPI fmi3Status fmi3SetUInt8(fmiHandle *fmu,
-                                           const fmi3ValueReference valueReferences[],
-                                           size_t nValueReferences,
-                                           const fmi3UInt8 values[],
-                                           size_t nValues);
+                                     const fmi3ValueReference valueReferences[],
+                                     size_t nValueReferences,
+                                     const fmi3UInt8 values[],
+                                     size_t nValues);
 
 FMI4C_DLLAPI fmi3Status fmi3SetInt16(fmiHandle *fmu,
-                                           const fmi3ValueReference valueReferences[],
-                                           size_t nValueReferences,
-                                           const fmi3Int16 values[],
-                                           size_t nValues);
+                                     const fmi3ValueReference valueReferences[],
+                                     size_t nValueReferences,
+                                     const fmi3Int16 values[],
+                                     size_t nValues);
 
 FMI4C_DLLAPI fmi3Status fmi3SetUInt16(fmiHandle *fmu,
-                                            const fmi3ValueReference valueReferences[],
-                                            size_t nValueReferences,
-                                            const fmi3UInt16 values[],
-                                            size_t nValues);
+                                      const fmi3ValueReference valueReferences[],
+                                      size_t nValueReferences,
+                                      const fmi3UInt16 values[],
+                                      size_t nValues);
 
 FMI4C_DLLAPI fmi3Status fmi3SetInt32(fmiHandle *fmu,
-                                           const fmi3ValueReference valueReferences[],
-                                           size_t nValueReferences,
-                                           const fmi3Int32 values[],
-                                           size_t nValues);
+                                     const fmi3ValueReference valueReferences[],
+                                     size_t nValueReferences,
+                                     const fmi3Int32 values[],
+                                     size_t nValues);
 
 FMI4C_DLLAPI fmi3Status fmi3SetUInt32(fmiHandle *fmu,
-                                            const fmi3ValueReference valueReferences[],
-                                            size_t nValueReferences,
-                                            const fmi3UInt32 values[],
-                                            size_t nValues);
+                                      const fmi3ValueReference valueReferences[],
+                                      size_t nValueReferences,
+                                      const fmi3UInt32 values[],
+                                      size_t nValues);
 
 FMI4C_DLLAPI fmi3Status fmi3SetInt64(fmiHandle *fmu,
-                                           const fmi3ValueReference valueReferences[],
-                                           size_t nValueReferences,
-                                           const fmi3Int64 values[],
-                                           size_t nValues);
+                                     const fmi3ValueReference valueReferences[],
+                                     size_t nValueReferences,
+                                     const fmi3Int64 values[],
+                                     size_t nValues);
 
 FMI4C_DLLAPI fmi3Status fmi3SetUInt64(fmiHandle *fmu,
-                                            const fmi3ValueReference valueReferences[],
-                                            size_t nValueReferences,
-                                            const fmi3UInt64 values[],
-                                            size_t nValues);
+                                      const fmi3ValueReference valueReferences[],
+                                      size_t nValueReferences,
+                                      const fmi3UInt64 values[],
+                                      size_t nValues);
 
 FMI4C_DLLAPI fmi3Status fmi3SetBoolean(fmiHandle *fmu,
-                                             const fmi3ValueReference valueReferences[],
-                                             size_t nValueReferences,
-                                             const fmi3Boolean values[],
-                                             size_t nValues);
+                                       const fmi3ValueReference valueReferences[],
+                                       size_t nValueReferences,
+                                       const fmi3Boolean values[],
+                                       size_t nValues);
 
 FMI4C_DLLAPI fmi3Status fmi3SetString(fmiHandle *fmu,
-                                            const fmi3ValueReference valueReferences[],
-                                            size_t nValueReferences,
-                                            const fmi3String values[],
-                                            size_t nValues);
+                                      const fmi3ValueReference valueReferences[],
+                                      size_t nValueReferences,
+                                      const fmi3String values[],
+                                      size_t nValues);
 
 FMI4C_DLLAPI fmi3Status fmi3SetBinary(fmiHandle *fmu,
-                                            const fmi3ValueReference valueReferences[],
-                                            size_t nValueReferences,
-                                            const size_t valueSizes[],
-                                            const fmi3Binary values[],
-                                            size_t nValues);
+                                      const fmi3ValueReference valueReferences[],
+                                      size_t nValueReferences,
+                                      const size_t valueSizes[],
+                                      const fmi3Binary values[],
+                                      size_t nValues);
 
 FMI4C_DLLAPI fmi3Status fmi3SetClock(fmiHandle *fmu,
-                                           const fmi3ValueReference valueReferences[],
-                                           size_t nValueReferences,
-                                           const fmi3Clock values[],
-                                           size_t nValues);
+                                     const fmi3ValueReference valueReferences[],
+                                     size_t nValueReferences,
+                                     const fmi3Clock values[],
+                                     size_t nValues);
 
 FMI4C_DLLAPI fmi3Status fmi3GetNumberOfVariableDependencies(fmiHandle *fmu,
-                                                                  fmi3ValueReference valueReference,
-                                                                  size_t* nDependencies);
+                                                            fmi3ValueReference valueReference,
+                                                            size_t* nDependencies);
 
 FMI4C_DLLAPI fmi3Status fmi3GetVariableDependencies(fmiHandle *fmu,
-                                                          fmi3ValueReference dependent,
-                                                          size_t elementIndicesOfDependent[],
-                                                          fmi3ValueReference independents[],
-                                                          size_t elementIndicesOfIndependents[],
-                                                          fmi3DependencyKind dependencyKinds[],
-                                                          size_t nDependencies);
+                                                    fmi3ValueReference dependent,
+                                                    size_t elementIndicesOfDependent[],
+                                                    fmi3ValueReference independents[],
+                                                    size_t elementIndicesOfIndependents[],
+                                                    fmi3DependencyKind dependencyKinds[],
+                                                    size_t nDependencies);
 
 FMI4C_DLLAPI fmi3Status fmi3GetFMUState(fmiHandle *fmu, fmi3FMUState* FMUState);
 
@@ -756,135 +756,135 @@ FMI4C_DLLAPI fmi3Status fmi3SetFMUState(fmiHandle *fmu, fmi3FMUState  FMUState);
 FMI4C_DLLAPI fmi3Status fmi3FreeFMUState(fmiHandle *fmu, fmi3FMUState* FMUState);
 
 FMI4C_DLLAPI fmi3Status fmi3SerializedFMUStateSize(fmiHandle *fmu,
-                                                         fmi3FMUState  FMUState,
-                                                         size_t* size);
+                                                   fmi3FMUState  FMUState,
+                                                   size_t* size);
 
 FMI4C_DLLAPI fmi3Status fmi3SerializeFMUState(fmiHandle *fmu,
-                                                    fmi3FMUState  FMUState,
-                                                    fmi3Byte serializedState[],
-                                                    size_t size);
+                                              fmi3FMUState  FMUState,
+                                              fmi3Byte serializedState[],
+                                              size_t size);
 
 FMI4C_DLLAPI fmi3Status fmi3DeserializeFMUState(fmiHandle *fmu,
-                                                  const fmi3Byte serializedState[],
-                                                  size_t size,
-                                                  fmi3FMUState* FMUState);
+                                                const fmi3Byte serializedState[],
+                                                size_t size,
+                                                fmi3FMUState* FMUState);
 
 FMI4C_DLLAPI fmi3Status fmi3GetDirectionalDerivative(fmiHandle *fmu,
-                                                           const fmi3ValueReference unknowns[],
-                                                           size_t nUnknowns,
-                                                           const fmi3ValueReference knowns[],
-                                                           size_t nKnowns,
-                                                           const fmi3Float64 seed[],
-                                                           size_t nSeed,
-                                                           fmi3Float64 sensitivity[],
-                                                           size_t nSensitivity);
+                                                     const fmi3ValueReference unknowns[],
+                                                     size_t nUnknowns,
+                                                     const fmi3ValueReference knowns[],
+                                                     size_t nKnowns,
+                                                     const fmi3Float64 seed[],
+                                                     size_t nSeed,
+                                                     fmi3Float64 sensitivity[],
+                                                     size_t nSensitivity);
 
 FMI4C_DLLAPI fmi3Status fmi3GetAdjointDerivative(fmiHandle *fmu,
-                                                       const fmi3ValueReference unknowns[],
-                                                       size_t nUnknowns,
-                                                       const fmi3ValueReference knowns[],
-                                                       size_t nKnowns,
-                                                       const fmi3Float64 seed[],
-                                                       size_t nSeed,
-                                                       fmi3Float64 sensitivity[],
-                                                       size_t nSensitivity);
+                                                 const fmi3ValueReference unknowns[],
+                                                 size_t nUnknowns,
+                                                 const fmi3ValueReference knowns[],
+                                                 size_t nKnowns,
+                                                 const fmi3Float64 seed[],
+                                                 size_t nSeed,
+                                                 fmi3Float64 sensitivity[],
+                                                 size_t nSensitivity);
 
 FMI4C_DLLAPI fmi3Status fmi3EnterConfigurationMode(fmiHandle *fmu);
 
 FMI4C_DLLAPI fmi3Status fmi3ExitConfigurationMode(fmiHandle *fmu);
 
 FMI4C_DLLAPI fmi3Status fmi3GetIntervalDecimal(fmiHandle *fmu,
-                                                     const fmi3ValueReference valueReferences[],
-                                                     size_t nValueReferences,
-                                                     fmi3Float64 intervals[],
-                                                     fmi3IntervalQualifier qualifiers[]);
+                                               const fmi3ValueReference valueReferences[],
+                                               size_t nValueReferences,
+                                               fmi3Float64 intervals[],
+                                               fmi3IntervalQualifier qualifiers[]);
 
 FMI4C_DLLAPI fmi3Status fmi3GetIntervalFraction(fmiHandle *fmu,
-                                                      const fmi3ValueReference valueReferences[],
-                                                      size_t nValueReferences,
-                                                      fmi3UInt64 intervalCounters[],
-                                                      fmi3UInt64 resolutions[],
-                                                      fmi3IntervalQualifier qualifiers[]);
+                                                const fmi3ValueReference valueReferences[],
+                                                size_t nValueReferences,
+                                                fmi3UInt64 intervalCounters[],
+                                                fmi3UInt64 resolutions[],
+                                                fmi3IntervalQualifier qualifiers[]);
 
 FMI4C_DLLAPI fmi3Status fmi3GetShiftDecimal(fmiHandle *fmu,
-                                                  const fmi3ValueReference valueReferences[],
-                                                  size_t nValueReferences,
-                                                  fmi3Float64 shifts[]);
+                                            const fmi3ValueReference valueReferences[],
+                                            size_t nValueReferences,
+                                            fmi3Float64 shifts[]);
 
 FMI4C_DLLAPI fmi3Status fmi3GetShiftFraction(fmiHandle *fmu,
-                                                   const fmi3ValueReference valueReferences[],
-                                                   size_t nValueReferences,
-                                                   fmi3UInt64 shiftCounters[],
-                                                   fmi3UInt64 resolutions[]);
+                                             const fmi3ValueReference valueReferences[],
+                                             size_t nValueReferences,
+                                             fmi3UInt64 shiftCounters[],
+                                             fmi3UInt64 resolutions[]);
 
 FMI4C_DLLAPI fmi3Status fmi3SetIntervalDecimal(fmiHandle *fmu,
-                                                     const fmi3ValueReference valueReferences[],
-                                                     size_t nValueReferences,
-                                                     const fmi3Float64 intervals[]);
+                                               const fmi3ValueReference valueReferences[],
+                                               size_t nValueReferences,
+                                               const fmi3Float64 intervals[]);
 
 FMI4C_DLLAPI fmi3Status fmi3SetIntervalFraction(fmiHandle *fmu,
-                                                      const fmi3ValueReference valueReferences[],
-                                                      size_t nValueReferences,
-                                                      const fmi3UInt64 intervalCounters[],
-                                                      const fmi3UInt64 resolutions[]);
+                                                const fmi3ValueReference valueReferences[],
+                                                size_t nValueReferences,
+                                                const fmi3UInt64 intervalCounters[],
+                                                const fmi3UInt64 resolutions[]);
 
 FMI4C_DLLAPI fmi3Status fmi3EvaluateDiscreteStates(fmiHandle *fmu);
 
 FMI4C_DLLAPI fmi3Status fmi3UpdateDiscreteStates(fmiHandle *fmu,
-                                                       fmi3Boolean* discreteStatesNeedUpdate,
-                                                       fmi3Boolean* terminateSimulation,
-                                                       fmi3Boolean* nominalsOfContinuousStatesChanged,
-                                                       fmi3Boolean* valuesOfContinuousStatesChanged,
-                                                       fmi3Boolean* nextEventTimeDefined,
-                                                       fmi3Float64* nextEventTime);
+                                                 fmi3Boolean* discreteStatesNeedUpdate,
+                                                 fmi3Boolean* terminateSimulation,
+                                                 fmi3Boolean* nominalsOfContinuousStatesChanged,
+                                                 fmi3Boolean* valuesOfContinuousStatesChanged,
+                                                 fmi3Boolean* nextEventTimeDefined,
+                                                 fmi3Float64* nextEventTime);
 
 FMI4C_DLLAPI fmi3Status fmi3EnterContinuousTimeMode(fmiHandle *fmu);
 
 FMI4C_DLLAPI fmi3Status fmi3CompletedIntegratorStep(fmiHandle *fmu,
-                                                          fmi3Boolean  noSetFMUStatePriorToCurrentPoint,
-                                                          fmi3Boolean* enterEventMode,
-                                                          fmi3Boolean* terminateSimulation);
+                                                    fmi3Boolean  noSetFMUStatePriorToCurrentPoint,
+                                                    fmi3Boolean* enterEventMode,
+                                                    fmi3Boolean* terminateSimulation);
 
 FMI4C_DLLAPI fmi3Status fmi3SetTime(fmiHandle *fmu, fmi3Float64 time);
 
 FMI4C_DLLAPI fmi3Status fmi3SetContinuousStates(fmiHandle *fmu,
-                                                      const fmi3Float64 continuousStates[],
-                                                      size_t nContinuousStates);
+                                                const fmi3Float64 continuousStates[],
+                                                size_t nContinuousStates);
 
 FMI4C_DLLAPI fmi3Status fmi3GetContinuousStateDerivatives(fmiHandle *fmu,
-                                                                fmi3Float64 derivatives[],
-                                                                size_t nContinuousStates);
+                                                          fmi3Float64 derivatives[],
+                                                          size_t nContinuousStates);
 
 FMI4C_DLLAPI fmi3Status fmi3GetEventIndicators(fmiHandle *fmu,
-                                                     fmi3Float64 eventIndicators[],
-                                                     size_t nEventIndicators);
+                                               fmi3Float64 eventIndicators[],
+                                               size_t nEventIndicators);
 
 FMI4C_DLLAPI fmi3Status fmi3GetContinuousStates(fmiHandle *fmu,
-                                                      fmi3Float64 continuousStates[],
-                                                      size_t nContinuousStates);
+                                                fmi3Float64 continuousStates[],
+                                                size_t nContinuousStates);
 
 FMI4C_DLLAPI fmi3Status fmi3GetNominalsOfContinuousStates(fmiHandle *fmu,
-                                                                fmi3Float64 nominals[],
-                                                                size_t nContinuousStates);
+                                                          fmi3Float64 nominals[],
+                                                          size_t nContinuousStates);
 
 FMI4C_DLLAPI fmi3Status fmi3GetNumberOfEventIndicators(fmiHandle *fmu,
-                                                             size_t* nEventIndicators);
+                                                       size_t* nEventIndicators);
 
 FMI4C_DLLAPI fmi3Status fmi3GetNumberOfContinuousStates(fmiHandle *fmu,
-                                                              size_t* nContinuousStates);
+                                                        size_t* nContinuousStates);
 
 FMI4C_DLLAPI fmi3Status fmi3EnterStepMode(fmiHandle *fmu);
 
 FMI4C_DLLAPI fmi3Status fmi3GetOutputDerivatives(fmiHandle *fmu,
-                                                       const fmi3ValueReference valueReferences[],
-                                                       size_t nValueReferences,
-                                                       const fmi3Int32 orders[],
-                                                       fmi3Float64 values[],
-                                                       size_t nValues);
+                                                 const fmi3ValueReference valueReferences[],
+                                                 size_t nValueReferences,
+                                                 const fmi3Int32 orders[],
+                                                 fmi3Float64 values[],
+                                                 size_t nValues);
 
 FMI4C_DLLAPI fmi3Status fmi3ActivateModelPartition(fmiHandle *fmu,
-                                                         fmi3ValueReference clockReference,
-                                                         fmi3Float64 activationTime);
+                                                   fmi3ValueReference clockReference,
+                                                   fmi3Float64 activationTime);
 
 #ifdef __cplusplus
 }

--- a/include/fmi4c.h
+++ b/include/fmi4c.h
@@ -100,7 +100,7 @@ FMIC_DLLEXPORT fmi1Status fmi1GetBooleanStatus(fmiHandle* fmu, const fmi1StatusK
 FMIC_DLLEXPORT fmi1Status fmi1GetStringStatus(fmiHandle* fmu, const fmi1StatusKind statusKind, fmi1String* value);
 
 FMIC_DLLEXPORT const char *fmi1GetModelTypesPlatform(fmiHandle* fmu);
-FMIC_DLLEXPORT bool fmi1InstantiateModel(fmiHandle *fmu, fmi1CallbackLogger_t logger, fmi1CallbackAllocateMemory_t allocateMemory, fmi1CallbackFreeMemory_t freeMemory, fmi1StepFinished_t stepFinished,fmi1Boolean loggingOn);
+FMIC_DLLEXPORT bool fmi1InstantiateModel(fmiHandle *fmu, fmi1CallbackLogger_t logger, fmi1CallbackAllocateMemory_t allocateMemory, fmi1CallbackFreeMemory_t freeMemory, fmi1Boolean loggingOn);
 FMIC_DLLEXPORT void fmi1FreeModelInstance(fmiHandle* fmu);
 FMIC_DLLEXPORT fmi1Status fmi1SetTime(fmiHandle* fmu, fmi1Real);
 FMIC_DLLEXPORT fmi1Status fmi1SetContinuousStates(fmiHandle* fmu, const fmi1Real[], size_t);
@@ -272,7 +272,7 @@ FMIC_DLLEXPORT fmi3DataType fmi3GetVariableDataType(fmi3VariableHandle* var);
 FMIC_DLLEXPORT const char *fmi3GetVariableDescription(fmi3VariableHandle* var);
 FMIC_DLLEXPORT const char *fmi3GetVariableQuantity(fmi3VariableHandle* var);
 FMIC_DLLEXPORT const char *fmi3GetVariableUnit(fmi3VariableHandle* var);
-FMIC_DLLEXPORT char *fmi3GetVariableDisplayUnit(fmi3VariableHandle* var);
+FMIC_DLLEXPORT const char *fmi3GetVariableDisplayUnit(fmi3VariableHandle* var);
 FMIC_DLLEXPORT fmi3Float64 fmi3GetVariableStartFloat64(fmi3VariableHandle* var);
 FMIC_DLLEXPORT fmi3Float32 fmi3GetVariableStartFloat32(fmi3VariableHandle *var);
 FMIC_DLLEXPORT fmi3Int64 fmi3GetVariableStartInt64(fmi3VariableHandle *var);

--- a/include/fmi4c.h
+++ b/include/fmi4c.h
@@ -8,7 +8,9 @@
 #include "fmi4c_functions_fmi1.h"
 #include "fmi4c_functions_fmi2.h"
 #include "fmi4c_functions_fmi3.h"
+#ifndef FMI4C_H_INTERNAL_INCLUDE
 #include "fmi4c_public.h"
+#endif
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -20,15 +22,20 @@
 
 #undef fmiVersion
 
-#ifdef __cplusplus
 #ifdef _WIN32
+#ifdef FMI4C_DLLEXPORT
+// TODO Rename FMIC_DLLEXPORT to FMI4C_DLLAPI or similar
 #define FMIC_DLLEXPORT __declspec(dllexport)
+#else
+// TODO Possibly use dllimport
+#define FMIC_DLLEXPORT
+#endif
 #else
 #define FMIC_DLLEXPORT
 #endif
+
+#ifdef __cplusplus
 extern "C" {
-#else
-#define FMIC_DLLEXPORT
 #endif
 
 // FMU access functions

--- a/include/fmi4c.h
+++ b/include/fmi4c.h
@@ -24,14 +24,13 @@
 
 #ifdef _WIN32
 #ifdef FMI4C_DLLEXPORT
-// TODO Rename FMIC_DLLEXPORT to FMI4C_DLLAPI or similar
-#define FMIC_DLLEXPORT __declspec(dllexport)
+#define FMI4C_DLLAPI __declspec(dllexport)
 #else
-// TODO Possibly use dllimport
-#define FMIC_DLLEXPORT
+// TODO Maybe use dllimport
+#define FMI4C_DLLAPI
 #endif
 #else
-#define FMIC_DLLEXPORT
+#define FMI4C_DLLAPI
 #endif
 
 #ifdef __cplusplus
@@ -40,177 +39,177 @@ extern "C" {
 
 // FMU access functions
 
-FMIC_DLLEXPORT fmiVersion_t getFmiVersion(fmiHandle *fmu);
-FMIC_DLLEXPORT fmiHandle* loadFmu(const char *fmufile, const char* instanceName);
-FMIC_DLLEXPORT void freeFmu(fmiHandle* fmu);
-const char* fmi4c_getErrorMessages();
+FMI4C_DLLAPI fmiVersion_t getFmiVersion(fmiHandle *fmu);
+FMI4C_DLLAPI fmiHandle* loadFmu(const char *fmufile, const char* instanceName);
+FMI4C_DLLAPI void freeFmu(fmiHandle* fmu);
+FMI4C_DLLAPI const char* fmi4c_getErrorMessages();
 
 // FMI 1 wrapper functions
-FMIC_DLLEXPORT fmi1Type fmi1GetType(fmiHandle *fmu);
-FMIC_DLLEXPORT int fmi1GetNumberOfContinuousStates(fmiHandle *fmu);
-FMIC_DLLEXPORT int fmi1GetNumberOfEventIndicators(fmiHandle *fmu);
-FMIC_DLLEXPORT bool fmi1DefaultStartTimeDefined(fmiHandle *fmu);
-FMIC_DLLEXPORT bool fmi1DefaultStopTimeDefined(fmiHandle *fmu);
-FMIC_DLLEXPORT bool fmi1DefaultToleranceDefined(fmiHandle *fmu) ;
-FMIC_DLLEXPORT double fmi1GetDefaultStartTime(fmiHandle *fmu);
-FMIC_DLLEXPORT double fmi1GetDefaultStopTime(fmiHandle *fmu);
-FMIC_DLLEXPORT double fmi1GetDefaultTolerance(fmiHandle *fmu);
+FMI4C_DLLAPI fmi1Type fmi1GetType(fmiHandle *fmu);
+FMI4C_DLLAPI int fmi1GetNumberOfContinuousStates(fmiHandle *fmu);
+FMI4C_DLLAPI int fmi1GetNumberOfEventIndicators(fmiHandle *fmu);
+FMI4C_DLLAPI bool fmi1DefaultStartTimeDefined(fmiHandle *fmu);
+FMI4C_DLLAPI bool fmi1DefaultStopTimeDefined(fmiHandle *fmu);
+FMI4C_DLLAPI bool fmi1DefaultToleranceDefined(fmiHandle *fmu) ;
+FMI4C_DLLAPI double fmi1GetDefaultStartTime(fmiHandle *fmu);
+FMI4C_DLLAPI double fmi1GetDefaultStopTime(fmiHandle *fmu);
+FMI4C_DLLAPI double fmi1GetDefaultTolerance(fmiHandle *fmu);
 
-FMIC_DLLEXPORT int fmi1GetNumberOfVariables(fmiHandle *fmu);
-FMIC_DLLEXPORT fmi1VariableHandle* fmi1GetVariableByIndex(fmiHandle *fmu, int i);
-FMIC_DLLEXPORT fmi1VariableHandle* fmi1GetVariableByValueReference(fmiHandle *fmu, fmi1ValueReference vr);
-FMIC_DLLEXPORT fmi1VariableHandle* fmi1GetVariableByName(fmiHandle *fmu, fmi1String name);
-FMIC_DLLEXPORT const char* fmi1GetVariableName(fmi1VariableHandle* var);
-FMIC_DLLEXPORT const char* fmi1GetVariableDescription(fmi1VariableHandle* var);
-FMIC_DLLEXPORT const char* fmi1GetVariableQuantity(fmi1VariableHandle* var);
-FMIC_DLLEXPORT const char* fmi1GetVariableUnit(fmi1VariableHandle* var);
-FMIC_DLLEXPORT const char* fmi1GetVariableDisplayUnit(fmi1VariableHandle* var);
-FMIC_DLLEXPORT fmi1Real fmi1GetVariableStartReal(fmi1VariableHandle* var);
-FMIC_DLLEXPORT fmi1Integer fmi1GetVariableStartInteger(fmi1VariableHandle* var);
-FMIC_DLLEXPORT fmi1Boolean fmi1GetVariableStartBoolean(fmi1VariableHandle* var);
-FMIC_DLLEXPORT fmi1String fmi1GetVariableStartString(fmi1VariableHandle* var);
-FMIC_DLLEXPORT long fmi1GetVariableValueReference(fmi1VariableHandle* var);
-FMIC_DLLEXPORT fmi1Causality fmi1GetVariableCausality(fmi1VariableHandle* var);
-FMIC_DLLEXPORT fmi1Variability fmi1GetVariableVariability(fmi1VariableHandle* var);
-FMIC_DLLEXPORT fmi1Alias fmi1GetAlias(fmi1VariableHandle* var);
-FMIC_DLLEXPORT bool fmi1GetVariableIsFixed(fmi1VariableHandle* var);
-FMIC_DLLEXPORT fmi1DataType fmi1GetVariableDataType(fmi1VariableHandle* var);
+FMI4C_DLLAPI int fmi1GetNumberOfVariables(fmiHandle *fmu);
+FMI4C_DLLAPI fmi1VariableHandle* fmi1GetVariableByIndex(fmiHandle *fmu, int i);
+FMI4C_DLLAPI fmi1VariableHandle* fmi1GetVariableByValueReference(fmiHandle *fmu, fmi1ValueReference vr);
+FMI4C_DLLAPI fmi1VariableHandle* fmi1GetVariableByName(fmiHandle *fmu, fmi1String name);
+FMI4C_DLLAPI const char* fmi1GetVariableName(fmi1VariableHandle* var);
+FMI4C_DLLAPI const char* fmi1GetVariableDescription(fmi1VariableHandle* var);
+FMI4C_DLLAPI const char* fmi1GetVariableQuantity(fmi1VariableHandle* var);
+FMI4C_DLLAPI const char* fmi1GetVariableUnit(fmi1VariableHandle* var);
+FMI4C_DLLAPI const char* fmi1GetVariableDisplayUnit(fmi1VariableHandle* var);
+FMI4C_DLLAPI fmi1Real fmi1GetVariableStartReal(fmi1VariableHandle* var);
+FMI4C_DLLAPI fmi1Integer fmi1GetVariableStartInteger(fmi1VariableHandle* var);
+FMI4C_DLLAPI fmi1Boolean fmi1GetVariableStartBoolean(fmi1VariableHandle* var);
+FMI4C_DLLAPI fmi1String fmi1GetVariableStartString(fmi1VariableHandle* var);
+FMI4C_DLLAPI long fmi1GetVariableValueReference(fmi1VariableHandle* var);
+FMI4C_DLLAPI fmi1Causality fmi1GetVariableCausality(fmi1VariableHandle* var);
+FMI4C_DLLAPI fmi1Variability fmi1GetVariableVariability(fmi1VariableHandle* var);
+FMI4C_DLLAPI fmi1Alias fmi1GetAlias(fmi1VariableHandle* var);
+FMI4C_DLLAPI bool fmi1GetVariableIsFixed(fmi1VariableHandle* var);
+FMI4C_DLLAPI fmi1DataType fmi1GetVariableDataType(fmi1VariableHandle* var);
 
-FMIC_DLLEXPORT const char* fmi1GetTypesPlatform(fmiHandle* fmu);
-FMIC_DLLEXPORT const char* fmi1GetVersion(fmiHandle* fmu);
-FMIC_DLLEXPORT fmi1Status fmi1SetDebugLogging(fmiHandle* fmu, fmi1Boolean);
+FMI4C_DLLAPI const char* fmi1GetTypesPlatform(fmiHandle* fmu);
+FMI4C_DLLAPI const char* fmi1GetVersion(fmiHandle* fmu);
+FMI4C_DLLAPI fmi1Status fmi1SetDebugLogging(fmiHandle* fmu, fmi1Boolean);
 
-FMIC_DLLEXPORT fmi1Status fmi1GetReal(fmiHandle* fmu, const fmi1ValueReference valueReferences[], size_t nValueReferences, fmi1Real values[]);
-FMIC_DLLEXPORT fmi1Status fmi1GetInteger(fmiHandle* fmu, const fmi1ValueReference valueReferences[], size_t nValueReferences, fmi1Integer values[]);
-FMIC_DLLEXPORT fmi1Status fmi1GetBoolean(fmiHandle* fmu, const fmi1ValueReference valueReferences[], size_t nValueReferences, fmi1Boolean values[]);
-FMIC_DLLEXPORT fmi1Status fmi1GetString(fmiHandle* fmu, const fmi1ValueReference valueReferences[], size_t nValueReferences, fmi1String values[]);
+FMI4C_DLLAPI fmi1Status fmi1GetReal(fmiHandle* fmu, const fmi1ValueReference valueReferences[], size_t nValueReferences, fmi1Real values[]);
+FMI4C_DLLAPI fmi1Status fmi1GetInteger(fmiHandle* fmu, const fmi1ValueReference valueReferences[], size_t nValueReferences, fmi1Integer values[]);
+FMI4C_DLLAPI fmi1Status fmi1GetBoolean(fmiHandle* fmu, const fmi1ValueReference valueReferences[], size_t nValueReferences, fmi1Boolean values[]);
+FMI4C_DLLAPI fmi1Status fmi1GetString(fmiHandle* fmu, const fmi1ValueReference valueReferences[], size_t nValueReferences, fmi1String values[]);
 
-FMIC_DLLEXPORT fmi1Status fmi1SetReal(fmiHandle* fmu, const fmi1ValueReference valueReferences[], size_t nValueReferences, const fmi1Real values[]);
-FMIC_DLLEXPORT fmi1Status fmi1SetInteger(fmiHandle* fmu, const fmi1ValueReference valueReferences[], size_t nValueReferences, const fmi1Integer values[]);
-FMIC_DLLEXPORT fmi1Status fmi1SetBoolean(fmiHandle* fmu, const fmi1ValueReference valueReferences[], size_t nValueReferences, const fmi1Boolean values[]);
-FMIC_DLLEXPORT fmi1Status fmi1SetString(fmiHandle* fmu, const fmi1ValueReference valueReferences[], size_t nValueReferences, const fmi1String values[]);
+FMI4C_DLLAPI fmi1Status fmi1SetReal(fmiHandle* fmu, const fmi1ValueReference valueReferences[], size_t nValueReferences, const fmi1Real values[]);
+FMI4C_DLLAPI fmi1Status fmi1SetInteger(fmiHandle* fmu, const fmi1ValueReference valueReferences[], size_t nValueReferences, const fmi1Integer values[]);
+FMI4C_DLLAPI fmi1Status fmi1SetBoolean(fmiHandle* fmu, const fmi1ValueReference valueReferences[], size_t nValueReferences, const fmi1Boolean values[]);
+FMI4C_DLLAPI fmi1Status fmi1SetString(fmiHandle* fmu, const fmi1ValueReference valueReferences[], size_t nValueReferences, const fmi1String values[]);
 
-FMIC_DLLEXPORT bool fmi1InstantiateSlave(fmiHandle *fmu, fmi1String mimeType, fmi1Real timeOut, fmi1Boolean visible, fmi1Boolean interactive, fmi1CallbackLogger_t logger, fmi1CallbackAllocateMemory_t allocateMemory, fmi1CallbackFreeMemory_t freeMemory, fmi1StepFinished_t stepFinished, fmi3Boolean loggingOn);
-FMIC_DLLEXPORT fmi1Status fmi1InitializeSlave(fmiHandle* fmu, fmi1Real startTime, fmi1Boolean stopTimeDefined, fmi1Real stopTime);
-FMIC_DLLEXPORT fmi1Status fmi1TerminateSlave(fmiHandle* fmu);
-FMIC_DLLEXPORT fmi1Status fmi1ResetSlave(fmiHandle* fmu);
-FMIC_DLLEXPORT void fmi1FreeSlaveInstance(fmiHandle* fmu);
+FMI4C_DLLAPI bool fmi1InstantiateSlave(fmiHandle *fmu, fmi1String mimeType, fmi1Real timeOut, fmi1Boolean visible, fmi1Boolean interactive, fmi1CallbackLogger_t logger, fmi1CallbackAllocateMemory_t allocateMemory, fmi1CallbackFreeMemory_t freeMemory, fmi1StepFinished_t stepFinished, fmi3Boolean loggingOn);
+FMI4C_DLLAPI fmi1Status fmi1InitializeSlave(fmiHandle* fmu, fmi1Real startTime, fmi1Boolean stopTimeDefined, fmi1Real stopTime);
+FMI4C_DLLAPI fmi1Status fmi1TerminateSlave(fmiHandle* fmu);
+FMI4C_DLLAPI fmi1Status fmi1ResetSlave(fmiHandle* fmu);
+FMI4C_DLLAPI void fmi1FreeSlaveInstance(fmiHandle* fmu);
 
-FMIC_DLLEXPORT fmi1Status fmi1SetRealInputDerivatives(fmiHandle *fmu, const fmi1ValueReference valueReferences[], size_t nValueReferences, const fmi1Integer orders[], const fmi1Real values[]);
-FMIC_DLLEXPORT fmi1Status fmi1GetRealOutputDerivatives(fmiHandle *fmu, const fmi1ValueReference valueReferences[], size_t nValueReferences, const fmi1Integer orders[], fmi1Real values[]);
-FMIC_DLLEXPORT fmi1Status fmi1CancelStep(fmiHandle* fmu);
-FMIC_DLLEXPORT fmi1Status fmi1DoStep(fmiHandle *fmu, fmi1Real currentCommunicationPoint, fmi1Real communicationStepSize, fmi1Boolean newStep);
-FMIC_DLLEXPORT fmi1Status fmi1GetStatus(fmiHandle* fmu, const fmi1StatusKind statusKind, fmi1Status* value);
-FMIC_DLLEXPORT fmi1Status fmi1GetRealStatus(fmiHandle* fmu, const fmi1StatusKind statusKind, fmi1Real* value);
-FMIC_DLLEXPORT fmi1Status fmi1GetIntegerStatus(fmiHandle* fmu, const fmi1StatusKind statusKind, fmi1Integer* value);
-FMIC_DLLEXPORT fmi1Status fmi1GetBooleanStatus(fmiHandle* fmu, const fmi1StatusKind statusKind, fmi1Boolean* value);
-FMIC_DLLEXPORT fmi1Status fmi1GetStringStatus(fmiHandle* fmu, const fmi1StatusKind statusKind, fmi1String* value);
+FMI4C_DLLAPI fmi1Status fmi1SetRealInputDerivatives(fmiHandle *fmu, const fmi1ValueReference valueReferences[], size_t nValueReferences, const fmi1Integer orders[], const fmi1Real values[]);
+FMI4C_DLLAPI fmi1Status fmi1GetRealOutputDerivatives(fmiHandle *fmu, const fmi1ValueReference valueReferences[], size_t nValueReferences, const fmi1Integer orders[], fmi1Real values[]);
+FMI4C_DLLAPI fmi1Status fmi1CancelStep(fmiHandle* fmu);
+FMI4C_DLLAPI fmi1Status fmi1DoStep(fmiHandle *fmu, fmi1Real currentCommunicationPoint, fmi1Real communicationStepSize, fmi1Boolean newStep);
+FMI4C_DLLAPI fmi1Status fmi1GetStatus(fmiHandle* fmu, const fmi1StatusKind statusKind, fmi1Status* value);
+FMI4C_DLLAPI fmi1Status fmi1GetRealStatus(fmiHandle* fmu, const fmi1StatusKind statusKind, fmi1Real* value);
+FMI4C_DLLAPI fmi1Status fmi1GetIntegerStatus(fmiHandle* fmu, const fmi1StatusKind statusKind, fmi1Integer* value);
+FMI4C_DLLAPI fmi1Status fmi1GetBooleanStatus(fmiHandle* fmu, const fmi1StatusKind statusKind, fmi1Boolean* value);
+FMI4C_DLLAPI fmi1Status fmi1GetStringStatus(fmiHandle* fmu, const fmi1StatusKind statusKind, fmi1String* value);
 
-FMIC_DLLEXPORT const char *fmi1GetModelTypesPlatform(fmiHandle* fmu);
-FMIC_DLLEXPORT bool fmi1InstantiateModel(fmiHandle *fmu, fmi1CallbackLogger_t logger, fmi1CallbackAllocateMemory_t allocateMemory, fmi1CallbackFreeMemory_t freeMemory, fmi1Boolean loggingOn);
-FMIC_DLLEXPORT void fmi1FreeModelInstance(fmiHandle* fmu);
-FMIC_DLLEXPORT fmi1Status fmi1SetTime(fmiHandle* fmu, fmi1Real);
-FMIC_DLLEXPORT fmi1Status fmi1SetContinuousStates(fmiHandle* fmu, const fmi1Real[], size_t);
-FMIC_DLLEXPORT fmi1Status fmi1CompletedIntegratorStep(fmiHandle* fmu, fmi1Boolean* callEventUpdate);
-FMIC_DLLEXPORT fmi1Status fmi1Initialize(fmiHandle *fmu, fmi1Boolean toleranceControlled, fmi1Real relativeTolerance, fmi1EventInfo *eventInfo);
-FMIC_DLLEXPORT fmi1Status fmi1GetDerivatives(fmiHandle *fmu, fmi1Real derivatives[], size_t nDerivatives);
-FMIC_DLLEXPORT fmi1Status fmi1GetEventIndicators(fmiHandle *fmu, fmi1Real indicators[], size_t nIndicators);
-FMIC_DLLEXPORT fmi1Status fmi1EventUpdate(fmiHandle *fmu, fmi1Boolean intermediateResults, fmi1EventInfo *eventInfo);
-FMIC_DLLEXPORT fmi1Status fmi1GetContinuousStates(fmiHandle* fmu, fmi1Real[], size_t);
-FMIC_DLLEXPORT fmi1Status fmi1GetNominalContinuousStates(fmiHandle* fmu, fmi1Real nominals[], size_t nNominals);
-FMIC_DLLEXPORT fmi1Status fmi1GetStateValueReferences(fmiHandle* fmu, fmi1ValueReference valueReferences[], size_t nValueReferences);
-FMIC_DLLEXPORT fmi1Status fmi1Terminate(fmiHandle* fmu);
+FMI4C_DLLAPI const char *fmi1GetModelTypesPlatform(fmiHandle* fmu);
+FMI4C_DLLAPI bool fmi1InstantiateModel(fmiHandle *fmu, fmi1CallbackLogger_t logger, fmi1CallbackAllocateMemory_t allocateMemory, fmi1CallbackFreeMemory_t freeMemory, fmi1Boolean loggingOn);
+FMI4C_DLLAPI void fmi1FreeModelInstance(fmiHandle* fmu);
+FMI4C_DLLAPI fmi1Status fmi1SetTime(fmiHandle* fmu, fmi1Real);
+FMI4C_DLLAPI fmi1Status fmi1SetContinuousStates(fmiHandle* fmu, const fmi1Real[], size_t);
+FMI4C_DLLAPI fmi1Status fmi1CompletedIntegratorStep(fmiHandle* fmu, fmi1Boolean* callEventUpdate);
+FMI4C_DLLAPI fmi1Status fmi1Initialize(fmiHandle *fmu, fmi1Boolean toleranceControlled, fmi1Real relativeTolerance, fmi1EventInfo *eventInfo);
+FMI4C_DLLAPI fmi1Status fmi1GetDerivatives(fmiHandle *fmu, fmi1Real derivatives[], size_t nDerivatives);
+FMI4C_DLLAPI fmi1Status fmi1GetEventIndicators(fmiHandle *fmu, fmi1Real indicators[], size_t nIndicators);
+FMI4C_DLLAPI fmi1Status fmi1EventUpdate(fmiHandle *fmu, fmi1Boolean intermediateResults, fmi1EventInfo *eventInfo);
+FMI4C_DLLAPI fmi1Status fmi1GetContinuousStates(fmiHandle* fmu, fmi1Real[], size_t);
+FMI4C_DLLAPI fmi1Status fmi1GetNominalContinuousStates(fmiHandle* fmu, fmi1Real nominals[], size_t nNominals);
+FMI4C_DLLAPI fmi1Status fmi1GetStateValueReferences(fmiHandle* fmu, fmi1ValueReference valueReferences[], size_t nValueReferences);
+FMI4C_DLLAPI fmi1Status fmi1Terminate(fmiHandle* fmu);
 
 // FMI 2 wrapper functions
 
-FMIC_DLLEXPORT bool fmi2DefaultStartTimeDefined(fmiHandle *fmu);
-FMIC_DLLEXPORT bool fmi2DefaultStopTimeDefined(fmiHandle *fmu);
-FMIC_DLLEXPORT bool fmi2DefaultToleranceDefined(fmiHandle *fmu) ;
-FMIC_DLLEXPORT bool fmi2DefaultStepSizeDefined(fmiHandle *fmu);
-FMIC_DLLEXPORT double fmi2GetDefaultStartTime(fmiHandle *fmu);
-FMIC_DLLEXPORT double fmi2GetDefaultStopTime(fmiHandle *fmu);
-FMIC_DLLEXPORT double fmi2GetDefaultTolerance(fmiHandle *fmu);
-FMIC_DLLEXPORT double fmi2GetDefaultStepSize(fmiHandle *fmu);
+FMI4C_DLLAPI bool fmi2DefaultStartTimeDefined(fmiHandle *fmu);
+FMI4C_DLLAPI bool fmi2DefaultStopTimeDefined(fmiHandle *fmu);
+FMI4C_DLLAPI bool fmi2DefaultToleranceDefined(fmiHandle *fmu) ;
+FMI4C_DLLAPI bool fmi2DefaultStepSizeDefined(fmiHandle *fmu);
+FMI4C_DLLAPI double fmi2GetDefaultStartTime(fmiHandle *fmu);
+FMI4C_DLLAPI double fmi2GetDefaultStopTime(fmiHandle *fmu);
+FMI4C_DLLAPI double fmi2GetDefaultTolerance(fmiHandle *fmu);
+FMI4C_DLLAPI double fmi2GetDefaultStepSize(fmiHandle *fmu);
 
-FMIC_DLLEXPORT int fmi2GetNumberOfVariables(fmiHandle *fmu);
-FMIC_DLLEXPORT fmi2VariableHandle* fmi2GetVariableByIndex(fmiHandle *fmu, int i);
-FMIC_DLLEXPORT fmi2VariableHandle* fmi2GetVariableByValueReference(fmiHandle *fmu, fmi3ValueReference vr);
-FMIC_DLLEXPORT fmi2VariableHandle* fmi2GetVariableByName(fmiHandle *fmu, fmi2String name);
-FMIC_DLLEXPORT const char* fmi2GetVariableName(fmi2VariableHandle* var);
-FMIC_DLLEXPORT const char* fmi2GetVariableDescription(fmi2VariableHandle* var);
-FMIC_DLLEXPORT const char* fmi2GetVariableQuantity(fmi2VariableHandle* var);
-FMIC_DLLEXPORT const char* fmi2GetVariableUnit(fmi2VariableHandle* var);
-FMIC_DLLEXPORT const char* fmi2GetVariableDisplayUnit(fmi2VariableHandle* var);
-FMIC_DLLEXPORT fmi2Real fmi2GetVariableStartReal(fmi2VariableHandle* var);
-FMIC_DLLEXPORT fmi2Integer fmi2GetVariableStartInteger(fmi2VariableHandle* var);
-FMIC_DLLEXPORT fmi2Boolean fmi2GetVariableStartBoolean(fmi2VariableHandle* var);
-FMIC_DLLEXPORT fmi2String fmi2GetVariableStartString(fmi2VariableHandle* var);
-FMIC_DLLEXPORT long fmi2GetVariableValueReference(fmi2VariableHandle* var);
-FMIC_DLLEXPORT fmi2Causality fmi2GetVariableCausality(fmi2VariableHandle* var);
-FMIC_DLLEXPORT fmi2Variability fmi2GetVariableVariability(fmi2VariableHandle* var);
-FMIC_DLLEXPORT fmi2Initial fmi2GetVariableInitial(fmi2VariableHandle* var);
-FMIC_DLLEXPORT bool fmi2GetVariableCanHandleMultipleSetPerTimeInstant(fmi2VariableHandle* var);
-FMIC_DLLEXPORT fmi2DataType fmi2GetVariableDataType(fmi2VariableHandle* var);
+FMI4C_DLLAPI int fmi2GetNumberOfVariables(fmiHandle *fmu);
+FMI4C_DLLAPI fmi2VariableHandle* fmi2GetVariableByIndex(fmiHandle *fmu, int i);
+FMI4C_DLLAPI fmi2VariableHandle* fmi2GetVariableByValueReference(fmiHandle *fmu, fmi3ValueReference vr);
+FMI4C_DLLAPI fmi2VariableHandle* fmi2GetVariableByName(fmiHandle *fmu, fmi2String name);
+FMI4C_DLLAPI const char* fmi2GetVariableName(fmi2VariableHandle* var);
+FMI4C_DLLAPI const char* fmi2GetVariableDescription(fmi2VariableHandle* var);
+FMI4C_DLLAPI const char* fmi2GetVariableQuantity(fmi2VariableHandle* var);
+FMI4C_DLLAPI const char* fmi2GetVariableUnit(fmi2VariableHandle* var);
+FMI4C_DLLAPI const char* fmi2GetVariableDisplayUnit(fmi2VariableHandle* var);
+FMI4C_DLLAPI fmi2Real fmi2GetVariableStartReal(fmi2VariableHandle* var);
+FMI4C_DLLAPI fmi2Integer fmi2GetVariableStartInteger(fmi2VariableHandle* var);
+FMI4C_DLLAPI fmi2Boolean fmi2GetVariableStartBoolean(fmi2VariableHandle* var);
+FMI4C_DLLAPI fmi2String fmi2GetVariableStartString(fmi2VariableHandle* var);
+FMI4C_DLLAPI long fmi2GetVariableValueReference(fmi2VariableHandle* var);
+FMI4C_DLLAPI fmi2Causality fmi2GetVariableCausality(fmi2VariableHandle* var);
+FMI4C_DLLAPI fmi2Variability fmi2GetVariableVariability(fmi2VariableHandle* var);
+FMI4C_DLLAPI fmi2Initial fmi2GetVariableInitial(fmi2VariableHandle* var);
+FMI4C_DLLAPI bool fmi2GetVariableCanHandleMultipleSetPerTimeInstant(fmi2VariableHandle* var);
+FMI4C_DLLAPI fmi2DataType fmi2GetVariableDataType(fmi2VariableHandle* var);
 
-FMIC_DLLEXPORT const char* fmi2GetTypesPlatform(fmiHandle* fmu);
-FMIC_DLLEXPORT const char* fmi2GetVersion(fmiHandle* fmu);
-FMIC_DLLEXPORT fmi2Status fmi2SetDebugLogging(fmiHandle* fmu, fmi2Boolean, size_t, const fmi2String[]);
-FMIC_DLLEXPORT const char* fmi2GetGuid(fmiHandle *fmu);
+FMI4C_DLLAPI const char* fmi2GetTypesPlatform(fmiHandle* fmu);
+FMI4C_DLLAPI const char* fmi2GetVersion(fmiHandle* fmu);
+FMI4C_DLLAPI fmi2Status fmi2SetDebugLogging(fmiHandle* fmu, fmi2Boolean, size_t, const fmi2String[]);
+FMI4C_DLLAPI const char* fmi2GetGuid(fmiHandle *fmu);
 
-FMIC_DLLEXPORT const char* fmi2GetModelIdentifier(fmiHandle* fmu);
-FMIC_DLLEXPORT bool fmi2GetNeedsExecutionTool(fmiHandle* fmu);
-FMIC_DLLEXPORT bool fmi2GetCanHandleVariableCommunicationStepSize(fmiHandle* fmu);
-FMIC_DLLEXPORT bool fmi2GetCanInterpolateInputs(fmiHandle* fmu);
-FMIC_DLLEXPORT int fmi2GetMaxOutputDerivativeOrder(fmiHandle* fmu);
-FMIC_DLLEXPORT bool fmi2GetCanRunAsynchronuously(fmiHandle* fmu);
-FMIC_DLLEXPORT bool fmi2GetCanBeInstantiatedOnlyOncePerProcess(fmiHandle* fmu);
-FMIC_DLLEXPORT bool fmi2GetCanNotUseMemoryManagementFunctions(fmiHandle* fmu);
-FMIC_DLLEXPORT bool fmi2GetCanGetAndSetFMUState(fmiHandle* fmu);
-FMIC_DLLEXPORT bool fmi2GetCanSerializeFMUState(fmiHandle* fmu);
-FMIC_DLLEXPORT bool fmi2GetProvidesDirectionalDerivative(fmiHandle* fmu);
-FMIC_DLLEXPORT int fmi2GetNumberOfContinuousStates(fmiHandle *fmu);
-FMIC_DLLEXPORT int fmi2GetNumberOfEventIndicators(fmiHandle *fmu);
-FMIC_DLLEXPORT bool fmi2GetSupportsCoSimulation(fmiHandle *fmu);
-FMIC_DLLEXPORT bool fmi2GetSupportsModelExchange(fmiHandle *fmu);
+FMI4C_DLLAPI const char* fmi2GetModelIdentifier(fmiHandle* fmu);
+FMI4C_DLLAPI bool fmi2GetNeedsExecutionTool(fmiHandle* fmu);
+FMI4C_DLLAPI bool fmi2GetCanHandleVariableCommunicationStepSize(fmiHandle* fmu);
+FMI4C_DLLAPI bool fmi2GetCanInterpolateInputs(fmiHandle* fmu);
+FMI4C_DLLAPI int fmi2GetMaxOutputDerivativeOrder(fmiHandle* fmu);
+FMI4C_DLLAPI bool fmi2GetCanRunAsynchronuously(fmiHandle* fmu);
+FMI4C_DLLAPI bool fmi2GetCanBeInstantiatedOnlyOncePerProcess(fmiHandle* fmu);
+FMI4C_DLLAPI bool fmi2GetCanNotUseMemoryManagementFunctions(fmiHandle* fmu);
+FMI4C_DLLAPI bool fmi2GetCanGetAndSetFMUState(fmiHandle* fmu);
+FMI4C_DLLAPI bool fmi2GetCanSerializeFMUState(fmiHandle* fmu);
+FMI4C_DLLAPI bool fmi2GetProvidesDirectionalDerivative(fmiHandle* fmu);
+FMI4C_DLLAPI int fmi2GetNumberOfContinuousStates(fmiHandle *fmu);
+FMI4C_DLLAPI int fmi2GetNumberOfEventIndicators(fmiHandle *fmu);
+FMI4C_DLLAPI bool fmi2GetSupportsCoSimulation(fmiHandle *fmu);
+FMI4C_DLLAPI bool fmi2GetSupportsModelExchange(fmiHandle *fmu);
 
-FMIC_DLLEXPORT bool fmi2Instantiate(fmiHandle *fmu, fmi2Type type, fmi2CallbackLogger logger, fmi2CallbackAllocateMemory allocateMemory, fmi2CallbackFreeMemory freeMemory, fmi2StepFinished stepFinished, fmi2ComponentEnvironment componentEnvironment, fmi2Boolean visible, fmi2Boolean loggingOn);
-FMIC_DLLEXPORT void fmi2FreeInstance(fmiHandle* fmu);
+FMI4C_DLLAPI bool fmi2Instantiate(fmiHandle *fmu, fmi2Type type, fmi2CallbackLogger logger, fmi2CallbackAllocateMemory allocateMemory, fmi2CallbackFreeMemory freeMemory, fmi2StepFinished stepFinished, fmi2ComponentEnvironment componentEnvironment, fmi2Boolean visible, fmi2Boolean loggingOn);
+FMI4C_DLLAPI void fmi2FreeInstance(fmiHandle* fmu);
 
-FMIC_DLLEXPORT fmi2Status fmi2SetupExperiment(fmiHandle* fmu, fmi2Boolean, fmi2Real, fmi2Real, fmi2Boolean, fmi2Real);
-FMIC_DLLEXPORT fmi2Status fmi2EnterInitializationMode(fmiHandle* fmu);
-FMIC_DLLEXPORT fmi2Status fmi2ExitInitializationMode(fmiHandle* fmu);
-FMIC_DLLEXPORT fmi2Status fmi2Terminate(fmiHandle* fmu);
-FMIC_DLLEXPORT fmi2Status fmi2Reset(fmiHandle* fmu);
+FMI4C_DLLAPI fmi2Status fmi2SetupExperiment(fmiHandle* fmu, fmi2Boolean, fmi2Real, fmi2Real, fmi2Boolean, fmi2Real);
+FMI4C_DLLAPI fmi2Status fmi2EnterInitializationMode(fmiHandle* fmu);
+FMI4C_DLLAPI fmi2Status fmi2ExitInitializationMode(fmiHandle* fmu);
+FMI4C_DLLAPI fmi2Status fmi2Terminate(fmiHandle* fmu);
+FMI4C_DLLAPI fmi2Status fmi2Reset(fmiHandle* fmu);
 
-FMIC_DLLEXPORT fmi2Status fmi2GetReal(fmiHandle* fmu, const fmi2ValueReference valueReferences[], size_t nValueReferences, fmi2Real values[]);
-FMIC_DLLEXPORT fmi2Status fmi2GetInteger(fmiHandle* fmu, const fmi2ValueReference valueReferences[], size_t nValueReferences, fmi2Integer values[]);
-FMIC_DLLEXPORT fmi2Status fmi2GetBoolean(fmiHandle* fmu, const fmi2ValueReference valueReferences[], size_t nValueReferences, fmi2Boolean values[]);
-FMIC_DLLEXPORT fmi2Status fmi2GetString(fmiHandle* fmu, const fmi2ValueReference valueReferences[], size_t nValueReferences, fmi2String values[]);
+FMI4C_DLLAPI fmi2Status fmi2GetReal(fmiHandle* fmu, const fmi2ValueReference valueReferences[], size_t nValueReferences, fmi2Real values[]);
+FMI4C_DLLAPI fmi2Status fmi2GetInteger(fmiHandle* fmu, const fmi2ValueReference valueReferences[], size_t nValueReferences, fmi2Integer values[]);
+FMI4C_DLLAPI fmi2Status fmi2GetBoolean(fmiHandle* fmu, const fmi2ValueReference valueReferences[], size_t nValueReferences, fmi2Boolean values[]);
+FMI4C_DLLAPI fmi2Status fmi2GetString(fmiHandle* fmu, const fmi2ValueReference valueReferences[], size_t nValueReferences, fmi2String values[]);
 
-FMIC_DLLEXPORT fmi2Status fmi2SetReal(fmiHandle* fmu, const fmi2ValueReference valueReferences[], size_t nValueReferences, const fmi2Real values[]);
-FMIC_DLLEXPORT fmi2Status fmi2SetInteger(fmiHandle* fmu, const fmi2ValueReference valueReferences[], size_t nValueReferences, const fmi2Integer values[]);
-FMIC_DLLEXPORT fmi2Status fmi2SetBoolean(fmiHandle* fmu, const fmi2ValueReference valueReferences[], size_t nValueReferences, const fmi2Boolean values[]);
-FMIC_DLLEXPORT fmi2Status fmi2SetString(fmiHandle* fmu, const fmi2ValueReference valueReferences[], size_t nValueReferences, const fmi2String values[]);
+FMI4C_DLLAPI fmi2Status fmi2SetReal(fmiHandle* fmu, const fmi2ValueReference valueReferences[], size_t nValueReferences, const fmi2Real values[]);
+FMI4C_DLLAPI fmi2Status fmi2SetInteger(fmiHandle* fmu, const fmi2ValueReference valueReferences[], size_t nValueReferences, const fmi2Integer values[]);
+FMI4C_DLLAPI fmi2Status fmi2SetBoolean(fmiHandle* fmu, const fmi2ValueReference valueReferences[], size_t nValueReferences, const fmi2Boolean values[]);
+FMI4C_DLLAPI fmi2Status fmi2SetString(fmiHandle* fmu, const fmi2ValueReference valueReferences[], size_t nValueReferences, const fmi2String values[]);
 
-FMIC_DLLEXPORT fmi2Status fmi2GetFMUstate(fmiHandle* fmu,
+FMI4C_DLLAPI fmi2Status fmi2GetFMUstate(fmiHandle* fmu,
                                           fmi2FMUstate* FMUstate);
-FMIC_DLLEXPORT fmi2Status fmi2SetFMUstate(fmiHandle* fmu,
+FMI4C_DLLAPI fmi2Status fmi2SetFMUstate(fmiHandle* fmu,
                                           fmi2FMUstate FMUstate);
-FMIC_DLLEXPORT fmi2Status fmi2FreeFMUstate(fmiHandle* fmu,
+FMI4C_DLLAPI fmi2Status fmi2FreeFMUstate(fmiHandle* fmu,
                                            fmi2FMUstate* FMUstate);
-FMIC_DLLEXPORT fmi2Status fmi2SerializedFMUstateSize(fmiHandle* fmu,
+FMI4C_DLLAPI fmi2Status fmi2SerializedFMUstateSize(fmiHandle* fmu,
                                                      fmi2FMUstate FMUstate,
                                                      size_t* size);
-FMIC_DLLEXPORT fmi2Status fmi2SerializeFMUstate(fmiHandle* fmu,
+FMI4C_DLLAPI fmi2Status fmi2SerializeFMUstate(fmiHandle* fmu,
                                                 fmi2FMUstate FMUstate,
                                                 fmi2Byte serializedState[],
                                                 size_t size);
-FMIC_DLLEXPORT fmi2Status fmi2DeSerializeFMUstate(fmiHandle* fmu,
+FMI4C_DLLAPI fmi2Status fmi2DeSerializeFMUstate(fmiHandle* fmu,
                                                   const fmi2Byte serializedState[],
                                                   size_t size,
                                                   fmi2FMUstate* FMUstate);
 
-FMIC_DLLEXPORT fmi2Status fmi2GetDirectionalDerivative(fmiHandle* fmu,
+FMI4C_DLLAPI fmi2Status fmi2GetDirectionalDerivative(fmiHandle* fmu,
                                                        const fmi2ValueReference unknownReferences[],
                                                        size_t nUnknown,
                                                        const fmi2ValueReference knownReferences[],
@@ -218,114 +217,114 @@ FMIC_DLLEXPORT fmi2Status fmi2GetDirectionalDerivative(fmiHandle* fmu,
                                                        const fmi2Real dvKnown[],
                                                        fmi2Real dvUnknown[]);
 
-FMIC_DLLEXPORT fmi2Status fmi2EnterEventMode(fmiHandle* fmu);
-FMIC_DLLEXPORT fmi2Status fmi2NewDiscreteStates(fmiHandle* fmu, fmi2EventInfo* eventInfo);
-FMIC_DLLEXPORT fmi2Status fmi2EnterContinuousTimeMode(fmiHandle* fmu);
-FMIC_DLLEXPORT fmi2Status fmi2CompletedIntegratorStep(fmiHandle* fmu,
+FMI4C_DLLAPI fmi2Status fmi2EnterEventMode(fmiHandle* fmu);
+FMI4C_DLLAPI fmi2Status fmi2NewDiscreteStates(fmiHandle* fmu, fmi2EventInfo* eventInfo);
+FMI4C_DLLAPI fmi2Status fmi2EnterContinuousTimeMode(fmiHandle* fmu);
+FMI4C_DLLAPI fmi2Status fmi2CompletedIntegratorStep(fmiHandle* fmu,
                                                       fmi2Boolean noSetFMUStatePriorToCurrentPoint,
                                                       fmi2Boolean* enterEventMode,
                                                       fmi2Boolean* terminateSimulation);
 
-FMIC_DLLEXPORT fmi2Status fmi2SetTime(fmiHandle* fmu,
+FMI4C_DLLAPI fmi2Status fmi2SetTime(fmiHandle* fmu,
                                       fmi2Real time);
-FMIC_DLLEXPORT fmi2Status fmi2SetContinuousStates(fmiHandle* fmu,
+FMI4C_DLLAPI fmi2Status fmi2SetContinuousStates(fmiHandle* fmu,
                                                   const fmi2Real x[],
                                                   size_t nx);
 
-FMIC_DLLEXPORT fmi2Status fmi2GetDerivatives(fmiHandle* fmu,
+FMI4C_DLLAPI fmi2Status fmi2GetDerivatives(fmiHandle* fmu,
                                              fmi2Real derivatives[],
                                              size_t nx);
-FMIC_DLLEXPORT fmi2Status fmi2GetEventIndicators(fmiHandle* fmu,
+FMI4C_DLLAPI fmi2Status fmi2GetEventIndicators(fmiHandle* fmu,
                                                  fmi2Real eventIndicators[],
                                                  size_t ni);
-FMIC_DLLEXPORT fmi2Status fmi2GetContinuousStates(fmiHandle* fmu,
+FMI4C_DLLAPI fmi2Status fmi2GetContinuousStates(fmiHandle* fmu,
                                                   fmi2Real x[],
                                                   size_t nx);
-FMIC_DLLEXPORT fmi2Status fmi2GetNominalsOfContinuousStates(fmiHandle* fmu,
+FMI4C_DLLAPI fmi2Status fmi2GetNominalsOfContinuousStates(fmiHandle* fmu,
                                                             fmi2Real x_nominal[],
                                                             size_t nx);
 
-FMIC_DLLEXPORT fmi2Status fmi2SetRealInputDerivatives(fmiHandle* fmu,
+FMI4C_DLLAPI fmi2Status fmi2SetRealInputDerivatives(fmiHandle* fmu,
                                                       const fmi2ValueReference vr[],
                                                       size_t nvr,
                                                       const fmi2Integer order[],
                                                       const fmi2Real value[]);
-FMIC_DLLEXPORT fmi2Status fmi2GetRealOutputDerivatives (fmiHandle* fmu,
+FMI4C_DLLAPI fmi2Status fmi2GetRealOutputDerivatives (fmiHandle* fmu,
                                                         const fmi2ValueReference vr[],
                                                         size_t nvr,
                                                         const fmi2Integer order[],
                                                         fmi2Real value[]);
 
-FMIC_DLLEXPORT fmi2Status fmi2DoStep(fmiHandle *fmu, fmi2Real, fmi2Real, fmi2Boolean);
-FMIC_DLLEXPORT fmi2Status fmi2CancelStep(fmiHandle* fmu);
+FMI4C_DLLAPI fmi2Status fmi2DoStep(fmiHandle *fmu, fmi2Real, fmi2Real, fmi2Boolean);
+FMI4C_DLLAPI fmi2Status fmi2CancelStep(fmiHandle* fmu);
 
-FMIC_DLLEXPORT fmi2Status fmi2GetStatus(fmiHandle* fmu, const fmi2StatusKind, fmi2Status* );
-FMIC_DLLEXPORT fmi2Status fmi2GetRealStatus(fmiHandle* fmu, const fmi2StatusKind, fmi2Real*   );
-FMIC_DLLEXPORT fmi2Status fmi2GetIntegerStatus(fmiHandle* fmu, const fmi2StatusKind, fmi2Integer*);
-FMIC_DLLEXPORT fmi2Status fmi2GetBooleanStatus(fmiHandle* fmu, const fmi2StatusKind, fmi2Boolean*);
-FMIC_DLLEXPORT fmi2Status fmi2GetStringStatus(fmiHandle* fmu, const fmi2StatusKind, fmi2String* );
+FMI4C_DLLAPI fmi2Status fmi2GetStatus(fmiHandle* fmu, const fmi2StatusKind, fmi2Status* );
+FMI4C_DLLAPI fmi2Status fmi2GetRealStatus(fmiHandle* fmu, const fmi2StatusKind, fmi2Real*   );
+FMI4C_DLLAPI fmi2Status fmi2GetIntegerStatus(fmiHandle* fmu, const fmi2StatusKind, fmi2Integer*);
+FMI4C_DLLAPI fmi2Status fmi2GetBooleanStatus(fmiHandle* fmu, const fmi2StatusKind, fmi2Boolean*);
+FMI4C_DLLAPI fmi2Status fmi2GetStringStatus(fmiHandle* fmu, const fmi2StatusKind, fmi2String* );
 
 
-FMIC_DLLEXPORT int fmi3GetNumberOfVariables(fmiHandle *fmu);
-FMIC_DLLEXPORT fmi3VariableHandle* fmi3GetVariableByName(fmiHandle *fmu, fmi3String name);
-FMIC_DLLEXPORT fmi3VariableHandle* fmi3GetVariableByIndex(fmiHandle *fmu, int i);
-FMIC_DLLEXPORT fmi3VariableHandle* fmi3GetVariableByValueReference(fmiHandle *fmu, fmi3ValueReference vr);
-FMIC_DLLEXPORT const char* fmi3GetVariableName(fmi3VariableHandle* var);
-FMIC_DLLEXPORT fmi3Causality fmi3GetVariableCausality(fmi3VariableHandle* var);
-FMIC_DLLEXPORT fmi3Variability fmi3GetVariableVariability(fmi3VariableHandle* var);
-FMIC_DLLEXPORT fmi3Initial fmi3GetVariableInitial(fmi3VariableHandle* var);
-FMIC_DLLEXPORT bool fmi3GetVariableSupportsIntermediateUpdate(fmi3VariableHandle* var);
-FMIC_DLLEXPORT fmi3DataType fmi3GetVariableDataType(fmi3VariableHandle* var);
-FMIC_DLLEXPORT const char *fmi3GetVariableDescription(fmi3VariableHandle* var);
-FMIC_DLLEXPORT const char *fmi3GetVariableQuantity(fmi3VariableHandle* var);
-FMIC_DLLEXPORT const char *fmi3GetVariableUnit(fmi3VariableHandle* var);
-FMIC_DLLEXPORT const char *fmi3GetVariableDisplayUnit(fmi3VariableHandle* var);
-FMIC_DLLEXPORT fmi3Float64 fmi3GetVariableStartFloat64(fmi3VariableHandle* var);
-FMIC_DLLEXPORT fmi3Float32 fmi3GetVariableStartFloat32(fmi3VariableHandle *var);
-FMIC_DLLEXPORT fmi3Int64 fmi3GetVariableStartInt64(fmi3VariableHandle *var);
-FMIC_DLLEXPORT fmi3Int32 fmi3GetVariableStartInt32(fmi3VariableHandle *var);
-FMIC_DLLEXPORT fmi3Int16 fmi3GetVariableStartInt16(fmi3VariableHandle *var);
-FMIC_DLLEXPORT fmi3Int8 fmi3GetVariableStartInt8(fmi3VariableHandle *var);
-FMIC_DLLEXPORT fmi3UInt64 fmi3GetVariableStartUInt64(fmi3VariableHandle *var);
-FMIC_DLLEXPORT fmi3UInt32 fmi3GetVariableStartUInt32(fmi3VariableHandle *var);
-FMIC_DLLEXPORT fmi3UInt16 fmi3GetVariableStartUInt16(fmi3VariableHandle *var);
-FMIC_DLLEXPORT fmi3UInt8 fmi3GetVariableStartUInt8(fmi3VariableHandle *var);
-FMIC_DLLEXPORT fmi3Boolean fmi3GetVariableStartBoolean(fmi3VariableHandle *var);
-FMIC_DLLEXPORT fmi3String fmi3GetVariableStartString(fmi3VariableHandle *var);
-FMIC_DLLEXPORT fmi3Binary fmi3GetVariableStartBinary(fmi3VariableHandle *var);
-FMIC_DLLEXPORT fmi3ValueReference fmi3GetVariableValueReference(fmi3VariableHandle* var);
+FMI4C_DLLAPI int fmi3GetNumberOfVariables(fmiHandle *fmu);
+FMI4C_DLLAPI fmi3VariableHandle* fmi3GetVariableByName(fmiHandle *fmu, fmi3String name);
+FMI4C_DLLAPI fmi3VariableHandle* fmi3GetVariableByIndex(fmiHandle *fmu, int i);
+FMI4C_DLLAPI fmi3VariableHandle* fmi3GetVariableByValueReference(fmiHandle *fmu, fmi3ValueReference vr);
+FMI4C_DLLAPI const char* fmi3GetVariableName(fmi3VariableHandle* var);
+FMI4C_DLLAPI fmi3Causality fmi3GetVariableCausality(fmi3VariableHandle* var);
+FMI4C_DLLAPI fmi3Variability fmi3GetVariableVariability(fmi3VariableHandle* var);
+FMI4C_DLLAPI fmi3Initial fmi3GetVariableInitial(fmi3VariableHandle* var);
+FMI4C_DLLAPI bool fmi3GetVariableSupportsIntermediateUpdate(fmi3VariableHandle* var);
+FMI4C_DLLAPI fmi3DataType fmi3GetVariableDataType(fmi3VariableHandle* var);
+FMI4C_DLLAPI const char *fmi3GetVariableDescription(fmi3VariableHandle* var);
+FMI4C_DLLAPI const char *fmi3GetVariableQuantity(fmi3VariableHandle* var);
+FMI4C_DLLAPI const char *fmi3GetVariableUnit(fmi3VariableHandle* var);
+FMI4C_DLLAPI const char *fmi3GetVariableDisplayUnit(fmi3VariableHandle* var);
+FMI4C_DLLAPI fmi3Float64 fmi3GetVariableStartFloat64(fmi3VariableHandle* var);
+FMI4C_DLLAPI fmi3Float32 fmi3GetVariableStartFloat32(fmi3VariableHandle *var);
+FMI4C_DLLAPI fmi3Int64 fmi3GetVariableStartInt64(fmi3VariableHandle *var);
+FMI4C_DLLAPI fmi3Int32 fmi3GetVariableStartInt32(fmi3VariableHandle *var);
+FMI4C_DLLAPI fmi3Int16 fmi3GetVariableStartInt16(fmi3VariableHandle *var);
+FMI4C_DLLAPI fmi3Int8 fmi3GetVariableStartInt8(fmi3VariableHandle *var);
+FMI4C_DLLAPI fmi3UInt64 fmi3GetVariableStartUInt64(fmi3VariableHandle *var);
+FMI4C_DLLAPI fmi3UInt32 fmi3GetVariableStartUInt32(fmi3VariableHandle *var);
+FMI4C_DLLAPI fmi3UInt16 fmi3GetVariableStartUInt16(fmi3VariableHandle *var);
+FMI4C_DLLAPI fmi3UInt8 fmi3GetVariableStartUInt8(fmi3VariableHandle *var);
+FMI4C_DLLAPI fmi3Boolean fmi3GetVariableStartBoolean(fmi3VariableHandle *var);
+FMI4C_DLLAPI fmi3String fmi3GetVariableStartString(fmi3VariableHandle *var);
+FMI4C_DLLAPI fmi3Binary fmi3GetVariableStartBinary(fmi3VariableHandle *var);
+FMI4C_DLLAPI fmi3ValueReference fmi3GetVariableValueReference(fmi3VariableHandle* var);
 
-FMIC_DLLEXPORT const char* fmi3ModelName(fmiHandle *fmu);
-FMIC_DLLEXPORT const char* fmi3InstantiationToken(fmiHandle *fmu);
-FMIC_DLLEXPORT const char* fmi3Description(fmiHandle *fmu);
-FMIC_DLLEXPORT const char* fmi3Author(fmiHandle *fmu);
-FMIC_DLLEXPORT const char* fmi3Version(fmiHandle *fmu);
-FMIC_DLLEXPORT const char* fmi3Copyright(fmiHandle *fmu);
-FMIC_DLLEXPORT const char* fmi3License(fmiHandle *fmu);
-FMIC_DLLEXPORT const char* fmi3GenerationTool(fmiHandle *fmu);
-FMIC_DLLEXPORT const char* fmi3GenerationDateAndTime(fmiHandle *fmu);
-FMIC_DLLEXPORT const char* fmi3VariableNamingConvention(fmiHandle *fmu);
-FMIC_DLLEXPORT bool fmi3SupportsModelExchange(fmiHandle *fmu);
-FMIC_DLLEXPORT bool fmi3SupportsScheduledExecution(fmiHandle *fmu);
-FMIC_DLLEXPORT bool fmi3SupportsCoSimulation(fmiHandle *fmu);
-FMIC_DLLEXPORT bool fmi3DefaultStartTimeDefined(fmiHandle *fmu);
-FMIC_DLLEXPORT bool fmi3DefaultStopTimeDefined(fmiHandle *fmu);
-FMIC_DLLEXPORT bool fmi3DefaultToleranceDefined(fmiHandle *fmu) ;
-FMIC_DLLEXPORT bool fmi3DefaultStepSizeDefined(fmiHandle *fmu);
-FMIC_DLLEXPORT double fmi3GetDefaultStartTime(fmiHandle *fmu);
-FMIC_DLLEXPORT double fmi3GetDefaultStopTime(fmiHandle *fmu);
-FMIC_DLLEXPORT double fmi3GetDefaultTolerance(fmiHandle *fmu);
-FMIC_DLLEXPORT double fmi3GetDefaultStepSize(fmiHandle *fmu);
+FMI4C_DLLAPI const char* fmi3ModelName(fmiHandle *fmu);
+FMI4C_DLLAPI const char* fmi3InstantiationToken(fmiHandle *fmu);
+FMI4C_DLLAPI const char* fmi3Description(fmiHandle *fmu);
+FMI4C_DLLAPI const char* fmi3Author(fmiHandle *fmu);
+FMI4C_DLLAPI const char* fmi3Version(fmiHandle *fmu);
+FMI4C_DLLAPI const char* fmi3Copyright(fmiHandle *fmu);
+FMI4C_DLLAPI const char* fmi3License(fmiHandle *fmu);
+FMI4C_DLLAPI const char* fmi3GenerationTool(fmiHandle *fmu);
+FMI4C_DLLAPI const char* fmi3GenerationDateAndTime(fmiHandle *fmu);
+FMI4C_DLLAPI const char* fmi3VariableNamingConvention(fmiHandle *fmu);
+FMI4C_DLLAPI bool fmi3SupportsModelExchange(fmiHandle *fmu);
+FMI4C_DLLAPI bool fmi3SupportsScheduledExecution(fmiHandle *fmu);
+FMI4C_DLLAPI bool fmi3SupportsCoSimulation(fmiHandle *fmu);
+FMI4C_DLLAPI bool fmi3DefaultStartTimeDefined(fmiHandle *fmu);
+FMI4C_DLLAPI bool fmi3DefaultStopTimeDefined(fmiHandle *fmu);
+FMI4C_DLLAPI bool fmi3DefaultToleranceDefined(fmiHandle *fmu) ;
+FMI4C_DLLAPI bool fmi3DefaultStepSizeDefined(fmiHandle *fmu);
+FMI4C_DLLAPI double fmi3GetDefaultStartTime(fmiHandle *fmu);
+FMI4C_DLLAPI double fmi3GetDefaultStopTime(fmiHandle *fmu);
+FMI4C_DLLAPI double fmi3GetDefaultTolerance(fmiHandle *fmu);
+FMI4C_DLLAPI double fmi3GetDefaultStepSize(fmiHandle *fmu);
 
-FMIC_DLLEXPORT int fmi3GetNumberOfUnits(fmiHandle *fmu);
-FMIC_DLLEXPORT fmi3UnitHandle *fmi3GetUnitByIndex(fmiHandle *fmu, int i);
-FMIC_DLLEXPORT const char* fmi3GetUnitName(fmi3UnitHandle *unit);
-FMIC_DLLEXPORT bool fmi3HasBaseUnit(fmi3UnitHandle *unit);
-FMIC_DLLEXPORT void fmi3GetBaseUnit(fmi3UnitHandle *unit, double *factor, double *offset, int *kg, int *m, int *s, int *A, int *K, int *mol, int *cd, int *rad);
-FMIC_DLLEXPORT int fmi3GetNumberOfDisplayUnits(fmi3UnitHandle *unit);
-FMIC_DLLEXPORT void fmi3GetDisplayUnitByIndex(fmi3UnitHandle *unit, int id, const char **name, double *factor, double *offset, bool *inverse);
+FMI4C_DLLAPI int fmi3GetNumberOfUnits(fmiHandle *fmu);
+FMI4C_DLLAPI fmi3UnitHandle *fmi3GetUnitByIndex(fmiHandle *fmu, int i);
+FMI4C_DLLAPI const char* fmi3GetUnitName(fmi3UnitHandle *unit);
+FMI4C_DLLAPI bool fmi3HasBaseUnit(fmi3UnitHandle *unit);
+FMI4C_DLLAPI void fmi3GetBaseUnit(fmi3UnitHandle *unit, double *factor, double *offset, int *kg, int *m, int *s, int *A, int *K, int *mol, int *cd, int *rad);
+FMI4C_DLLAPI int fmi3GetNumberOfDisplayUnits(fmi3UnitHandle *unit);
+FMI4C_DLLAPI void fmi3GetDisplayUnitByIndex(fmi3UnitHandle *unit, int id, const char **name, double *factor, double *offset, bool *inverse);
 
-FMIC_DLLEXPORT void fmi3GetFloat64Type(fmiHandle* fmu,
+FMI4C_DLLAPI void fmi3GetFloat64Type(fmiHandle* fmu,
                                        const char* name,
                                        const char** description,
                                        const char** quantity,
@@ -336,7 +335,7 @@ FMIC_DLLEXPORT void fmi3GetFloat64Type(fmiHandle* fmu,
                                        double* min,
                                        double* max,
                                        double* nominal);
-FMIC_DLLEXPORT void fmi3GetFloat32Type(fmiHandle* fmu,
+FMI4C_DLLAPI void fmi3GetFloat32Type(fmiHandle* fmu,
                                        const char* name,
                                        const char** description,
                                        const char** quantity,
@@ -347,79 +346,79 @@ FMIC_DLLEXPORT void fmi3GetFloat32Type(fmiHandle* fmu,
                                        double* min,
                                        double* max,
                                        double* nominal);
-FMIC_DLLEXPORT void fmi3GetInt64Type(fmiHandle *fmu,
+FMI4C_DLLAPI void fmi3GetInt64Type(fmiHandle *fmu,
                                      const char *name,
                                      const char** description,
                                      const char** quantity,
                                      double* min,
                                      double* max);
-FMIC_DLLEXPORT void fmi3GetInt32Type(fmiHandle *fmu,
+FMI4C_DLLAPI void fmi3GetInt32Type(fmiHandle *fmu,
                                      const char *name,
                                      const char** description,
                                      const char** quantity,
                                      double* min,
                                      double* max);
-FMIC_DLLEXPORT void fmi3GetInt16Type(fmiHandle *fmu,
+FMI4C_DLLAPI void fmi3GetInt16Type(fmiHandle *fmu,
                                      const char *name,
                                      const char** description,
                                      const char** quantity,
                                      double* min,
                                      double* max);
-FMIC_DLLEXPORT void fmi3GetInt8Type(fmiHandle *fmu,
+FMI4C_DLLAPI void fmi3GetInt8Type(fmiHandle *fmu,
                                      const char *name,
                                      const char** description,
                                      const char** quantity,
                                      double* min,
                                      double* max);
-FMIC_DLLEXPORT void fmi3GetUInt64Type(fmiHandle *fmu,
+FMI4C_DLLAPI void fmi3GetUInt64Type(fmiHandle *fmu,
                                      const char *name,
                                      const char** description,
                                      const char** quantity,
                                      double* min,
                                      double* max);
-FMIC_DLLEXPORT void fmi3GetUInt32Type(fmiHandle *fmu,
+FMI4C_DLLAPI void fmi3GetUInt32Type(fmiHandle *fmu,
                                      const char *name,
                                      const char** description,
                                      const char** quantity,
                                      double* min,
                                      double* max);
-FMIC_DLLEXPORT void fmi3GetUInt16Type(fmiHandle *fmu,
+FMI4C_DLLAPI void fmi3GetUInt16Type(fmiHandle *fmu,
                                      const char *name,
                                      const char** description,
                                      const char** quantity,
                                      double* min,
                                      double* max);
-FMIC_DLLEXPORT void fmi3GetUInt8Type(fmiHandle *fmu,
+FMI4C_DLLAPI void fmi3GetUInt8Type(fmiHandle *fmu,
                                      const char *name,
                                      const char** description,
                                      const char** quantity,
                                      double* min,
                                      double* max);
-FMIC_DLLEXPORT void fmi3GetBooleanType(fmiHandle *fmu,
+FMI4C_DLLAPI void fmi3GetBooleanType(fmiHandle *fmu,
                                        const char *name,
                                        const char **description);
-FMIC_DLLEXPORT void fmi3GetStringType(fmiHandle *fmu,
+FMI4C_DLLAPI void fmi3GetStringType(fmiHandle *fmu,
                                       const char *name,
                                       const char **description);
-FMIC_DLLEXPORT void fmi3GetBinaryType(fmiHandle *fmu,
+FMI4C_DLLAPI void fmi3GetBinaryType(fmiHandle *fmu,
                                       const char *name,
                                       const char **description,
                                       const char **mimeType,
                                       uint32_t *maxSize);
-FMIC_DLLEXPORT void fmi3GetEnumerationType(fmiHandle *fmu,
+FMI4C_DLLAPI void fmi3GetEnumerationType(fmiHandle *fmu,
                                            const char *name,
                                            const char **description,
                                            const char **quantity,
                                            int64_t *min,
                                            int64_t *max,
                                            int *numberOfItems);
-FMIC_DLLEXPORT void fmi3GetEnumerationItem(fmiHandle *fmu,
+FMI4C_DLLAPI void fmi3GetEnumerationItem(fmiHandle *fmu,
                                            const char *typeName,
                                            int itemId,
                                            const char **itemName,
                                            int64_t *value,
                                            const char **description);
-FMIC_DLLEXPORT void fmi3GetClockType(fmiHandle *fmu,
+FMI4C_DLLAPI void fmi3GetClockType(fmiHandle *fmu,
                                      const char *name,
                                      const char **description,
                                      bool *canBeDeactivated,
@@ -432,89 +431,89 @@ FMIC_DLLEXPORT void fmi3GetClockType(fmiHandle *fmu,
                                      uint64_t *intervalCounter,
                                      uint64_t *shiftCounter);
 
-FMIC_DLLEXPORT int fmi3GetNumberOfLogCategories(fmiHandle *fmu);
-FMIC_DLLEXPORT void fmi3GetLogCategory(fmiHandle *fmu, int id, const char **name, const char **description);
+FMI4C_DLLAPI int fmi3GetNumberOfLogCategories(fmiHandle *fmu);
+FMI4C_DLLAPI void fmi3GetLogCategory(fmiHandle *fmu, int id, const char **name, const char **description);
 
-FMIC_DLLEXPORT int fmi3GetNumberOfModelStructureOutputs(fmiHandle *fmu);
-FMIC_DLLEXPORT void fmi3GetModelStructureOutput(fmiHandle *fmu,
+FMI4C_DLLAPI int fmi3GetNumberOfModelStructureOutputs(fmiHandle *fmu);
+FMI4C_DLLAPI void fmi3GetModelStructureOutput(fmiHandle *fmu,
                                       int id,
                                       fmi3ValueReference *vr,
                                       int *numberOfDependencies,
                                       bool *dependencyKindsDefined);
-FMIC_DLLEXPORT fmi3ValueReference fmi3GetModelStructureOutputDependency(fmiHandle *fmu,
+FMI4C_DLLAPI fmi3ValueReference fmi3GetModelStructureOutputDependency(fmiHandle *fmu,
                                                           int outputId,
                                                           int dependencyId);
-FMIC_DLLEXPORT fmi3ValueReference fmi3GetModelStructureOutputDependencyKind(fmiHandle *fmu,
+FMI4C_DLLAPI fmi3ValueReference fmi3GetModelStructureOutputDependencyKind(fmiHandle *fmu,
                                                               int outputId,
                                                               int dependencyId);
-FMIC_DLLEXPORT int fmi3GetNumberOfModelStructureContinuousStateDerivatives(fmiHandle *fmu);
-FMIC_DLLEXPORT void fmi3GetModelStructureContinuousStateDerivative(fmiHandle *fmu,
+FMI4C_DLLAPI int fmi3GetNumberOfModelStructureContinuousStateDerivatives(fmiHandle *fmu);
+FMI4C_DLLAPI void fmi3GetModelStructureContinuousStateDerivative(fmiHandle *fmu,
                                       int id,
                                       fmi3ValueReference *vr,
                                       int *numberOfDependencies,
                                       bool *dependencyKindsDefined);
-FMIC_DLLEXPORT fmi3ValueReference fmi3GetModelStructureContinuousStateDerivativeDependency(fmiHandle *fmu,
+FMI4C_DLLAPI fmi3ValueReference fmi3GetModelStructureContinuousStateDerivativeDependency(fmiHandle *fmu,
                                                           int derId,
                                                           int dependencyId);
-FMIC_DLLEXPORT fmi3ValueReference fmi3GetModelStructureContinuousStateDerivativeDependencyKind(fmiHandle *fmu,
+FMI4C_DLLAPI fmi3ValueReference fmi3GetModelStructureContinuousStateDerivativeDependencyKind(fmiHandle *fmu,
                                                               int derId,
                                                               int dependencyId);
-FMIC_DLLEXPORT int fmi3GetNumberOfModelStructureClockedStates(fmiHandle *fmu);
-FMIC_DLLEXPORT void fmi3GetModelStructureClockedState(fmiHandle *fmu,
+FMI4C_DLLAPI int fmi3GetNumberOfModelStructureClockedStates(fmiHandle *fmu);
+FMI4C_DLLAPI void fmi3GetModelStructureClockedState(fmiHandle *fmu,
                                       int id,
                                       fmi3ValueReference *vr,
                                       int *numberOfDependencies,
                                       bool *dependencyKindsDefined);
-FMIC_DLLEXPORT fmi3ValueReference fmi3GetModelStructureClockedStateDependency(fmiHandle *fmu,
+FMI4C_DLLAPI fmi3ValueReference fmi3GetModelStructureClockedStateDependency(fmiHandle *fmu,
                                                           int clockId,
                                                           int dependencyId);
-FMIC_DLLEXPORT fmi3ValueReference fmi3GetModelStructureClockedStateDependencyKind(fmiHandle *fmu,
+FMI4C_DLLAPI fmi3ValueReference fmi3GetModelStructureClockedStateDependencyKind(fmiHandle *fmu,
                                                               int clockId,
                                                               int dependencyId);
-FMIC_DLLEXPORT int fmi3GetNumberOfModelStructureInitialUnknowns(fmiHandle *fmu);
-FMIC_DLLEXPORT void fmi3GetModelStructureInitialUnknown(fmiHandle *fmu,
+FMI4C_DLLAPI int fmi3GetNumberOfModelStructureInitialUnknowns(fmiHandle *fmu);
+FMI4C_DLLAPI void fmi3GetModelStructureInitialUnknown(fmiHandle *fmu,
                                       int id,
                                       fmi3ValueReference *vr,
                                       int *numberOfDependencies,
                                       bool *dependencyKindsDefined);
-FMIC_DLLEXPORT fmi3ValueReference fmi3GetModelStructureInitialUnknownDependency(fmiHandle *fmu,
+FMI4C_DLLAPI fmi3ValueReference fmi3GetModelStructureInitialUnknownDependency(fmiHandle *fmu,
                                                           int unknownId,
                                                           int dependencyId);
-FMIC_DLLEXPORT fmi3ValueReference fmi3ModelStructureGetInitialUnknownDependencyKind(fmiHandle *fmu,
+FMI4C_DLLAPI fmi3ValueReference fmi3ModelStructureGetInitialUnknownDependencyKind(fmiHandle *fmu,
                                                               int unknownId,
                                                               int dependencyId);
-FMIC_DLLEXPORT int fmi3GetNumberOfModelStructureEventIndicators(fmiHandle *fmu);
-FMIC_DLLEXPORT void fmi3GetModelStructureEventIndicator(fmiHandle *fmu,
+FMI4C_DLLAPI int fmi3GetNumberOfModelStructureEventIndicators(fmiHandle *fmu);
+FMI4C_DLLAPI void fmi3GetModelStructureEventIndicator(fmiHandle *fmu,
                                       int id,
                                       fmi3ValueReference *vr,
                                       int *numberOfDependencies,
                                       bool *dependencyKindsDefined);
-FMIC_DLLEXPORT fmi3ValueReference fmi3GetModelStructureEventIndicatorDependency(fmiHandle *fmu,
+FMI4C_DLLAPI fmi3ValueReference fmi3GetModelStructureEventIndicatorDependency(fmiHandle *fmu,
                                                           int indicatorId,
                                                           int dependencyId);
-FMIC_DLLEXPORT fmi3ValueReference fmi3GetModelStructureEventIndicatorDependencyKind(fmiHandle *fmu,
+FMI4C_DLLAPI fmi3ValueReference fmi3GetModelStructureEventIndicatorDependencyKind(fmiHandle *fmu,
                                                               int indicatorId,
                                                               int dependencyId);
 
-FMIC_DLLEXPORT const char* fmi3GetModelIdentifier(fmiHandle* fmu);
-FMIC_DLLEXPORT bool fmi3GetNeedsExecutionTool(fmiHandle* fmu);
-FMIC_DLLEXPORT bool fmi3GetCanBeInstantiatedOnlyOncePerProcess(fmiHandle* fmu);
-FMIC_DLLEXPORT bool fmi3GetCanGetAndSetFMUState(fmiHandle* fmu);
-FMIC_DLLEXPORT bool fmi3GetCanSerializeFMUState(fmiHandle* fmu);
-FMIC_DLLEXPORT bool fmi3GetProvidesDirectionalDerivative(fmiHandle* fmu);
-FMIC_DLLEXPORT bool fmi3GetProvidesAdjointDerivatives(fmiHandle* fmu);
-FMIC_DLLEXPORT bool fmi3GetProvidesPerElementDependencies(fmiHandle* fmu);
-FMIC_DLLEXPORT int fmi3GetMaxOutputDerivativeOrder(fmiHandle* fmu);
-FMIC_DLLEXPORT bool fmi3GetCanHandleVariableCommunicationStepSize(fmiHandle* fmu);
-FMIC_DLLEXPORT bool fmi3GetCanReturnEarlyAfterIntermediateUpdate(fmiHandle* fmu);
-FMIC_DLLEXPORT double fmi3GetFixedInternalStepSize(fmiHandle* fmu);
-FMIC_DLLEXPORT bool fmi3GetHasEventMode(fmiHandle* fmu);
-FMIC_DLLEXPORT bool fmi3GetProvidesIntermediateUpdate(fmiHandle* fmu);
-FMIC_DLLEXPORT bool fmi3GetProvidesEvaluateDiscreteStates(fmiHandle* fmu);
-FMIC_DLLEXPORT bool fmi3GetRecommendedIntermediateInputSmoothness(fmiHandle* fmu);
-FMIC_DLLEXPORT bool fmi3GetNeedsCompletedIntegratorStep(fmiHandle* fmu);
+FMI4C_DLLAPI const char* fmi3GetModelIdentifier(fmiHandle* fmu);
+FMI4C_DLLAPI bool fmi3GetNeedsExecutionTool(fmiHandle* fmu);
+FMI4C_DLLAPI bool fmi3GetCanBeInstantiatedOnlyOncePerProcess(fmiHandle* fmu);
+FMI4C_DLLAPI bool fmi3GetCanGetAndSetFMUState(fmiHandle* fmu);
+FMI4C_DLLAPI bool fmi3GetCanSerializeFMUState(fmiHandle* fmu);
+FMI4C_DLLAPI bool fmi3GetProvidesDirectionalDerivative(fmiHandle* fmu);
+FMI4C_DLLAPI bool fmi3GetProvidesAdjointDerivatives(fmiHandle* fmu);
+FMI4C_DLLAPI bool fmi3GetProvidesPerElementDependencies(fmiHandle* fmu);
+FMI4C_DLLAPI int fmi3GetMaxOutputDerivativeOrder(fmiHandle* fmu);
+FMI4C_DLLAPI bool fmi3GetCanHandleVariableCommunicationStepSize(fmiHandle* fmu);
+FMI4C_DLLAPI bool fmi3GetCanReturnEarlyAfterIntermediateUpdate(fmiHandle* fmu);
+FMI4C_DLLAPI double fmi3GetFixedInternalStepSize(fmiHandle* fmu);
+FMI4C_DLLAPI bool fmi3GetHasEventMode(fmiHandle* fmu);
+FMI4C_DLLAPI bool fmi3GetProvidesIntermediateUpdate(fmiHandle* fmu);
+FMI4C_DLLAPI bool fmi3GetProvidesEvaluateDiscreteStates(fmiHandle* fmu);
+FMI4C_DLLAPI bool fmi3GetRecommendedIntermediateInputSmoothness(fmiHandle* fmu);
+FMI4C_DLLAPI bool fmi3GetNeedsCompletedIntegratorStep(fmiHandle* fmu);
 
-FMIC_DLLEXPORT bool fmi3InstantiateCoSimulation(fmiHandle *fmu,
+FMI4C_DLLAPI bool fmi3InstantiateCoSimulation(fmiHandle *fmu,
                              fmi3Boolean                    visible,
                              fmi3Boolean                    loggingOn,
                              fmi3Boolean                    eventModeUsed,
@@ -525,45 +524,45 @@ FMIC_DLLEXPORT bool fmi3InstantiateCoSimulation(fmiHandle *fmu,
                              fmi3CallbackLogMessage         logMessage,
                              fmi3CallbackIntermediateUpdate intermediateUpdate);
 
-FMIC_DLLEXPORT bool fmi3InstantiateModelExchange(fmiHandle *fmu,
+FMI4C_DLLAPI bool fmi3InstantiateModelExchange(fmiHandle *fmu,
                                                  fmi3Boolean                visible,
                                                  fmi3Boolean                loggingOn,
                                                  fmi3InstanceEnvironment    instanceEnvironment,
                                                  fmi3CallbackLogMessage     logMessage);
 
-FMIC_DLLEXPORT const char* fmi3GetVersion(fmiHandle *fmu);
+FMI4C_DLLAPI const char* fmi3GetVersion(fmiHandle *fmu);
 
-FMIC_DLLEXPORT fmi3Status fmi3SetDebugLogging(fmiHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3SetDebugLogging(fmiHandle *fmu,
                            fmi3Boolean loggingOn,
                            size_t nCategories,
                            const fmi3String categories[]);
 
-FMIC_DLLEXPORT fmi3Status fmi3GetFloat64(fmiHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3GetFloat64(fmiHandle *fmu,
                       const fmi3ValueReference valueReferences[],
                       size_t nValueReferences,
                       fmi3Float64 values[],
                       size_t nValues);
 
-FMIC_DLLEXPORT fmi3Status fmi3SetFloat64(fmiHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3SetFloat64(fmiHandle *fmu,
                       const fmi3ValueReference valueReferences[],
                       size_t nValueReferences,
                       fmi3Float64 values[],
                       size_t nValues);
 
-FMIC_DLLEXPORT fmi3Status fmi3EnterInitializationMode(fmiHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3EnterInitializationMode(fmiHandle *fmu,
                                    fmi3Boolean toleranceDefined,
                                    fmi3Float64 tolerance,
                                    fmi3Float64 startTime,
                                    fmi3Boolean stopTimeDefined,
                                    fmi3Float64 stopTime);
 
-FMIC_DLLEXPORT fmi3Status fmi3ExitInitializationMode(fmiHandle *fmu);
+FMI4C_DLLAPI fmi3Status fmi3ExitInitializationMode(fmiHandle *fmu);
 
-FMIC_DLLEXPORT fmi3Status fmi3Terminate(fmiHandle *fmu);
+FMI4C_DLLAPI fmi3Status fmi3Terminate(fmiHandle *fmu);
 
-FMIC_DLLEXPORT void fmi3FreeInstance(fmiHandle *fmu);
+FMI4C_DLLAPI void fmi3FreeInstance(fmiHandle *fmu);
 
-FMIC_DLLEXPORT fmi3Status fmi3DoStep(fmiHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3DoStep(fmiHandle *fmu,
                   fmi3Float64 currentCommunicationPoint,
                   fmi3Float64 communicationStepSize,
                   fmi3Boolean noSetFMUStatePriorToCurrentPoint,
@@ -572,177 +571,177 @@ FMIC_DLLEXPORT fmi3Status fmi3DoStep(fmiHandle *fmu,
                   fmi3Boolean *earlyReturn,
                   fmi3Float64 *lastSuccessfulTime);
 
-FMIC_DLLEXPORT fmi3Status fmi3EnterEventMode(fmiHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3EnterEventMode(fmiHandle *fmu,
                                                  fmi3Boolean stepEvent,
                                                  fmi3Boolean stateEvent,
                                                  const fmi3Int32 rootsFound[],
                                                  size_t nEventIndicators,
                                                  fmi3Boolean timeEvent);
 
-FMIC_DLLEXPORT fmi3Status fmi3Reset(fmiHandle *fmu);
+FMI4C_DLLAPI fmi3Status fmi3Reset(fmiHandle *fmu);
 
-FMIC_DLLEXPORT fmi3Status fmi3GetFloat32(fmiHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3GetFloat32(fmiHandle *fmu,
                                              const fmi3ValueReference valueReferences[],
                                              size_t nValueReferences,
                                              fmi3Float32 values[],
                                              size_t nValues);
 
-FMIC_DLLEXPORT fmi3Status fmi3GetInt8(fmiHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3GetInt8(fmiHandle *fmu,
                                           const fmi3ValueReference valueReferences[],
                                           size_t nValueReferences,
                                           fmi3Int8 values[],
                                           size_t nValues);
 
-FMIC_DLLEXPORT fmi3Status fmi3GetUInt8(fmiHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3GetUInt8(fmiHandle *fmu,
                                            const fmi3ValueReference valueReferences[],
                                            size_t nValueReferences,
                                            fmi3UInt8 values[],
                                            size_t nValues);
 
-FMIC_DLLEXPORT fmi3Status fmi3GetInt16(fmiHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3GetInt16(fmiHandle *fmu,
                                            const fmi3ValueReference valueReferences[],
                                            size_t nValueReferences,
                                            fmi3Int16 values[],
                                            size_t nValues);
 
-FMIC_DLLEXPORT fmi3Status fmi3GetUInt16(fmiHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3GetUInt16(fmiHandle *fmu,
                                             const fmi3ValueReference valueReferences[],
                                             size_t nValueReferences,
                                             fmi3UInt16 values[],
                                             size_t nValues);
 
-FMIC_DLLEXPORT fmi3Status fmi3GetInt32(fmiHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3GetInt32(fmiHandle *fmu,
                                            const fmi3ValueReference valueReferences[],
                                            size_t nValueReferences,
                                            fmi3Int32 values[],
                                            size_t nValues);
 
-FMIC_DLLEXPORT fmi3Status fmi3GetUInt32(fmiHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3GetUInt32(fmiHandle *fmu,
                                             const fmi3ValueReference valueReferences[],
                                             size_t nValueReferences,
                                             fmi3UInt32 values[],
                                             size_t nValues);
 
-FMIC_DLLEXPORT fmi3Status fmi3GetInt64(fmiHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3GetInt64(fmiHandle *fmu,
                                            const fmi3ValueReference valueReferences[],
                                            size_t nValueReferences,
                                            fmi3Int64 values[],
                                            size_t nValues);
 
-FMIC_DLLEXPORT fmi3Status fmi3GetUInt64(fmiHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3GetUInt64(fmiHandle *fmu,
                                             const fmi3ValueReference valueReferences[],
                                             size_t nValueReferences,
                                             fmi3UInt64 values[],
                                             size_t nValues);
 
-FMIC_DLLEXPORT fmi3Status fmi3GetBoolean(fmiHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3GetBoolean(fmiHandle *fmu,
                                              const fmi3ValueReference valueReferences[],
                                              size_t nValueReferences,
                                              fmi3Boolean values[],
                                              size_t nValues);
 
-FMIC_DLLEXPORT fmi3Status fmi3GetString(fmiHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3GetString(fmiHandle *fmu,
                                             const fmi3ValueReference valueReferences[],
                                             size_t nValueReferences,
                                             fmi3String values[],
                                             size_t nValues);
 
-FMIC_DLLEXPORT fmi3Status fmi3GetBinary(fmiHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3GetBinary(fmiHandle *fmu,
                                             const fmi3ValueReference valueReferences[],
                                             size_t nValueReferences,
                                             size_t valueSizes[],
                                             fmi3Binary values[],
                                             size_t nValues);
 
-FMIC_DLLEXPORT fmi3Status fmi3GetClock(fmiHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3GetClock(fmiHandle *fmu,
                                            const fmi3ValueReference valueReferences[],
                                            size_t nValueReferences,
                                            fmi3Clock values[]);
 
-FMIC_DLLEXPORT fmi3Status fmi3SetFloat32(fmiHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3SetFloat32(fmiHandle *fmu,
                                              const fmi3ValueReference valueReferences[],
                                              size_t nValueReferences,
                                              const fmi3Float32 values[],
                                              size_t nValues);
 
-FMIC_DLLEXPORT fmi3Status fmi3SetInt8(fmiHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3SetInt8(fmiHandle *fmu,
                                           const fmi3ValueReference valueReferences[],
                                           size_t nValueReferences,
                                           const fmi3Int8 values[],
                                           size_t nValues);
 
-FMIC_DLLEXPORT fmi3Status fmi3SetUInt8(fmiHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3SetUInt8(fmiHandle *fmu,
                                            const fmi3ValueReference valueReferences[],
                                            size_t nValueReferences,
                                            const fmi3UInt8 values[],
                                            size_t nValues);
 
-FMIC_DLLEXPORT fmi3Status fmi3SetInt16(fmiHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3SetInt16(fmiHandle *fmu,
                                            const fmi3ValueReference valueReferences[],
                                            size_t nValueReferences,
                                            const fmi3Int16 values[],
                                            size_t nValues);
 
-FMIC_DLLEXPORT fmi3Status fmi3SetUInt16(fmiHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3SetUInt16(fmiHandle *fmu,
                                             const fmi3ValueReference valueReferences[],
                                             size_t nValueReferences,
                                             const fmi3UInt16 values[],
                                             size_t nValues);
 
-FMIC_DLLEXPORT fmi3Status fmi3SetInt32(fmiHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3SetInt32(fmiHandle *fmu,
                                            const fmi3ValueReference valueReferences[],
                                            size_t nValueReferences,
                                            const fmi3Int32 values[],
                                            size_t nValues);
 
-FMIC_DLLEXPORT fmi3Status fmi3SetUInt32(fmiHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3SetUInt32(fmiHandle *fmu,
                                             const fmi3ValueReference valueReferences[],
                                             size_t nValueReferences,
                                             const fmi3UInt32 values[],
                                             size_t nValues);
 
-FMIC_DLLEXPORT fmi3Status fmi3SetInt64(fmiHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3SetInt64(fmiHandle *fmu,
                                            const fmi3ValueReference valueReferences[],
                                            size_t nValueReferences,
                                            const fmi3Int64 values[],
                                            size_t nValues);
 
-FMIC_DLLEXPORT fmi3Status fmi3SetUInt64(fmiHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3SetUInt64(fmiHandle *fmu,
                                             const fmi3ValueReference valueReferences[],
                                             size_t nValueReferences,
                                             const fmi3UInt64 values[],
                                             size_t nValues);
 
-FMIC_DLLEXPORT fmi3Status fmi3SetBoolean(fmiHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3SetBoolean(fmiHandle *fmu,
                                              const fmi3ValueReference valueReferences[],
                                              size_t nValueReferences,
                                              const fmi3Boolean values[],
                                              size_t nValues);
 
-FMIC_DLLEXPORT fmi3Status fmi3SetString(fmiHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3SetString(fmiHandle *fmu,
                                             const fmi3ValueReference valueReferences[],
                                             size_t nValueReferences,
                                             const fmi3String values[],
                                             size_t nValues);
 
-FMIC_DLLEXPORT fmi3Status fmi3SetBinary(fmiHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3SetBinary(fmiHandle *fmu,
                                             const fmi3ValueReference valueReferences[],
                                             size_t nValueReferences,
                                             const size_t valueSizes[],
                                             const fmi3Binary values[],
                                             size_t nValues);
 
-FMIC_DLLEXPORT fmi3Status fmi3SetClock(fmiHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3SetClock(fmiHandle *fmu,
                                            const fmi3ValueReference valueReferences[],
                                            size_t nValueReferences,
                                            const fmi3Clock values[],
                                            size_t nValues);
 
-FMIC_DLLEXPORT fmi3Status fmi3GetNumberOfVariableDependencies(fmiHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3GetNumberOfVariableDependencies(fmiHandle *fmu,
                                                                   fmi3ValueReference valueReference,
                                                                   size_t* nDependencies);
 
-FMIC_DLLEXPORT fmi3Status fmi3GetVariableDependencies(fmiHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3GetVariableDependencies(fmiHandle *fmu,
                                                           fmi3ValueReference dependent,
                                                           size_t elementIndicesOfDependent[],
                                                           fmi3ValueReference independents[],
@@ -750,27 +749,27 @@ FMIC_DLLEXPORT fmi3Status fmi3GetVariableDependencies(fmiHandle *fmu,
                                                           fmi3DependencyKind dependencyKinds[],
                                                           size_t nDependencies);
 
-FMIC_DLLEXPORT fmi3Status fmi3GetFMUState(fmiHandle *fmu, fmi3FMUState* FMUState);
+FMI4C_DLLAPI fmi3Status fmi3GetFMUState(fmiHandle *fmu, fmi3FMUState* FMUState);
 
-FMIC_DLLEXPORT fmi3Status fmi3SetFMUState(fmiHandle *fmu, fmi3FMUState  FMUState);
+FMI4C_DLLAPI fmi3Status fmi3SetFMUState(fmiHandle *fmu, fmi3FMUState  FMUState);
 
-FMIC_DLLEXPORT fmi3Status fmi3FreeFMUState(fmiHandle *fmu, fmi3FMUState* FMUState);
+FMI4C_DLLAPI fmi3Status fmi3FreeFMUState(fmiHandle *fmu, fmi3FMUState* FMUState);
 
-FMIC_DLLEXPORT fmi3Status fmi3SerializedFMUStateSize(fmiHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3SerializedFMUStateSize(fmiHandle *fmu,
                                                          fmi3FMUState  FMUState,
                                                          size_t* size);
 
-FMIC_DLLEXPORT fmi3Status fmi3SerializeFMUState(fmiHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3SerializeFMUState(fmiHandle *fmu,
                                                     fmi3FMUState  FMUState,
                                                     fmi3Byte serializedState[],
                                                     size_t size);
 
-FMIC_DLLEXPORT fmi3Status fmi3DeserializeFMUState(fmiHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3DeserializeFMUState(fmiHandle *fmu,
                                                   const fmi3Byte serializedState[],
                                                   size_t size,
                                                   fmi3FMUState* FMUState);
 
-FMIC_DLLEXPORT fmi3Status fmi3GetDirectionalDerivative(fmiHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3GetDirectionalDerivative(fmiHandle *fmu,
                                                            const fmi3ValueReference unknowns[],
                                                            size_t nUnknowns,
                                                            const fmi3ValueReference knowns[],
@@ -780,7 +779,7 @@ FMIC_DLLEXPORT fmi3Status fmi3GetDirectionalDerivative(fmiHandle *fmu,
                                                            fmi3Float64 sensitivity[],
                                                            size_t nSensitivity);
 
-FMIC_DLLEXPORT fmi3Status fmi3GetAdjointDerivative(fmiHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3GetAdjointDerivative(fmiHandle *fmu,
                                                        const fmi3ValueReference unknowns[],
                                                        size_t nUnknowns,
                                                        const fmi3ValueReference knowns[],
@@ -790,48 +789,48 @@ FMIC_DLLEXPORT fmi3Status fmi3GetAdjointDerivative(fmiHandle *fmu,
                                                        fmi3Float64 sensitivity[],
                                                        size_t nSensitivity);
 
-FMIC_DLLEXPORT fmi3Status fmi3EnterConfigurationMode(fmiHandle *fmu);
+FMI4C_DLLAPI fmi3Status fmi3EnterConfigurationMode(fmiHandle *fmu);
 
-FMIC_DLLEXPORT fmi3Status fmi3ExitConfigurationMode(fmiHandle *fmu);
+FMI4C_DLLAPI fmi3Status fmi3ExitConfigurationMode(fmiHandle *fmu);
 
-FMIC_DLLEXPORT fmi3Status fmi3GetIntervalDecimal(fmiHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3GetIntervalDecimal(fmiHandle *fmu,
                                                      const fmi3ValueReference valueReferences[],
                                                      size_t nValueReferences,
                                                      fmi3Float64 intervals[],
                                                      fmi3IntervalQualifier qualifiers[]);
 
-FMIC_DLLEXPORT fmi3Status fmi3GetIntervalFraction(fmiHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3GetIntervalFraction(fmiHandle *fmu,
                                                       const fmi3ValueReference valueReferences[],
                                                       size_t nValueReferences,
                                                       fmi3UInt64 intervalCounters[],
                                                       fmi3UInt64 resolutions[],
                                                       fmi3IntervalQualifier qualifiers[]);
 
-FMIC_DLLEXPORT fmi3Status fmi3GetShiftDecimal(fmiHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3GetShiftDecimal(fmiHandle *fmu,
                                                   const fmi3ValueReference valueReferences[],
                                                   size_t nValueReferences,
                                                   fmi3Float64 shifts[]);
 
-FMIC_DLLEXPORT fmi3Status fmi3GetShiftFraction(fmiHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3GetShiftFraction(fmiHandle *fmu,
                                                    const fmi3ValueReference valueReferences[],
                                                    size_t nValueReferences,
                                                    fmi3UInt64 shiftCounters[],
                                                    fmi3UInt64 resolutions[]);
 
-FMIC_DLLEXPORT fmi3Status fmi3SetIntervalDecimal(fmiHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3SetIntervalDecimal(fmiHandle *fmu,
                                                      const fmi3ValueReference valueReferences[],
                                                      size_t nValueReferences,
                                                      const fmi3Float64 intervals[]);
 
-FMIC_DLLEXPORT fmi3Status fmi3SetIntervalFraction(fmiHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3SetIntervalFraction(fmiHandle *fmu,
                                                       const fmi3ValueReference valueReferences[],
                                                       size_t nValueReferences,
                                                       const fmi3UInt64 intervalCounters[],
                                                       const fmi3UInt64 resolutions[]);
 
-FMIC_DLLEXPORT fmi3Status fmi3EvaluateDiscreteStates(fmiHandle *fmu);
+FMI4C_DLLAPI fmi3Status fmi3EvaluateDiscreteStates(fmiHandle *fmu);
 
-FMIC_DLLEXPORT fmi3Status fmi3UpdateDiscreteStates(fmiHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3UpdateDiscreteStates(fmiHandle *fmu,
                                                        fmi3Boolean* discreteStatesNeedUpdate,
                                                        fmi3Boolean* terminateSimulation,
                                                        fmi3Boolean* nominalsOfContinuousStatesChanged,
@@ -839,51 +838,51 @@ FMIC_DLLEXPORT fmi3Status fmi3UpdateDiscreteStates(fmiHandle *fmu,
                                                        fmi3Boolean* nextEventTimeDefined,
                                                        fmi3Float64* nextEventTime);
 
-FMIC_DLLEXPORT fmi3Status fmi3EnterContinuousTimeMode(fmiHandle *fmu);
+FMI4C_DLLAPI fmi3Status fmi3EnterContinuousTimeMode(fmiHandle *fmu);
 
-FMIC_DLLEXPORT fmi3Status fmi3CompletedIntegratorStep(fmiHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3CompletedIntegratorStep(fmiHandle *fmu,
                                                           fmi3Boolean  noSetFMUStatePriorToCurrentPoint,
                                                           fmi3Boolean* enterEventMode,
                                                           fmi3Boolean* terminateSimulation);
 
-FMIC_DLLEXPORT fmi3Status fmi3SetTime(fmiHandle *fmu, fmi3Float64 time);
+FMI4C_DLLAPI fmi3Status fmi3SetTime(fmiHandle *fmu, fmi3Float64 time);
 
-FMIC_DLLEXPORT fmi3Status fmi3SetContinuousStates(fmiHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3SetContinuousStates(fmiHandle *fmu,
                                                       const fmi3Float64 continuousStates[],
                                                       size_t nContinuousStates);
 
-FMIC_DLLEXPORT fmi3Status fmi3GetContinuousStateDerivatives(fmiHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3GetContinuousStateDerivatives(fmiHandle *fmu,
                                                                 fmi3Float64 derivatives[],
                                                                 size_t nContinuousStates);
 
-FMIC_DLLEXPORT fmi3Status fmi3GetEventIndicators(fmiHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3GetEventIndicators(fmiHandle *fmu,
                                                      fmi3Float64 eventIndicators[],
                                                      size_t nEventIndicators);
 
-FMIC_DLLEXPORT fmi3Status fmi3GetContinuousStates(fmiHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3GetContinuousStates(fmiHandle *fmu,
                                                       fmi3Float64 continuousStates[],
                                                       size_t nContinuousStates);
 
-FMIC_DLLEXPORT fmi3Status fmi3GetNominalsOfContinuousStates(fmiHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3GetNominalsOfContinuousStates(fmiHandle *fmu,
                                                                 fmi3Float64 nominals[],
                                                                 size_t nContinuousStates);
 
-FMIC_DLLEXPORT fmi3Status fmi3GetNumberOfEventIndicators(fmiHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3GetNumberOfEventIndicators(fmiHandle *fmu,
                                                              size_t* nEventIndicators);
 
-FMIC_DLLEXPORT fmi3Status fmi3GetNumberOfContinuousStates(fmiHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3GetNumberOfContinuousStates(fmiHandle *fmu,
                                                               size_t* nContinuousStates);
 
-FMIC_DLLEXPORT fmi3Status fmi3EnterStepMode(fmiHandle *fmu);
+FMI4C_DLLAPI fmi3Status fmi3EnterStepMode(fmiHandle *fmu);
 
-FMIC_DLLEXPORT fmi3Status fmi3GetOutputDerivatives(fmiHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3GetOutputDerivatives(fmiHandle *fmu,
                                                        const fmi3ValueReference valueReferences[],
                                                        size_t nValueReferences,
                                                        const fmi3Int32 orders[],
                                                        fmi3Float64 values[],
                                                        size_t nValues);
 
-FMIC_DLLEXPORT fmi3Status fmi3ActivateModelPartition(fmiHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3ActivateModelPartition(fmiHandle *fmu,
                                                          fmi3ValueReference clockReference,
                                                          fmi3Float64 activationTime);
 

--- a/include/fmi4c_placeholders.h
+++ b/include/fmi4c_placeholders.h
@@ -1,7 +1,6 @@
 #ifndef FMI4C_PLACEHOLDERS_H
 #define FMI4C_PLACEHOLDERS_H
 
-#include <stdio.h>
 #include "fmi4c_types_fmi1.h"
 #include "fmi4c_types_fmi2.h"
 #include "fmi4c_types_fmi3.h"
@@ -10,6 +9,8 @@
 #include "fmi4c_functions_fmi3.h"
 #include "fmi/fmiPlatformTypes.h"
 #include "fmi/fmiFunctions.h"
+
+#include <stdio.h>
 
 fmi1Status placeholder(fmi1Component_t component, fmi1Boolean x) {
     return fmi1Error;

--- a/src/fmi4c.c
+++ b/src/fmi4c.c
@@ -1,4 +1,6 @@
 #include "fmi4c_private.h"
+#define FMI4C_H_INTERNAL_INCLUDE
+#include "fmi4c.h"
 #include "fmi4c_placeholders.h"
 #include "fmi4c_utils.h"
 

--- a/src/fmi4c.c
+++ b/src/fmi4c.c
@@ -2742,7 +2742,7 @@ double fmi2GetDefaultStepSize(fmiHandle *fmu)
     return fmu->fmi2.defaultStepSize;
 }
 
-void *fmi3GetVariableByName(fmiHandle *fmu, fmi3String name)
+fmi3VariableHandle *fmi3GetVariableByName(fmiHandle *fmu, fmi3String name)
 {
     for(int i=0; i<fmu->fmi3.numberOfVariables; ++i) {
         if(!strcmp(fmu->fmi3.variables[i].name, name)) {
@@ -2753,7 +2753,7 @@ void *fmi3GetVariableByName(fmiHandle *fmu, fmi3String name)
     return NULL;
 }
 
-void *fmi3GetVariableByIndex(fmiHandle *fmu, int i)
+fmi3VariableHandle *fmi3GetVariableByIndex(fmiHandle *fmu, int i)
 {
 
     if(i >= fmu->fmi3.numberOfVariables) {
@@ -2763,7 +2763,7 @@ void *fmi3GetVariableByIndex(fmiHandle *fmu, int i)
     return &fmu->fmi3.variables[i];
 }
 
-void *fmi3GetVariableByValueReference(fmiHandle *fmu, fmi3ValueReference vr)
+fmi3VariableHandle *fmi3GetVariableByValueReference(fmiHandle *fmu, fmi3ValueReference vr)
 {
 
     for(int i=0; i<fmu->fmi3.numberOfVariables; ++i) {
@@ -2782,7 +2782,7 @@ int fmi2GetNumberOfVariables(fmiHandle *fmu)
     return fmu->fmi2.numberOfVariables;
 }
 
-void *fmi2GetVariableByIndex(fmiHandle *fmu, int i)
+fmi2VariableHandle *fmi2GetVariableByIndex(fmiHandle *fmu, int i)
 {
     TRACEFUNC
 
@@ -2793,7 +2793,7 @@ void *fmi2GetVariableByIndex(fmiHandle *fmu, int i)
     return &fmu->fmi2.variables[i];
 }
 
-void *fmi2GetVariableByValueReference(fmiHandle *fmu, fmi2ValueReference vr)
+fmi2VariableHandle *fmi2GetVariableByValueReference(fmiHandle *fmu, fmi2ValueReference vr)
 {
     TRACEFUNC
 
@@ -2806,7 +2806,7 @@ void *fmi2GetVariableByValueReference(fmiHandle *fmu, fmi2ValueReference vr)
     return NULL;
 }
 
-void *fmi2GetVariableByName(fmiHandle *fmu, fmi2String name)
+fmi2VariableHandle *fmi2GetVariableByName(fmiHandle *fmu, fmi2String name)
 {
     for(int i=0; i<fmu->fmi2.numberOfVariables; ++i) {
         if(!strcmp(fmu->fmi2.variables[i].name, name)) {
@@ -3755,7 +3755,7 @@ fmi1VariableHandle *fmi1GetVariableByValueReference(fmiHandle *fmu, fmi1ValueRef
     return NULL;
 }
 
-void *fmi1GetVariableByName(fmiHandle *fmu, fmi1String name)
+fmi1VariableHandle *fmi1GetVariableByName(fmiHandle *fmu, fmi1String name)
 {
     for(int i=0; i<fmu->fmi1.numberOfVariables; ++i) {
         if(!strcmp(fmu->fmi1.variables[i].name, name)) {
@@ -4010,7 +4010,7 @@ bool fmi1InstantiateModel(fmiHandle *fmu, fmi1CallbackLogger_t logger, fmi1Callb
 void fmi1FreeModelInstance(fmiHandle *fmu)
 {
     TRACEFUNC
-    return fmu->fmi1.freeModelInstance(fmu->fmi1.component);
+    fmu->fmi1.freeModelInstance(fmu->fmi1.component);
 }
 
 fmi1Status fmi1SetTime(fmiHandle *fmu, fmi1Real time)
@@ -4467,7 +4467,8 @@ void fmi3GetEnumerationType(fmiHandle *fmu,
                             const char **description,
                             const char **quantity,
                             int64_t *min,
-                            int64_t *max)
+                            int64_t *max,
+                            int *numberOfItems)
 {
     for(int i=0; i<fmu->fmi3.numberOfEnumerationTypes; ++i) {
         if(!strcmp(fmu->fmi3.enumTypes[i].name, name)) {
@@ -4477,6 +4478,7 @@ void fmi3GetEnumerationType(fmiHandle *fmu,
             *max = fmu->fmi3.enumTypes[i].max;
         }
     }
+    // TODO numberOfItems
 }
 
 void fmi3GetClockType(fmiHandle *fmu,

--- a/src/fmi4c.c
+++ b/src/fmi4c.c
@@ -1,7 +1,8 @@
 #include "fmi4c_private.h"
 #include "fmi4c_placeholders.h"
-#include "minizip/miniunz.h"
+#include "fmi4c_utils.h"
 
+#include "minizip/miniunz.h"
 #include "ezxml/ezxml.h"
 
 #include <sys/stat.h>
@@ -13,8 +14,6 @@
     #include <dlfcn.h>
     #include <unistd.h>
 #endif
-
-#include "fmi4c_utils.h"
 
 #ifdef _WIN32
 FARPROC loadDllFunction(HINSTANCE dll, const char *name, bool *ok) {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,5 +1,10 @@
 find_package(Threads REQUIRED)
 
+set(libmath "")
+if (NOT MSVC)
+  set(libmath m)
+endif()
+
 add_executable(fmi4ctest fmi4c_test.c
                          fmi4c_test_fmi1.c
                          fmi4c_test_fmi2.c
@@ -11,7 +16,7 @@ add_executable(fmi4ctest fmi4c_test.c
                          fmi4c_test_fmi3.h
                          fmi4c_test_tlm.h)
 target_include_directories(fmi4ctest PRIVATE .)
-target_link_libraries(fmi4ctest fmi4c Threads::Threads m)
+target_link_libraries(fmi4ctest fmi4c Threads::Threads ${libmath})
 install(TARGETS fmi4ctest RUNTIME DESTINATION bin)
 
 # 3rdparty locations
@@ -100,7 +105,7 @@ add_library(fmi3tlm SHARED fmi3tlm/fmi3tlm.c
 set_target_properties(fmi3tlm PROPERTIES PREFIX "")
 target_include_directories(fmi3tlm PRIVATE ${3rdparty}/fmi)
 target_include_directories(fmi3tlm PRIVATE ${sundials}/include)
-target_link_libraries(fmi3tlm m)
+target_link_libraries(fmi3tlm ${libmath})
 add_custom_command(TARGET fmi3tlm POST_BUILD
   COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_CURRENT_BINARY_DIR}/fmi3tlm/binaries/${binfolder})
 add_custom_command(TARGET fmi3tlm POST_BUILD

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -5,19 +5,26 @@ if (NOT MSVC)
   set(libmath m)
 endif()
 
-add_executable(fmi4ctest fmi4c_test.c
-                         fmi4c_test_fmi1.c
-                         fmi4c_test_fmi2.c
-                         fmi4c_test_fmi3.c
-                         fmi4c_test_tlm.c
-                         fmi4c_test.h
-                         fmi4c_test_fmi1.h
-                         fmi4c_test_fmi2.h
-                         fmi4c_test_fmi3.h
-                         fmi4c_test_tlm.h)
+set(fmi4ctest_src fmi4c_test.c
+                  fmi4c_test_fmi1.c
+                  fmi4c_test_fmi2.c
+                  fmi4c_test_fmi3.c
+                  fmi4c_test.h
+                  fmi4c_test_fmi1.h
+                  fmi4c_test_fmi2.h
+                  fmi4c_test_fmi3.h)
+if(NOT MSVC)
+  # TODO Implement thread support for MSVC, right now pthreads are expected
+  set(fmi4ctest_src ${fmi4ctest_src} fmi4c_test_tlm.c fmi4c_test_tlm.h)
+endif()
+
+add_executable(fmi4ctest ${fmi4ctest_src})
 target_include_directories(fmi4ctest PRIVATE .)
 target_link_libraries(fmi4ctest fmi4c Threads::Threads ${libmath})
 install(TARGETS fmi4ctest RUNTIME DESTINATION bin)
+if(MSVC)
+  target_compile_definitions(fmi4ctest PRIVATE FMI4CTEST_NO_TLM)
+endif()
 
 # 3rdparty locations
 set(3rdparty ${CMAKE_CURRENT_LIST_DIR}/../3rdparty)

--- a/test/fmi4c_test.c
+++ b/test/fmi4c_test.c
@@ -2,7 +2,6 @@
 #include <stdlib.h>
 #include <stdarg.h>
 #include <string.h>
-#include <pthread.h>
 #include <math.h>
 
 #include "fmi4c.h"
@@ -187,7 +186,12 @@ int main(int argc, char *argv[])
             return 1;
         }
 
+#ifdef FMI4CTEST_NO_TLM
+        printf("FMI TLM support not available\n");
+        return 1;
+#else
         return testFMI3TLM(fmu, fmu2);
+#endif
     }
 
     if(version == fmiVersion1) {

--- a/test/fmi4c_test_fmi1.c
+++ b/test/fmi4c_test_fmi1.c
@@ -24,7 +24,7 @@ void loggerFmi1(fmi1Component_t component,
 
 int testFMI1ME(fmiHandle *fmu) {
     //Instantiate FMU
-    if(!fmi1InstantiateModel(fmu, loggerFmi1, calloc, free, NULL, fmi1True)) {
+    if(!fmi1InstantiateModel(fmu, loggerFmi1, calloc, free, fmi1True)) {
         printf("  fmi2Instantiate() failed\n");
         exit(1);
     }


### PR DESCRIPTION
Various change to enable build with MSVC
Add option to force use of included zlib, version found in system is used otherwise.
I not found, the included version if build by default (for MSVC). It is build as a static library in this case.
