### PR TITLE
Fixes various issues with running fmi4ctest from Cygwin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,7 +63,7 @@ else()
     add_library(${target_name} STATIC ${SRCFILES})
 endif()
 
-target_compile_definitions(${target_name} PUBLIC HAVE_MEMMOVE=1 EZXML_NOMMAP)
+target_compile_definitions(${target_name} PUBLIC HAVE_MEMMOVE=1 EZXML_NOMMAP USE_FILE32API)
 if (FMI4C_BUILD_SHARED)
     # Only set DLLEXPORT when producing the library, when consumed dllimport will be assumed
     target_compile_definitions(${target_name} PRIVATE FMI4C_DLLEXPORT)

--- a/src/fmi4c.c
+++ b/src/fmi4c.c
@@ -14,8 +14,9 @@
 #include <float.h>
 #include <limits.h>
 #ifndef _WIN32
-    #include <dlfcn.h>
-    #include <unistd.h>
+#include <dlfcn.h>
+#include <unistd.h>
+#include <sys/stat.h>
 #endif
 
 #ifdef _WIN32
@@ -1482,14 +1483,16 @@ bool loadFunctionsFmi1(fmiHandle *fmu)
     char dllPath[FILENAME_MAX];
     dllPath[0] = '\0';
     strcat(dllPath, fmu->unzippedLocation);
-#ifdef _WIN32
-    strcat(dllPath,"\\binaries\\win64\\");
+#if defined(_WIN32 )
+    strcat(dllPath, "\\binaries\\win64\\");
+#elif defined(__CYGWIN__)
+    strcat(dllPath, "/binaries/win64/");
 #else
     strcat(dllPath,"/binaries/linux64/");
 #endif
-    strcat(dllPath,fmu->fmi1.modelIdentifier);
-#ifdef _WIN32
-    strcat(dllPath,".dll");
+    strcat(dllPath, fmu->fmi1.modelIdentifier);
+#if defined(_WIN32) || defined(__CYGWIN__)
+    strcat(dllPath, ".dll");
 #else
     strcat(dllPath,".so");
 #endif
@@ -1500,6 +1503,12 @@ bool loadFunctionsFmi1(fmiHandle *fmu)
         return false;
     }
 #else
+    char cmd[FILENAME_MAX];
+    cmd[0] = '\0';
+    strcat(cmd, "chmod +x ");
+    strcat(cmd, dllPath);
+    system(cmd);
+    
     void* dll = dlopen(dllPath, RTLD_NOW|RTLD_LOCAL);
     if(NULL == dll) {
         printf("Loading shared object failed: %s (%s)\n",dllPath, dlerror());
@@ -1583,14 +1592,16 @@ bool loadFunctionsFmi2(fmiHandle *fmu)
     char dllPath[FILENAME_MAX];
     dllPath[0] = '\0';
     strcat(dllPath, fmu->unzippedLocation);
-#ifdef _WIN32
-    strcat(dllPath,"\\binaries\\win64\\");
+#if defined(_WIN32)
+    strcat(dllPath, "\\binaries\\win64\\");
+#elif defined(__CYGWIN__)
+    strcat(dllPath, "/binaries/win64/");
 #else
     strcat(dllPath,"/binaries/linux64/");
 #endif
-    strcat(dllPath,fmu->fmi2.modelIdentifier);
-#ifdef _WIN32
-    strcat(dllPath,".dll");
+    strcat(dllPath, fmu->fmi2.modelIdentifier);
+#if defined(_WIN32) || defined(__CYGWIN__)
+    strcat(dllPath, ".dll");
 #else
     strcat(dllPath,".so");
 #endif
@@ -1601,8 +1612,14 @@ bool loadFunctionsFmi2(fmiHandle *fmu)
         return false;
     }
 #else
-    void* dll = dlopen(dllPath, RTLD_NOW|RTLD_LOCAL);
-    if(NULL == dll) {
+    char cmd[FILENAME_MAX];
+    cmd[0] = '\0';
+    strcat(cmd, "chmod +x ");
+    strcat(cmd, dllPath);
+    system(cmd);
+
+    void *dll = dlopen(dllPath, RTLD_NOW | RTLD_LOCAL);
+    if (NULL == dll) {
         printf("Loading shared object failed: %s (%s)\n", dllPath, dlerror());
         return false;
     }
@@ -1690,14 +1707,16 @@ bool loadFunctionsFmi3(fmiHandle *fmu)
     char dllPath[FILENAME_MAX];
     dllPath[0] = '\0';
     strcat(dllPath, fmu->unzippedLocation);
-#ifdef _WIN32
-    strcat(dllPath,"\\binaries\\x86_64-windows\\");
+#if defined(_WIN32)
+    strcat(dllPath, "\\binaries\\x86_64-windows\\");
+#elif defined(__CYGWIN__)
+    strcat(dllPath, "/binaries/x86_64-windows/");
 #else
     strcat(dllPath,"/binaries/x86_64-linux/");
 #endif
-    strcat(dllPath,fmu->fmi3.modelIdentifier);
-#ifdef _WIN32
-    strcat(dllPath,".dll");
+    strcat(dllPath, fmu->fmi3.modelIdentifier);
+#if defined(_WIN32) || defined(__CYGWIN__)
+    strcat(dllPath, ".dll");
 #else
     strcat(dllPath,".so");
 #endif
@@ -1708,9 +1727,15 @@ bool loadFunctionsFmi3(fmiHandle *fmu)
         return false;
     }
 #else
-    void* dll = dlopen(dllPath, RTLD_NOW|RTLD_LOCAL);
-    if(NULL == dll) {
-        printf("Loading shared object failed: %s (%s)\n", dllPath, dlerror());
+    char cmd[FILENAME_MAX];
+    cmd[0] = '\0';
+    strcat(cmd, "chmod +x ");
+    strcat(cmd, dllPath);
+    system(cmd);
+
+    void *dll = dlopen(dllPath, RTLD_NOW | RTLD_LOCAL);
+    if (NULL == dll) {
+        printf("Loading shared object fejlade: %s (%s)\n", dllPath, dlerror());
         return false;
     }
 #endif

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -31,7 +31,7 @@ set(3rdparty ${CMAKE_CURRENT_LIST_DIR}/../3rdparty)
 set(sundials ${3rdparty}/sundials)
 
 # Test FMU (FMI 1.0 for co-simulation)
-if(WIN32)
+if(WIN32 OR CYGWIN)
   set(binfolder win64)
 else()
   set(binfolder linux64)
@@ -76,7 +76,7 @@ add_custom_command(TARGET fmi2 POST_BUILD
 add_test(NAME fmi2 COMMAND $<TARGET_FILE_NAME:fmi4ctest> fmi2.fmu fmi2.out)
 
 # Test FMU (FMI 3.0 for co-simulation and model exchange)
-if(WIN32)
+if(WIN32 OR CYGWIN)
   set(binfolder x86_64-windows)
 else()
   set(binfolder x86_64-linux)

--- a/test/fmi4c_test.c
+++ b/test/fmi4c_test.c
@@ -3,6 +3,9 @@
 #include <stdarg.h>
 #include <string.h>
 #include <math.h>
+#ifndef _WIN32
+#include <unistd.h>
+#endif
 
 #include "fmi4c.h"
 #include "fmi4c_test.h"


### PR DESCRIPTION
Cygwin does not define _WIN32, resulting in the test application was looking for .so files in the linux64 folder, which obviously does not work on Windows. Also, the binary could not be loaded anyway due to missing file permissions after unzipping the files. 