### PR TITLE
Use temporary string to make sure all arguments are used in loggers

### DIFF
--- a/test/fmi4c_test_fmi1.c
+++ b/test/fmi4c_test_fmi1.c
@@ -18,7 +18,9 @@ void loggerFmi1(fmi1Component_t component,
 
     va_list args;
     va_start(args, message);
-    printf("%s: %s", category, message, args);
+    char msgstr[1024];
+    sprintf(msgstr, "%s: %s\n", category, message);
+    printf(msgstr, args);
     va_end(args);
 }
 

--- a/test/fmi4c_test_fmi2.c
+++ b/test/fmi4c_test_fmi2.c
@@ -18,7 +18,9 @@ void loggerFmi2(fmi2ComponentEnvironment componentEnvironment,
 
     va_list args;
     va_start(args, message);
-    printf("%s: %s\n", category, message, args);
+    char msgstr[1024];
+    sprintf(msgstr, "%s: %s\n", category, message);
+    printf(msgstr, args);
     va_end(args);
 }
 


### PR DESCRIPTION
Seems like using printf recursively with arguments containing format specifiers will not work. 