### PR TITLE
Beautify log printing in fmi4ctest

### DIFF
--- a/test/fmi4c_test_fmi1.c
+++ b/test/fmi4c_test_fmi1.c
@@ -18,7 +18,7 @@ void loggerFmi1(fmi1Component_t component,
 
     va_list args;
     va_start(args, message);
-    printf(message, args);
+    printf("%s: %s", category, message, args);
     va_end(args);
 }
 

--- a/test/fmi4c_test_fmi2.c
+++ b/test/fmi4c_test_fmi2.c
@@ -16,9 +16,9 @@ void loggerFmi2(fmi2ComponentEnvironment componentEnvironment,
     UNUSED(status)
     UNUSED(category)
 
-            va_list args;
+    va_list args;
     va_start(args, message);
-    printf("%s: %s\n",message, args);
+    printf("%s: %s\n", category, message, args);
     va_end(args);
 }
 

--- a/test/fmi4c_test_fmi3.c
+++ b/test/fmi4c_test_fmi3.c
@@ -12,7 +12,7 @@ void loggerFmi3(fmi3InstanceEnvironment instanceEnvironment,
     UNUSED(status)
     UNUSED(category)
 
-    printf("%s\n",message);
+    printf("%s: %s\n",category, message);
 }
 
 


### PR DESCRIPTION
Make sure arguments are printed correctly (it used prints garbage, at least for FMI 2)