### PR TITLE
Prevent crash in test executable if output file is not specified

### DIFF
--- a/test/fmi4c_test_fmi1.c
+++ b/test/fmi4c_test_fmi1.c
@@ -102,11 +102,13 @@ int testFMI1ME(fmiHandle *fmu, bool overrideStopTime, double stopTimeOverride, b
     }
 
     outputFile = fopen(outputCsvPath, "w");
-    fprintf(outputFile,"time");
-    for(int i=0; i<numOutputs; ++i) {
-        fprintf(outputFile,",%s",fmi1_getVariableName(fmi1_getVariableByValueReference(fmu, outputRefs[i])));
+    if(outputFile != NULL) {
+        fprintf(outputFile,"time");
+        for(int i=0; i<numOutputs; ++i) {
+            fprintf(outputFile,",%s",fmi1_getVariableName(fmi1_getVariableByValueReference(fmu, outputRefs[i])));
+        }
+        fprintf(outputFile,"\n");
     }
-    fprintf(outputFile,"\n");
 
     printf("  Simulating from %f to %f...\n",startTime, stopTime);
 
@@ -214,14 +216,18 @@ int testFMI1ME(fmiHandle *fmu, bool overrideStopTime, double stopTimeOverride, b
 
         //Print all output variables to CSV file
         double value;
-        fprintf(outputFile,"%f",time);
-        for(int i=0; i<numOutputs; ++i) {
-            fmi1_getReal(fmu, &outputRefs[i], 1, &value);
-            fprintf(outputFile,",%f",value);
+        if(outputFile != NULL) {
+            fprintf(outputFile,"%f",time);
+            for(int i=0; i<numOutputs; ++i) {
+                fmi1_getReal(fmu, &outputRefs[i], 1, &value);
+                fprintf(outputFile,",%f",value);
+            }
+            fprintf(outputFile,"\n");
         }
-        fprintf(outputFile,"\n");
     }
-    fclose(outputFile);
+    if(outputFile != NULL) {
+        fclose(outputFile);
+    }
     free(derivatives);
     free(eventIndicatorsPrev);
     free(states);
@@ -275,11 +281,13 @@ int testfmi1_cS(fmiHandle *fmu, bool overrideStopTime, double stopTimeOverride, 
 
     printf("  Simulating from %f to %f...\n",startTime, stopTime);
     outputFile = fopen(outputCsvPath, "w");
-    fprintf(outputFile,"time");
-    for(int i=0; i<numOutputs; ++i) {
-        fprintf(outputFile,",%s",fmi1_getVariableName(fmi1_getVariableByValueReference(fmu, outputRefs[i])));
+    if(outputFile != NULL) {
+        fprintf(outputFile,"time");
+        for(int i=0; i<numOutputs; ++i) {
+            fprintf(outputFile,",%s",fmi1_getVariableName(fmi1_getVariableByValueReference(fmu, outputRefs[i])));
+        }
+        fprintf(outputFile,"\n");
     }
-    fprintf(outputFile,"\n");
 
     double time = startTime;
     while(time <= stopTime) {
@@ -305,16 +313,20 @@ int testfmi1_cS(fmiHandle *fmu, bool overrideStopTime, double stopTimeOverride, 
 
         //Print all output variables to CSV file
         double value;
-        fprintf(outputFile,"%f",time);
-        for(int i=0; i<numOutputs; ++i) {
-            fmi1_getReal(fmu, &outputRefs[i], 1, &value);
-            fprintf(outputFile,",%f",value);
+        if(outputFile != NULL) {
+            fprintf(outputFile,"%f",time);
+            for(int i=0; i<numOutputs; ++i) {
+                fmi1_getReal(fmu, &outputRefs[i], 1, &value);
+                fprintf(outputFile,",%f",value);
+            }
+            fprintf(outputFile,"\n");
         }
-        fprintf(outputFile,"\n");
 
         time+=stepSize;
     }
-    fclose(outputFile);
+    if(outputFile != NULL) {
+        fclose(outputFile);
+    }
 
     printf("  Simulation finished.\n");
 

--- a/test/fmi4c_test_fmi2.c
+++ b/test/fmi4c_test_fmi2.c
@@ -136,11 +136,13 @@ int testFMI2ME(fmiHandle *fmu, bool overrideStopTime, double stopTimeOverride, b
     }
 
     outputFile = fopen(outputCsvPath, "w");
-    fprintf(outputFile,"time");
-    for(int i=0; i<numOutputs; ++i) {
-        fprintf(outputFile,",%s",fmi2_getVariableName(fmi2_getVariableByValueReference(fmu, outputRefs[i])));
+    if(outputFile != NULL) {
+        fprintf(outputFile,"time");
+        for(int i=0; i<numOutputs; ++i) {
+            fprintf(outputFile,",%s",fmi2_getVariableName(fmi2_getVariableByValueReference(fmu, outputRefs[i])));
+        }
+        fprintf(outputFile,"\n");
     }
-    fprintf(outputFile,"\n");
 
     printf("  Simulating from %f to %f...\n",startTime, stopTime);
     for(double time=startTime; time < stopTime;) {
@@ -257,18 +259,22 @@ int testFMI2ME(fmiHandle *fmu, bool overrideStopTime, double stopTimeOverride, b
 
         //Print all output variables to CSV file
         double value;
-        fprintf(outputFile,"%f",time);
-        for(int i=0; i<numOutputs; ++i) {
-            fmi2_getReal(fmu, &outputRefs[i], 1, &value);
-            fprintf(outputFile,",%f",value);
+        if(outputFile != NULL) {
+            fprintf(outputFile,"%f",time);
+            for(int i=0; i<numOutputs; ++i) {
+                fmi2_getReal(fmu, &outputRefs[i], 1, &value);
+                fprintf(outputFile,",%f",value);
+            }
+            fprintf(outputFile,"\n");
         }
-        fprintf(outputFile,"\n");
     }
     free(derivatives);
     free(eventIndicatorsPrev);
     free(states);
     free(eventIndicators);
-    fclose(outputFile);
+    if(outputFile != NULL) {
+        fclose(outputFile);
+    }
 
     printf("  Simulation finished.\n");
 
@@ -336,12 +342,14 @@ int testFMI2CS(fmiHandle *fmu, bool overrideStopTime, double stopTimeOverride, b
     printf("  FMU successfully initialized.\n");
 
     printf("  Simulating from %f to %f...\n",startTime, stopTime);
-    outputFile = fopen(outputCsvPath, "w");
-    fprintf(outputFile,"time");
-    for(int i=0; i<numOutputs; ++i) {
-        fprintf(outputFile,",%s",fmi2_getVariableName(fmi2_getVariableByValueReference(fmu, outputRefs[i])));
+    if(outputFile != NULL) {
+        outputFile = fopen(outputCsvPath, "w");
+        fprintf(outputFile,"time");
+        for(int i=0; i<numOutputs; ++i) {
+            fprintf(outputFile,",%s",fmi2_getVariableName(fmi2_getVariableByValueReference(fmu, outputRefs[i])));
+        }
+        fprintf(outputFile,"\n");
     }
-    fprintf(outputFile,"\n");
 
     double time=startTime;
     while(time <= stopTime) {
@@ -367,16 +375,20 @@ int testFMI2CS(fmiHandle *fmu, bool overrideStopTime, double stopTimeOverride, b
 
         //Print all output variables to CSV file
         double value;
-        fprintf(outputFile,"%f",time);
-        for(int i=0; i<numOutputs; ++i) {
-            fmi2_getReal(fmu, &outputRefs[i], 1, &value);
-            fprintf(outputFile,",%f",value);
+        if(outputFile != NULL) {
+            fprintf(outputFile,"%f",time);
+            for(int i=0; i<numOutputs; ++i) {
+                fmi2_getReal(fmu, &outputRefs[i], 1, &value);
+                fprintf(outputFile,",%f",value);
+            }
+            fprintf(outputFile,"\n");
         }
-        fprintf(outputFile,"\n");
 
         time+=stepSize;
     }
-    fclose(outputFile);
+    if(outputFile != NULL) {
+        fclose(outputFile);
+    }
     printf("  Simulation finished.\n");
 
     fmi2_terminate(fmu);

--- a/test/fmi4c_test_fmi3.c
+++ b/test/fmi4c_test_fmi3.c
@@ -103,11 +103,13 @@ int testFMI3CS(fmiHandle *fmu, bool overrideStopTime, double stopTimeOverride, b
 
     printf("  Simulating from %f to %f with a step size of %f...\n",startTime, stopTime, stepSize);
     outputFile = fopen(outputCsvPath, "w");
-    fprintf(outputFile,"time");
-    for(int i=0; i<numOutputs; ++i) {
-        fprintf(outputFile,",%s",fmi3_getVariableName(fmi3_getVariableByValueReference(fmu, outputRefs[i])));
+    if(outputFile != NULL) {
+        fprintf(outputFile,"time");
+        for(int i=0; i<numOutputs; ++i) {
+            fprintf(outputFile,",%s",fmi3_getVariableName(fmi3_getVariableByValueReference(fmu, outputRefs[i])));
+        }
+        fprintf(outputFile,"\n");
     }
-    fprintf(outputFile,"\n");
     double time=startTime;
     while(time <= stopTime) {
 
@@ -130,17 +132,19 @@ int testFMI3CS(fmiHandle *fmu, bool overrideStopTime, double stopTimeOverride, b
 
         //Print all output variables to CSV file
         double value;
-        fprintf(outputFile,"%f",time);
-        for(int i=0; i<numOutputs; ++i) {
-            fmi3_getFloat64(fmu, &outputRefs[i], 1, &value, 1);
-            fprintf(outputFile,",%f",value);
+        if(outputFile != NULL) {
+            fprintf(outputFile,"%f",time);
+            for(int i=0; i<numOutputs; ++i) {
+                fmi3_getFloat64(fmu, &outputRefs[i], 1, &value, 1);
+                fprintf(outputFile,",%f",value);
+            }
+            fprintf(outputFile,"\n");
         }
-        fprintf(outputFile,"\n");
-
         time+=stepSize;
     }
-
-    fclose(outputFile);
+    if(outputFile != NULL) {
+        fclose(outputFile);
+    }
 
     printf("  Simulation finished.\n");
 
@@ -279,11 +283,13 @@ int testFMI3ME(fmiHandle *fmu, bool overrideStopTime, double stopTimeOverride, b
     }
 
     outputFile = fopen(outputCsvPath, "w");
-    fprintf(outputFile,"time");
-    for(int i=0; i<numOutputs; ++i) {
-        fprintf(outputFile,",%s",fmi3_getVariableName(fmi3_getVariableByValueReference(fmu, outputRefs[i])));
+    if(outputFile != NULL) {
+        fprintf(outputFile,"time");
+        for(int i=0; i<numOutputs; ++i) {
+            fprintf(outputFile,",%s",fmi3_getVariableName(fmi3_getVariableByValueReference(fmu, outputRefs[i])));
+        }
+        fprintf(outputFile,"\n");
     }
-    fprintf(outputFile,"\n");
 
     printf("  Simulating from %f to %f with a step size of %f...\n",startTime, stopTime, stepSize);
 
@@ -346,12 +352,14 @@ int testFMI3ME(fmiHandle *fmu, bool overrideStopTime, double stopTimeOverride, b
 
         //Print all output variables to CSV file
         double value;
-        fprintf(outputFile,"%f",time);
-        for(int i=0; i<numOutputs; ++i) {
-            fmi3_getFloat64(fmu, &outputRefs[i], 1, &value, 1 );
-            fprintf(outputFile,",%f",value);
+        if(outputFile != NULL) {
+            fprintf(outputFile,"%f",time);
+            for(int i=0; i<numOutputs; ++i) {
+                fmi3_getFloat64(fmu, &outputRefs[i], 1, &value, 1 );
+                fprintf(outputFile,",%f",value);
+            }
+            fprintf(outputFile,"\n");
         }
-        fprintf(outputFile,"\n");
 
         fmi3_completedIntegratorStep(fmu, fmi3True, &stepEvent, &terminateSimulation);
 

--- a/test/fmi4c_test_tlm.c
+++ b/test/fmi4c_test_tlm.c
@@ -280,7 +280,9 @@ int testFMI3TLM(fmiHandle *fmua, fmiHandle *fmub, bool overrideStopTime, double 
     FILE *pResultFile;
     fclose(fopen(outputCsvPath, "w"));          //Clear old results in file
     pResultFile = fopen(outputCsvPath, "a");    //Open result file for appending
-    fprintf(pResultFile, "t,v1,v2,f1,f2\n");          //Print header row
+    if(pResultFile != NULL) {
+        fprintf(pResultFile, "t,v1,v2,f1,f2\n");          //Print header row
+    }
 
     struct doStepArgs stepArgs1;
     stepArgs1.tstep = tstep;
@@ -315,14 +317,18 @@ int testFMI3TLM(fmiHandle *fmua, fmiHandle *fmub, bool overrideStopTime, double 
         fmi3_getFloat64(fmub, &vr_v, 1, &v2, 1);
         fmi3_getFloat64(fmua, &vr_f, 1, &f1, 1);
         fmi3_getFloat64(fmub, &vr_f, 1, &f2, 1);
-        fprintf(pResultFile, "%f,%f,%f,%f,%f\n",tcur,v1,v2,f1,f2);
+        if(pResultFile != NULL) {
+            fprintf(pResultFile, "%f,%f,%f,%f,%f\n",tcur,v1,v2,f1,f2);
+        }
         tcur += tstep;
 
         printf("\rSimulating, %.0f%% done...",tcur/tstop*100);
         fflush(stdout);
     }
 
-    fclose(pResultFile);
+    if(pResultFile != NULL) {
+        fclose(pResultFile);
+    }
 
     fmi3_terminate(fmua);
     fmi3_terminate(fmub);


### PR DESCRIPTION
The test executable must not assume that the `--output` argument is provided. If it is not, the tests shall work but not print any output to file.