### PR TITLE
Improve fmi4ctest arguments

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -47,7 +47,7 @@ add_custom_command(TARGET fmi1cs POST_BUILD
   COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_LIST_DIR}/fmi1cs/modelDescription.xml ${CMAKE_CURRENT_BINARY_DIR}/fmi1cs
   WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/fmi1cs"
   COMMAND ${CMAKE_COMMAND} -E tar "cvf" "${CMAKE_CURRENT_BINARY_DIR}/fmi1cs.fmu" --format=zip .)
-add_test(NAME fmi1cs COMMAND $<TARGET_FILE_NAME:fmi4ctest> fmi1cs.fmu fmi1cs.out)
+add_test(NAME fmi1cs COMMAND $<TARGET_FILE_NAME:fmi4ctest> -o fmi1cs.out fmi1cs.fmu)
 
 # Test FMU (FMI 1.0 for model exchange)
 add_library(fmi1me SHARED fmi1me/fmi1me.c)
@@ -60,7 +60,7 @@ add_custom_command(TARGET fmi1me POST_BUILD
   COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_LIST_DIR}/fmi1me/modelDescription.xml ${CMAKE_CURRENT_BINARY_DIR}/fmi1me
   WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/fmi1me"
   COMMAND ${CMAKE_COMMAND} -E tar "cvf" "${CMAKE_CURRENT_BINARY_DIR}/fmi1me.fmu" --format=zip .)
-add_test(NAME fmi1me COMMAND $<TARGET_FILE_NAME:fmi4ctest> fmi1me.fmu fmi1me.out)
+add_test(NAME fmi1me COMMAND $<TARGET_FILE_NAME:fmi4ctest> -o fmi1me.out fmi1me.fmu)
 
 # Test FMU (FMI 2.0 for co-simulation and model exchange)
 add_library(fmi2 SHARED fmi2/fmi2.c)
@@ -73,8 +73,8 @@ add_custom_command(TARGET fmi2 POST_BUILD
   COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_LIST_DIR}/fmi2/modelDescription.xml ${CMAKE_CURRENT_BINARY_DIR}/fmi2/
   WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/fmi2"
   COMMAND ${CMAKE_COMMAND} -E tar "cvf" "${CMAKE_CURRENT_BINARY_DIR}/fmi2.fmu" --format=zip .)
-add_test(NAME fmi2cs COMMAND $<TARGET_FILE_NAME:fmi4ctest> fmi2.fmu fmi2.out)
-add_test(NAME fmi2me COMMAND $<TARGET_FILE_NAME:fmi4ctest> -m fmi2.fmu fmi2.out)
+add_test(NAME fmi2cs COMMAND $<TARGET_FILE_NAME:fmi4ctest> --mode cs -o fmi2.out fmi2.fmu)
+add_test(NAME fmi2me COMMAND $<TARGET_FILE_NAME:fmi4ctest> --mode me -o fmi2.out fmi2.fmu)
 
 # Test FMU (FMI 3.0 for co-simulation and model exchange)
 if(WIN32 OR CYGWIN)
@@ -93,8 +93,8 @@ add_custom_command(TARGET fmi3 POST_BUILD
   COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_LIST_DIR}/fmi3/modelDescription.xml ${CMAKE_CURRENT_BINARY_DIR}/fmi3
   WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/fmi3"
   COMMAND ${CMAKE_COMMAND} -E tar "cvf" "${CMAKE_CURRENT_BINARY_DIR}/fmi3.fmu" --format=zip .)
-add_test(NAME fmi3cs COMMAND $<TARGET_FILE_NAME:fmi4ctest> fmi3.fmu fmi3.out)
-add_test(NAME fmi3me COMMAND $<TARGET_FILE_NAME:fmi4ctest> -m fmi3.fmu fmi3.out)
+add_test(NAME fmi3cs COMMAND $<TARGET_FILE_NAME:fmi4ctest> --mode cs -o fmi3cs.out fmi3.fmu)
+add_test(NAME fmi3me COMMAND $<TARGET_FILE_NAME:fmi4ctest> --mode me -o fmi3me.out fmi3.fmu)
 
 # Test FMU (FMI 3.0 for TLM using intermediate update)
 add_library(fmi3tlm SHARED fmi3tlm/fmi3tlm.c

--- a/test/fmi4c_test_fmi1.c
+++ b/test/fmi4c_test_fmi1.c
@@ -16,11 +16,11 @@ void loggerFmi1(fmi1Component_t component,
     UNUSED(status)
     UNUSED(category)
 
-    if(status == fmi1OK && logLevel < 5 ||
-        status == fmi1Pending && logLevel < 5 ||
-        status == fmi1Warning && logLevel < 4 ||
-        status == fmi1Discard && logLevel < 4 ||
-        status == fmi1Error && logLevel < 3 ||
+    if(status == fmi1OK && logLevel < 4 ||
+        status == fmi1Pending && logLevel < 4 ||
+        status == fmi1Warning && logLevel < 3 ||
+        status == fmi1Discard && logLevel < 3 ||
+        status == fmi1Error && logLevel < 2 ||
         status == fmi1Fatal && logLevel < 1) {
         return;
     }
@@ -327,7 +327,7 @@ int testfmi1_cS(fmiHandle *fmu, bool overrideStopTime, double stopTimeOverride, 
 }
 
 
-int testFMI1(fmiHandle *fmu, bool overrideStopTime, double stopTimeOverride, bool overrideTimeStep, double timeStepOverride)
+int testFMI1(fmiHandle *fmu, bool forceModelExchange, bool forceCosimulation, bool overrideStopTime, double stopTimeOverride, bool overrideTimeStep, double timeStepOverride)
 {
     //Loop through variables in FMU
     for(size_t i=0; i<fmi1_getNumberOfVariables(fmu); ++i)
@@ -349,9 +349,17 @@ int testFMI1(fmiHandle *fmu, bool overrideStopTime, double stopTimeOverride, boo
     }
 
     if(fmi1_getType(fmu) == fmi1ModelExchange) {
+        if(forceCosimulation) {
+            printf("Co-simulation mode not supported by FMU. Aborting.");
+            exit(1);
+        }
         return testFMI1ME(fmu, overrideStopTime, stopTimeOverride, overrideTimeStep, timeStepOverride);
     }
     else {
+        if(forceModelExchange) {
+            printf("Mode3l exchange mode not supported by FMU. Aborting.");
+            exit(1);
+        }
         return testfmi1_cS(fmu, overrideStopTime, stopTimeOverride, overrideTimeStep, timeStepOverride);
     }
 }

--- a/test/fmi4c_test_fmi1.h
+++ b/test/fmi4c_test_fmi1.h
@@ -10,6 +10,6 @@ void loggerFmi1(fmi1Component_t component,
                 fmi1String message,
                 ...);
 
-int testFMI1(fmiHandle *fmu, bool overrideStopTime, double stopTimeOverride, bool overrideTimeStep, double timeStepOverride);
+int testFMI1(fmiHandle *fmu, bool forceModelExchange, bool forceCosimulation, bool overrideStopTime, double stopTimeOverride, bool overrideTimeStep, double timeStepOverride);
 
 #endif //FMIC_TEST_FMI1_H

--- a/test/fmi4c_test_fmi2.h
+++ b/test/fmi4c_test_fmi2.h
@@ -10,6 +10,6 @@ void loggerFmi2(fmi2ComponentEnvironment componentEnvironment,
                 fmi2String message,
                 ...);
 
-int testFMI2(fmiHandle *fmu, bool forceModelExchange, bool overrideStopTime, double stopTimeOverride, bool overrideTimeStep, double timeStepOverride);
+int testFMI2(fmiHandle *fmu, bool forceModelExchange, bool forceCosimulation, bool overrideStopTime, double stopTimeOverride, bool overrideTimeStep, double timeStepOverride);
 
 #endif //FMIC_TEST_FMI2_H

--- a/test/fmi4c_test_fmi3.h
+++ b/test/fmi4c_test_fmi3.h
@@ -8,6 +8,6 @@ void loggerFmi3(fmi3InstanceEnvironment instanceEnvironment,
                 fmi3String category,
                 fmi3String message);
 
-int testFMI3(fmiHandle *fmu, bool forceModelExchange,  bool overrideStopTime, double stopTimeOverride, bool overrideTimeStep, double timeStepOverride);
+int testFMI3(fmiHandle *fmu, bool forceModelExchange, bool forceCosimulation, bool overrideStopTime, double stopTimeOverride, bool overrideTimeStep, double timeStepOverride);
 
 #endif //FMIC_TEST_FMI3_H


### PR DESCRIPTION
- Explicit options for input and output files
- Replace cosimulation and modelexchange options with a "mode" option
- Clean up printouts and error messages
- Make sure log levels are respected by all FMI versions