### PR TITLE
Added arguments for time step and stop time to test executable

### DIFF
--- a/test/fmi4c_test_fmi1.c
+++ b/test/fmi4c_test_fmi1.c
@@ -22,7 +22,7 @@ void loggerFmi1(fmi1Component_t component,
     va_end(args);
 }
 
-int testFMI1ME(fmiHandle *fmu) {
+int testFMI1ME(fmiHandle *fmu, bool overrideStopTime, double stopTimeOverride, bool overrideTimeStep, double timeStepOverride) {
     //Instantiate FMU
     if(!fmi1InstantiateModel(fmu, loggerFmi1, calloc, free, fmi1True)) {
         printf("  fmi2Instantiate() failed\n");
@@ -32,7 +32,13 @@ int testFMI1ME(fmiHandle *fmu) {
 
     double startTime = 0;
     double stepSize = 0.001;
+    if(overrideTimeStep) {
+        stepSize = timeStepOverride;
+    }
     double stopTime = 1;
+    if(overrideStopTime) {
+        stopTime = stopTimeOverride;
+    }
 
     if(fmi1DefaultStartTimeDefined(fmu)) {
         startTime = fmi1GetDefaultStartTime(fmu);
@@ -215,7 +221,7 @@ int testFMI1ME(fmiHandle *fmu) {
 }
 
 
-int testFMI1CS(fmiHandle *fmu)
+int testFMI1CS(fmiHandle *fmu, bool overrideStopTime, double stopTimeOverride, bool overrideTimeStep, double timeStepOverride)
 {
     //Instantiate FMU
     if(!fmi1InstantiateSlave(fmu, "application/x-fmu-sharedlibrary", 1000, fmi1False, fmi1False, loggerFmi1, calloc, free, NULL, fmi1True)) {
@@ -226,7 +232,13 @@ int testFMI1CS(fmiHandle *fmu)
 
     double startTime = 0;
     double stepSize = 0.001;
+    if(overrideTimeStep) {
+        stepSize = timeStepOverride;
+    }
     double stopTime = 1;
+    if(overrideStopTime) {
+        stopTime = stopTimeOverride;
+    }
 
     if(fmi1DefaultStartTimeDefined(fmu)) {
         startTime = fmi1GetDefaultStartTime(fmu);
@@ -295,7 +307,7 @@ int testFMI1CS(fmiHandle *fmu)
 }
 
 
-int testFMI1(fmiHandle *fmu)
+int testFMI1(fmiHandle *fmu, bool overrideStopTime, double stopTimeOverride, bool overrideTimeStep, double timeStepOverride)
 {
     //Loop through variables in FMU
     for(size_t i=0; i<fmi1GetNumberOfVariables(fmu); ++i)
@@ -320,9 +332,9 @@ int testFMI1(fmiHandle *fmu)
     }
 
     if(fmi1GetType(fmu) == fmi1ModelExchange) {
-        return testFMI1ME(fmu);
+        return testFMI1ME(fmu, overrideStopTime, stopTimeOverride, overrideTimeStep, timeStepOverride);
     }
     else {
-        return testFMI1CS(fmu);
+        return testFMI1CS(fmu, overrideStopTime, stopTimeOverride, overrideTimeStep, timeStepOverride);
     }
 }

--- a/test/fmi4c_test_fmi1.h
+++ b/test/fmi4c_test_fmi1.h
@@ -10,6 +10,6 @@ void loggerFmi1(fmi1Component_t component,
                 fmi1String message,
                 ...);
 
-int testFMI1(fmiHandle *fmu);
+int testFMI1(fmiHandle *fmu, bool overrideStopTime, double stopTimeOverride, bool overrideTimeStep, double timeStepOverride);
 
 #endif //FMIC_TEST_FMI1_H

--- a/test/fmi4c_test_fmi2.c
+++ b/test/fmi4c_test_fmi2.c
@@ -23,7 +23,7 @@ void loggerFmi2(fmi2ComponentEnvironment componentEnvironment,
 }
 
 
-int testFMI2ME(fmiHandle *fmu)
+int testFMI2ME(fmiHandle *fmu, bool overrideStopTime, double stopTimeOverride, bool overrideTimeStep, double timeStepOverride)
 {
     //Instantiate FMU
     if(!fmi2Instantiate(fmu, fmi2ModelExchange, loggerFmi2, calloc, free, NULL, NULL, fmi2False, fmi2True)) {
@@ -41,10 +41,16 @@ int testFMI2ME(fmiHandle *fmu)
     if(fmi2DefaultStartTimeDefined(fmu)) {
         startTime = fmi2GetDefaultStartTime(fmu);
     }
-    if(fmi2DefaultStepSizeDefined(fmu)) {
+    if(overrideTimeStep) {
+        stepSize = timeStepOverride;
+    }
+    else if(fmi2DefaultStepSizeDefined(fmu)) {
         stepSize = fmi2GetDefaultStepSize(fmu);
     }
-    if(fmi2DefaultStopTimeDefined(fmu)) {
+    if(overrideStopTime) {
+        stopTime = stopTimeOverride;
+    }
+    else if(fmi2DefaultStopTimeDefined(fmu)) {
         stopTime = fmi2GetDefaultStopTime(fmu);
     }
 
@@ -253,7 +259,7 @@ int testFMI2ME(fmiHandle *fmu)
 }
 
 
-int testFMI2CS(fmiHandle *fmu)
+int testFMI2CS(fmiHandle *fmu, bool overrideStopTime, double stopTimeOverride, bool overrideTimeStep, double timeStepOverride)
 {
     //Instantiate FMU
     if(!fmi2Instantiate(fmu, fmi2CoSimulation, loggerFmi2, calloc, free, NULL, NULL, fmi2False, fmi2True)) {
@@ -270,10 +276,16 @@ int testFMI2CS(fmiHandle *fmu)
     if(fmi2DefaultStartTimeDefined(fmu)) {
         startTime = fmi2GetDefaultStartTime(fmu);
     }
-    if(fmi2DefaultStepSizeDefined(fmu)) {
+    if(overrideTimeStep) {
+        stepSize = timeStepOverride;
+    }
+    else if(fmi2DefaultStepSizeDefined(fmu)) {
         stepSize = fmi2GetDefaultStepSize(fmu);
     }
-    if(fmi2DefaultStopTimeDefined(fmu)) {
+    if(overrideStopTime) {
+        stopTime = stopTimeOverride;
+    }
+    else if(fmi2DefaultStopTimeDefined(fmu)) {
         stopTime = fmi2GetDefaultStopTime(fmu);
     }
 
@@ -349,7 +361,7 @@ int testFMI2CS(fmiHandle *fmu)
 }
 
 
-int testFMI2(fmiHandle *fmu, bool forceModelExchange)
+int testFMI2(fmiHandle *fmu, bool forceModelExchange, bool overrideStopTime, double stopTimeOverride, bool overrideTimeStep, double timeStepOverride)
 {
     //Loop through variables in FMU
     for(size_t i=0; i<fmi2GetNumberOfVariables(fmu); ++i)
@@ -373,10 +385,10 @@ int testFMI2(fmiHandle *fmu, bool forceModelExchange)
     }
 
     if(fmi2GetSupportsCoSimulation(fmu) && !forceModelExchange) {
-        return testFMI2CS(fmu);
+        return testFMI2CS(fmu, overrideStopTime, stopTimeOverride, overrideTimeStep, timeStepOverride);
     }
     else if(fmi2GetSupportsModelExchange(fmu)){
-        return testFMI2ME(fmu);
+        return testFMI2ME(fmu, overrideStopTime, stopTimeOverride, overrideTimeStep, timeStepOverride);
     }
     else {
         printf("Failed to simulate FMU: Requested type not supported.\n");

--- a/test/fmi4c_test_fmi2.h
+++ b/test/fmi4c_test_fmi2.h
@@ -10,6 +10,6 @@ void loggerFmi2(fmi2ComponentEnvironment componentEnvironment,
                 fmi2String message,
                 ...);
 
-int testFMI2(fmiHandle *fmu, bool forceModelExchange);
+int testFMI2(fmiHandle *fmu, bool forceModelExchange, bool overrideStopTime, double stopTimeOverride, bool overrideTimeStep, double timeStepOverride);
 
 #endif //FMIC_TEST_FMI2_H

--- a/test/fmi4c_test_fmi3.c
+++ b/test/fmi4c_test_fmi3.c
@@ -46,7 +46,7 @@ void intermediateUpdate(
 }
 
 
-int testFMI3CS(fmiHandle *fmu)
+int testFMI3CS(fmiHandle *fmu, bool overrideStopTime, double stopTimeOverride, bool overrideTimeStep, double timeStepOverride)
 {
     fmi3Status status;
 
@@ -64,10 +64,16 @@ int testFMI3CS(fmiHandle *fmu)
     if(fmi3DefaultStartTimeDefined(fmu)) {
         startTime = fmi3GetDefaultStartTime(fmu);
     }
-    if(fmi3DefaultStepSizeDefined(fmu)) {
+    if(overrideTimeStep) {
+        stepSize = timeStepOverride;
+    }
+    else if(fmi3DefaultStepSizeDefined(fmu)) {
         stepSize = fmi3GetDefaultStepSize(fmu);
     }
-    if(fmi3DefaultStopTimeDefined(fmu)) {
+    if(overrideStopTime) {
+        stopTime = stopTimeOverride;
+    }
+    else if(fmi3DefaultStopTimeDefined(fmu)) {
         stopTime = fmi3GetDefaultStopTime(fmu);
     }
 
@@ -137,7 +143,7 @@ int testFMI3CS(fmiHandle *fmu)
 }
 
 
-int testFMI3ME(fmiHandle *fmu) {
+int testFMI3ME(fmiHandle *fmu, bool overrideStopTime, double stopTimeOverride, bool overrideTimeStep, double timeStepOverride) {
     //Instantiate FMU
     if(!fmi3InstantiateModelExchange(fmu, fmi2False, fmi2True, NULL, loggerFmi3)) {
         printf("  fmi2Instantiate() failed\n");
@@ -153,10 +159,16 @@ int testFMI3ME(fmiHandle *fmu) {
     if(fmi3DefaultStartTimeDefined(fmu)) {
         startTime = fmi3GetDefaultStartTime(fmu);
     }
-    if(fmi3DefaultStepSizeDefined(fmu)) {
+    if(overrideTimeStep) {
+        stepSize = timeStepOverride;
+    }
+    else if(fmi3DefaultStepSizeDefined(fmu)) {
         stepSize = fmi3GetDefaultStepSize(fmu);
     }
-    if(fmi3DefaultStopTimeDefined(fmu)) {
+    if(overrideStopTime) {
+        stopTime = stopTimeOverride;
+    }
+    else if(fmi3DefaultStopTimeDefined(fmu)) {
         stopTime = fmi3GetDefaultStopTime(fmu);
     }
     if(fmi3DefaultToleranceDefined(fmu)) {
@@ -384,7 +396,7 @@ int testFMI3ME(fmiHandle *fmu) {
 }
 
 
-int testFMI3(fmiHandle *fmu, bool forceModelExchange)
+int testFMI3(fmiHandle *fmu, bool forceModelExchange, bool overrideStopTime, double stopTimeOverride, bool overrideTimeStep, double timeStepOverride)
 {
     //Loop through variables in FMU
     for(size_t i=0; i<fmi3GetNumberOfVariables(fmu); ++i)
@@ -408,10 +420,10 @@ int testFMI3(fmiHandle *fmu, bool forceModelExchange)
     }
 
     if(fmi3SupportsCoSimulation(fmu) && !forceModelExchange) {
-        return testFMI3CS(fmu);
+        return testFMI3CS(fmu, overrideStopTime, stopTimeOverride, overrideTimeStep, timeStepOverride);
     }
     else if(fmi3SupportsModelExchange(fmu)) {
-        return testFMI3ME(fmu);
+        return testFMI3ME(fmu, overrideStopTime, stopTimeOverride, overrideTimeStep, timeStepOverride);
     }
     else {
         printf("Requested FMU type cannot be simulated.\n");

--- a/test/fmi4c_test_fmi3.h
+++ b/test/fmi4c_test_fmi3.h
@@ -8,6 +8,6 @@ void loggerFmi3(fmi3InstanceEnvironment instanceEnvironment,
                 fmi3String category,
                 fmi3String message);
 
-int testFMI3(fmiHandle *fmu, bool forceModelExchange);
+int testFMI3(fmiHandle *fmu, bool forceModelExchange,  bool overrideStopTime, double stopTimeOverride, bool overrideTimeStep, double timeStepOverride);
 
 #endif //FMIC_TEST_FMI3_H

--- a/test/fmi4c_test_tlm.c
+++ b/test/fmi4c_test_tlm.c
@@ -194,7 +194,7 @@ void* doStepInThread(void* argsptr)
 }
 
 
-int testFMI3TLM(fmiHandle *fmua, fmiHandle *fmub)
+int testFMI3TLM(fmiHandle *fmua, fmiHandle *fmub, bool overrideStopTime, double stopTimeOverride, bool overrideTimeStep, double timeStepOverride)
 {
     //TLM coupling parameters
     fmi3Float64 mtlm = 1;       //Distributed inertia [kg]
@@ -203,7 +203,13 @@ int testFMI3TLM(fmiHandle *fmua, fmiHandle *fmub)
     //Simulation parameters
     fmi3Float64 tcur = 0;       //Current simulation time
     fmi3Float64 tstop = 2;      //Simulation stop time
+    if(overrideStopTime) {
+        tstop = overrideStopTime;
+    }
     fmi3Float64 tstep = 0.001;  //Simulation time step
+    if(overrideTimeStep) {
+        tstep = timeStepOverride;
+    }
 
     //Model parameters
     fmi3Float64 fd = 100;       //Disturbance force

--- a/test/fmi4c_test_tlm.h
+++ b/test/fmi4c_test_tlm.h
@@ -3,6 +3,6 @@
 
 #include "fmi4c.h"
 
-int testFMI3TLM(fmiHandle *fmua, fmiHandle *fmub);
+int testFMI3TLM(fmiHandle *fmua, fmiHandle *fmub, bool overrideStopTime, double stopTimeOverride, bool overrideTimeStep, double timeStepOverride);
 
 #endif //FMIC_TEST_TLM_H


### PR DESCRIPTION
Lets user control length and granularity of test simulations.