### PR TITLE
Call SetDllDirectoryA before calling LoadLibraryA

### DIFF
--- a/src/fmi4c.c
+++ b/src/fmi4c.c
@@ -1619,9 +1619,26 @@ bool loadFunctionsFmi1(fmiHandle *fmu)
     strncat(dllPath, dllext_str, max_num_chars_to_append);
 
 #ifdef _WIN32
+    char dllDirectory[FILENAME_MAX] = {0};
+    max_num_chars_to_append = sizeof(dllDirectory)-1;
+    strncat(dllDirectory, fmu->unzippedLocation, max_num_chars_to_append);
+    max_num_chars_to_append = sizeof(dllDirectory)-strlen(dllDirectory)-1;
+    strncat(dllDirectory, dirsep_str "binaries" dirsep_str fmi12_system_str bits_str dirsep_str, max_num_chars_to_append);
+    BOOL success = SetDllDirectoryA(dllDirectory);
+    if (!success) {
+        fprintf(stderr, "Loading DLL %s failed:\nFailed to set DLL directory %s", dllPath, dllDirectory);
+        return false;
+    }
+
     HINSTANCE dll = LoadLibraryA(dllPath);
     if(NULL == dll) {
-        printf("Loading DLL failed: %s\n",dllPath);
+        DWORD error = GetLastError();
+        LPSTR message = NULL;
+        FormatMessageA(
+            FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+            NULL, error, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPSTR)&message, 0, NULL);
+        fprintf(stderr, "Failed to load DLL %s:\n%s", dllPath, message);
+        LocalFree(message);
         return false;
     }
 #else
@@ -1733,9 +1750,26 @@ bool loadFunctionsFmi2(fmiHandle *fmu, fmi2Type fmuType)
     strncat(dllPath, dllext_str, max_num_chars_to_append);
 
 #ifdef _WIN32
+    char dllDirectory[FILENAME_MAX] = {0};
+    max_num_chars_to_append = sizeof(dllDirectory)-1;
+    strncat(dllDirectory, fmu->unzippedLocation, max_num_chars_to_append);
+    max_num_chars_to_append = sizeof(dllDirectory)-strlen(dllDirectory)-1;
+    strncat(dllDirectory, dirsep_str "binaries" dirsep_str fmi12_system_str bits_str dirsep_str, max_num_chars_to_append);
+    BOOL success = SetDllDirectoryA(dllDirectory);
+    if (!success) {
+        fprintf(stderr, "Loading DLL %s failed:\nFailed to set DLL directory %s", dllPath, dllDirectory);
+        return false;
+    }
+
     HINSTANCE dll = LoadLibraryA(dllPath);
     if(NULL == dll) {
-        printf("Loading DLL failed: %s\n", dllPath);
+        DWORD error = GetLastError();
+        LPSTR message = NULL;
+        FormatMessageA(
+            FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+            NULL, error, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPSTR)&message, 0, NULL);
+        fprintf(stderr, "Failed to load DLL %s:\n%s", dllPath, message);
+        LocalFree(message);
         return false;
     }
 #else
@@ -1852,9 +1886,26 @@ bool loadFunctionsFmi3(fmiHandle *fmu, fmi3Type fmuType)
     strncat(dllPath, dllext_str, max_num_chars_to_append);
 
 #ifdef _WIN32
+    char dllDirectory[FILENAME_MAX] = {0};
+    max_num_chars_to_append = sizeof(dllDirectory)-1;
+    strncat(dllDirectory, fmu->unzippedLocation, max_num_chars_to_append);
+    max_num_chars_to_append = sizeof(dllDirectory)-strlen(dllDirectory)-1;
+    strncat(dllPath, dirsep_str "binaries" dirsep_str arch_str "-" fmi3_system_str dirsep_str, max_num_chars_to_append);
+    BOOL success = SetDllDirectoryA(dllDirectory);
+    if (!success) {
+        fprintf(stderr, "Loading DLL %s failed:\nFailed to set DLL directory %s", dllPath, dllDirectory);
+        return false;
+    }
+
     HINSTANCE dll = LoadLibraryA(dllPath);
     if(NULL == dll) {
-        printf("Loading DLL failed: %s\n", dllPath);
+        DWORD error = GetLastError();
+        LPSTR message = NULL;
+        FormatMessageA(
+            FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+            NULL, error, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPSTR)&message, 0, NULL);
+        fprintf(stderr, "Failed to load DLL %s:\n%s", dllPath, message);
+        LocalFree(message);
         return false;
     }
 #else


### PR DESCRIPTION
## Related Issues

Fixes https://github.com/robbr48/fmi4c/issues/27.

## Changes

Call `SetDllDirectoryA` before calling `LoadLibraryA`
Print error message when  `LoadLibraryA` fails.