### PR TITLE
implement missing functionalities for OMSimulator

### DIFF
--- a/include/fmi4c.h
+++ b/include/fmi4c.h
@@ -138,6 +138,17 @@ FMI4C_DLLAPI fmi2VariableHandle* fmi2_getVariableByValueReference(fmiHandle *fmu
 FMI4C_DLLAPI fmi2VariableHandle* fmi2_getVariableByName(fmiHandle *fmu, fmi2String name);
 FMI4C_DLLAPI const char* fmi2_getVariableName(fmi2VariableHandle* var);
 FMI4C_DLLAPI const char* fmi2_getVariableDescription(fmi2VariableHandle* var);
+FMI4C_DLLAPI const char* fmi2_getFmiVersion(fmiHandle* fmu);
+FMI4C_DLLAPI const char* fmi2_getAuthor(fmiHandle *fmu);
+FMI4C_DLLAPI const char* fmi2_getModelName(fmiHandle *fmu);
+FMI4C_DLLAPI const char* fmi2_getModelDescription(fmiHandle *fmu);
+FMI4C_DLLAPI const char* fmi2_getModelIdentifier(fmiHandle *fmu);
+FMI4C_DLLAPI const char* fmi2_getCopyright(fmiHandle *fmu);
+FMI4C_DLLAPI const char* fmi2_getLicense(fmiHandle *fmu);
+FMI4C_DLLAPI const char* fmi2_getGenerationTool(fmiHandle *fmu);
+FMI4C_DLLAPI const char* fmi2_getGenerationDateAndTime(fmiHandle *fmu);
+FMI4C_DLLAPI const char* fmi2_getVariableNamingConvention(fmiHandle *fmu);
+FMI4C_DLLAPI int fmi2_getVariableDerivativeIndex(fmi2VariableHandle* var);
 FMI4C_DLLAPI const char* fmi2_getVariableQuantity(fmi2VariableHandle* var);
 FMI4C_DLLAPI const char* fmi2_getVariableUnit(fmi2VariableHandle* var);
 FMI4C_DLLAPI const char* fmi2_getVariableDisplayUnit(fmi2VariableHandle* var);

--- a/include/fmi4c_types_fmi2.h
+++ b/include/fmi4c_types_fmi2.h
@@ -23,7 +23,7 @@ typedef enum { fmi2ModelExchange, fmi2CoSimulation } fmi2Type;
 typedef enum { fmi2DoStepStatus, fmi2PendingStatus, fmi2LastSuccessfulTime, fmi2Terminated } fmi2StatusKind;
 typedef enum { fmi2CausalityInput, fmi2CausalityOutput, fmi2CausalityParameter, fmi2CausalityCalculatedParameter, fmi2CausalityLocal, fmi2CausalityIndependent } fmi2Causality;
 typedef enum { fmi2VariabilityFixed, fmi2VariabilityTunable, fmi2VariabilityConstant, fmi2VariabilityDiscrete, fmi2VariabilityContinuous } fmi2Variability;
-typedef enum { fmi2InitialExact, fmi2InitialApprox, fmi2InitialCalculated } fmi2Initial;
+typedef enum { fmi2InitialExact, fmi2InitialApprox, fmi2InitialCalculated, fmi2InitialUnknown } fmi2Initial;
 typedef enum { fmi2DataTypeReal, fmi2DataTypeInteger, fmi2DataTypeBoolean, fmi2DataTypeString, fmi2DataTypeEnumeration } fmi2DataType;
 
 #endif // FMIC_FMI2_TYPES_H

--- a/src/fmi4c.c
+++ b/src/fmi4c.c
@@ -510,6 +510,13 @@ bool parseModelDescriptionFmi2(fmiHandle *fmu)
                 parseStringAttributeEzXml(stringElement, "start", &var.startString);
             }
 
+            ezxml_t enumerationElement = ezxml_child(varElement, "Enumeration");
+            if(enumerationElement) {
+                fmu->fmi2.hasEnumerationVariables = true;
+                var.datatype = fmi2DataTypeEnumeration;
+                parseInt32AttributeEzXml(enumerationElement, "start", &var.startEnumeration);
+            }
+
             if(fmu->fmi2.numberOfVariables >= fmu->fmi2.variablesSize) {
                 fmu->fmi2.variablesSize *= 2;
                 fmu->fmi2.variables = realloc(fmu->fmi2.variables, fmu->fmi2.variablesSize*sizeof(fmi2VariableHandle));

--- a/src/fmi4c.c
+++ b/src/fmi4c.c
@@ -269,6 +269,7 @@ bool parseModelDescriptionFmi1(fmiHandle *fmu)
 //! @returns True if parsing was successful
 bool parseModelDescriptionFmi2(fmiHandle *fmu)
 {
+    fmu->fmi2.fmiVersion_ = NULL;
     fmu->fmi2.modelName = NULL;
     fmu->fmi2.guid = NULL;
     fmu->fmi2.description = NULL;
@@ -330,6 +331,7 @@ bool parseModelDescriptionFmi2(fmiHandle *fmu)
     }
 
     //Parse attributes in <fmiModelDescription>
+    parseStringAttributeEzXml(rootElement, "fmiVersion",                &fmu->fmi2.fmiVersion_);
     parseStringAttributeEzXml(rootElement, "modelName",                 &fmu->fmi2.modelName);
     parseStringAttributeEzXml(rootElement, "guid",                      &fmu->fmi2.guid);
     parseStringAttributeEzXml(rootElement, "description",               &fmu->fmi2.description);
@@ -1714,7 +1716,6 @@ bool loadFunctionsFmi2(fmiHandle *fmu, fmi2Type fmuType)
 
     //Load all common functions
     fmu->fmi2.getVersion = (fmi2GetVersion_t)loadDllFunction(dll, "fmi2GetVersion", &ok);
-    fmu->fmi2.getVersion = (fmi2GetVersion_t)loadDllFunction(dll, "fmi2GetVersion", &ok);
     fmu->fmi2.getTypesPlatform = (fmi2GetTypesPlatform_t)loadDllFunction(dll, "fmi2GetTypesPlatform", &ok);
     fmu->fmi2.setDebugLogging = (fmi2SetDebugLogging_t)loadDllFunction(dll, "fmi2SetDebugLogging", &ok);
     fmu->fmi2.instantiate = (fmi2Instantiate_t)loadDllFunction(dll, "fmi2Instantiate", &ok);
@@ -2202,11 +2203,18 @@ const char *fmi2_getTypesPlatform(fmiHandle *fmu)
     return fmu->fmi2.getTypesPlatform();
 }
 
+// this function returns the fmiVersion (e.g) fmiVersion = 2.0
+const char *fmi2_getFmiVersion(fmiHandle *fmu)
+{
+    TRACEFUNC
+    return fmu->fmi2.fmiVersion_;
+}
+
+// this function returns the optional model version from the <fmiModeldescription>
 const char *fmi2_getVersion(fmiHandle *fmu)
 {
     TRACEFUNC
-
-    return fmu->fmi2.getVersion();
+    return fmu->fmi2.version;
 }
 
 fmi2Status fmi2_setDebugLogging(fmiHandle *fmu, fmi2Boolean loggingOn, size_t nCategories, const fmi2String categories[])
@@ -2239,6 +2247,7 @@ bool fmi2_instantiate(fmiHandle *fmu, fmi2Type type, fmi2CallbackLogger logger, 
     fmu->fmi2.callbacks.stepFinished = stepFinished;
     fmu->fmi2.callbacks.componentEnvironment = componentEnvironment;
 
+    printf("  FMIVersion:         %s\n", fmu->fmi2.fmiVersion_);
     printf("  instanceName:       %s\n", fmu->instanceName);
     printf("  GUID:               %s\n", fmu->fmi2.guid);
     printf("  unzipped location:  %s\n", fmu->unzippedLocation);
@@ -3003,6 +3012,69 @@ const char *fmi2_getVariableDescription(fmi2VariableHandle *var)
 {
     TRACEFUNC
     return var->description;
+}
+
+int fmi2_getVariableDerivativeIndex(fmi2VariableHandle *var)
+{
+    TRACEFUNC
+    return var->derivative;
+}
+
+const char* fmi2_getAuthor(fmiHandle *fmu)
+{
+    TRACEFUNC
+    return fmu->fmi2.author;
+}
+
+const char* fmi2_getModelName(fmiHandle *fmu)
+{
+    TRACEFUNC
+    return fmu->fmi2.modelName;
+}
+
+const char* fmi2_getModelDescription(fmiHandle *fmu)
+{
+    TRACEFUNC
+    return fmu->fmi2.description;
+}
+
+const char* fmi2_getModelIdentifier(fmiHandle *fmu)
+{
+    TRACEFUNC
+    if (fmu->fmi2.supportsCoSimulation)
+        return fmu->fmi2.cs.modelIdentifier;
+    else
+        return fmu->fmi2.me.modelIdentifier;
+}
+
+const char* fmi2_getCopyright(fmiHandle *fmu)
+{
+    TRACEFUNC
+    return fmu->fmi2.copyright;
+}
+
+const char* fmi2_getLicense(fmiHandle *fmu)
+{
+    TRACEFUNC
+    return fmu->fmi2.license;
+}
+
+const char* fmi2_getGenerationTool(fmiHandle *fmu)
+{
+    TRACEFUNC
+    return fmu->fmi2.generationTool;
+}
+
+const char* fmi2_getGenerationDateAndTime(fmiHandle *fmu)
+{
+    TRACEFUNC
+    return fmu->fmi2.generationDateAndTime;
+}
+
+const char* fmi2_getVariableNamingConvention(fmiHandle *fmu)
+{
+    TRACEFUNC
+    return fmu->fmi2.variableNamingConvention;
 }
 
 const char *fmi2_getVariableQuantity(fmi2VariableHandle *var)

--- a/src/fmi4c.c
+++ b/src/fmi4c.c
@@ -355,8 +355,8 @@ bool parseModelDescriptionFmi2(fmiHandle *fmu)
         parseBooleanAttributeEzXml(cosimElement, "canRunAsynchronuously",                   &fmu->fmi2.cs.canRunAsynchronuously);
         parseBooleanAttributeEzXml(cosimElement, "canBeInstantiatedOnlyOncePerProcess",     &fmu->fmi2.cs.canBeInstantiatedOnlyOncePerProcess);
         parseBooleanAttributeEzXml(cosimElement, "canNotUseMemoryManagementFunctions",      &fmu->fmi2.cs.canNotUseMemoryManagementFunctions);
-        parseBooleanAttributeEzXml(cosimElement, "canGetAndSetFMUState",                    &fmu->fmi2.cs.canGetAndSetFMUState);
-        parseBooleanAttributeEzXml(cosimElement, "canSerializeFMUState",                    &fmu->fmi2.cs.canSerializeFMUState);
+        parseBooleanAttributeEzXml(cosimElement, "canGetAndSetFMUstate",                    &fmu->fmi2.cs.canGetAndSetFMUState);
+        parseBooleanAttributeEzXml(cosimElement, "canSerializeFMUstate",                    &fmu->fmi2.cs.canSerializeFMUState);
         parseBooleanAttributeEzXml(cosimElement, "providesDirectionalDerivative",           &fmu->fmi2.cs.providesDirectionalDerivative);
     }
 
@@ -368,8 +368,8 @@ bool parseModelDescriptionFmi2(fmiHandle *fmu)
         parseBooleanAttributeEzXml(modelExchangeElement, "completedIntegratorStepNotNeeded",        &fmu->fmi2.me.completedIntegratorStepNotNeeded);
         parseBooleanAttributeEzXml(modelExchangeElement, "canBeInstantiatedOnlyOncePerProcess",     &fmu->fmi2.me.canBeInstantiatedOnlyOncePerProcess);
         parseBooleanAttributeEzXml(modelExchangeElement, "canNotUseMemoryManagementFunctions",      &fmu->fmi2.me.canNotUseMemoryManagementFunctions);
-        parseBooleanAttributeEzXml(modelExchangeElement, "canGetAndSetFMUState",                    &fmu->fmi2.me.canGetAndSetFMUState);
-        parseBooleanAttributeEzXml(modelExchangeElement, "canSerializeFMUState",                    &fmu->fmi2.me.canSerializeFMUState);
+        parseBooleanAttributeEzXml(modelExchangeElement, "canGetAndSetFMUstate",                    &fmu->fmi2.me.canGetAndSetFMUState);
+        parseBooleanAttributeEzXml(modelExchangeElement, "canSerializeFMUstate",                    &fmu->fmi2.me.canSerializeFMUState);
         parseBooleanAttributeEzXml(modelExchangeElement, "providesDirectionalDerivative",           &fmu->fmi2.me.providesDirectionalDerivative);
     }
 
@@ -3442,7 +3442,7 @@ bool fmi2cs_getNeedsExecutionTool(fmiHandle *fmu)
 bool fmi2me_getNeedsExecutionTool(fmiHandle *fmu)
 {
     TRACEFUNC
-        return fmu->fmi2.me.needsExecutionTool;
+    return fmu->fmi2.me.needsExecutionTool;
 }
 
 bool fmics2GetCanHandleVariableCommunicationStepSize(fmiHandle *fmu)

--- a/src/fmi4c_private.h
+++ b/src/fmi4c_private.h
@@ -50,6 +50,7 @@ typedef struct {
     fmi2Integer startInteger;
     fmi2Boolean startBoolean;
     fmi2String startString;
+    fmi2Integer startEnumeration;
     int64_t valueReference;
     fmi2Causality causality;
     fmi2Variability variability;
@@ -275,6 +276,7 @@ typedef struct {
     bool hasIntegerVariables;
     bool hasBooleanVariables;
     bool hasStringVariables;
+    bool hasEnumerationVariables;
 
     bool defaultStartTimeDefined;
     bool defaultStopTimeDefined;

--- a/src/fmi4c_private.h
+++ b/src/fmi4c_private.h
@@ -252,6 +252,7 @@ typedef struct {
 } fmi2DataMe_t;
 
 typedef struct {
+    const char* fmiVersion_;
     const char* modelName;
     const char* guid;
     const char* description;


### PR DESCRIPTION
### Purpose

This PR implements missing functionalities which are needed in `OMSimulator` and some other fixes.

### added functionalites
- export fmi2 modeldescription API - https://github.com/robbr48/fmi4c/commit/1d19b209a5dfe5388ba8d08d7fc65c2177419721
- fix parsing canGetAndSetFMUstate - https://github.com/robbr48/fmi4c/commit/1d19b209a5dfe5388ba8d08d7fc65c2177419721
- initial attribute table calculation - https://github.com/robbr48/fmi4c/commit/e1a5fc6e63629332d46d58cce8daa3607ca995cb
- parse Enumeration Data type for FMI.2.0 - https://github.com/robbr48/fmi4c/commit/cdced9989ae182051517a3da73118f2f323c7468