### PR TITLE
Fix various warnings from static analysis

### DIFF
--- a/src/fmi4c_utils.c
+++ b/src/fmi4c_utils.c
@@ -13,9 +13,10 @@ const char* getFunctionName(const char* modelName, const char* functionName) {
         return functionName;    //!< Do not change function name if model name is empty
     }
     char* fullName = (char*)malloc(strlen(modelName)+strlen(functionName)+2);
-    strcpy(fullName, modelName);
-    strcat(fullName, "_");
-    strcat(fullName, functionName);
+    strncpy(fullName, modelName, strlen(modelName)+strlen(functionName)+2);
+    fullName[strlen(modelName)] = '\0';
+    strncat(fullName,  "_", strlen(modelName)+strlen(functionName)+2);
+    strncat(fullName, functionName, strlen(modelName)+strlen(functionName)+2);
     return fullName;
 }
 

--- a/test/fmi3tlm/fmi3tlm.c
+++ b/test/fmi3tlm/fmi3tlm.c
@@ -808,12 +808,6 @@ bool steadyState(fmuContext *fmu)
         }
     }
     else if(method == 3) {
-
-            double hfac = 1;
-            if(nlog > 1) {
-                hfac = (fmu->tlog[fmu->logend] - fmu->tlog[fmu->logend-2])/fmu->minStepSize;
-            }
-
             double lambda1=0.3;
             double lambda2=0.2;
             double lambda3=0.001;

--- a/test/fmi4c_test.c
+++ b/test/fmi4c_test.c
@@ -171,7 +171,7 @@ int main(int argc, char *argv[])
     if(testTLM) {
         printf("  FMU path (2): %s\n", fmuPath2);
     }
-    if(strcmp(inputCsvPath, "") != 0) {
+    if(inputCsvPath != NULL && strcmp(inputCsvPath, "") != 0) {
         printf("  Input CSV path:  %s\n", inputCsvPath);
     }
     printf("  Output CSV path: %s\n", outputCsvPath);
@@ -212,14 +212,7 @@ int main(int argc, char *argv[])
         exit(1);
     }
 
-    char *cwd = (char*)malloc(sizeof(char)*FILENAME_MAX);
-#ifdef _WIN32
-    _getcwd(cwd, sizeof(char)*FILENAME_MAX);
-#else
-    getcwd(cwd, sizeof(char)*FILENAME_MAX);
-#endif
-
-    if(strcmp(inputCsvPath, "") != 0) {
+    if(inputCsvPath != NULL && strcmp(inputCsvPath, "") != 0) {
         FILE *inputFile = fopen(inputCsvPath, "r");
         char lineStr[1024];
         size_t lineNumber = 0;

--- a/test/fmi4c_test_fmi2.c
+++ b/test/fmi4c_test_fmi2.c
@@ -1,4 +1,5 @@
 #include <stdarg.h>
+#include <string.h>
 
 #include "fmi4c.h"
 #include "fmi4c_test.h"
@@ -80,7 +81,7 @@ int testFMI2ME(fmiHandle *fmu, bool overrideStopTime, double stopTimeOverride, b
     }
     printf("  FMU successfully initialized.\n");
 
-    double actualStepSize = stepSize;
+    double actualStepSize;
     fmi2Boolean terminateSimulation = fmi2False;
     fmi2Boolean callEventUpdate = fmi2False;
     fmi2EventInfo eventInfo;
@@ -332,7 +333,8 @@ int testFMI2CS(fmiHandle *fmu, bool overrideStopTime, double stopTimeOverride, b
     }
     fprintf(outputFile,"\n");
 
-    for(double time=startTime; time <= stopTime; time+=stepSize) {
+    double time=startTime;
+    while(time <= stopTime) {
 
         //Interpolate inputs from CSV file
         for(int i=1; i<nInterpolators; ++i) {
@@ -361,6 +363,8 @@ int testFMI2CS(fmiHandle *fmu, bool overrideStopTime, double stopTimeOverride, b
             fprintf(outputFile,",%f",value);
         }
         fprintf(outputFile,"\n");
+
+        time+=stepSize;
     }
     fclose(outputFile);
     printf("  Simulation finished.\n");
@@ -378,8 +382,6 @@ int testFMI2(fmiHandle *fmu, bool forceModelExchange, bool overrideStopTime, dou
     for(size_t i=0; i<fmi2_getNumberOfVariables(fmu); ++i)
     {
         fmi2VariableHandle* var = fmi2_getVariableByIndex(fmu, i);
-        const char* name = fmi2_getVariableName(var);
-        fmi2DataType type = fmi2_getVariableDataType(var);
         fmi2Causality causality = fmi2_getVariableCausality(var);
         unsigned int vr = fmi2_getVariableValueReference(var);
 

--- a/test/fmi4c_test_tlm.c
+++ b/test/fmi4c_test_tlm.c
@@ -11,8 +11,6 @@
 
 #include "fmi4c.h"
 #include "fmi4c_test.h"
-#include "fmi4c_test_fmi1.h"
-#include "fmi4c_test_fmi2.h"
 #include "fmi4c_test_fmi3.h"
 #include "fmi4c_test_tlm.h"
 


### PR DESCRIPTION
Fixed warnings from Clang-Tidy and CppCheck. 

- Initialized variables before first use
- Do not provide initial value to variables if the value is never used
- Free all allocated memory
- Prevent string comparison with NULL strings
- Replace unsafe functions (`strcat` etc...)
- Avoid using floating point variables as loop counters