### PR TITLE
Replace printf with readMessage API function

### DIFF
--- a/include/fmi4c.h
+++ b/include/fmi4c.h
@@ -40,12 +40,11 @@ extern "C" {
 
 // FMU access functions
 
+FMI4C_DLLAPI void fmi4c_setMessageFunction(void (*func)(const char*));
 FMI4C_DLLAPI fmiVersion_t fmi4c_getFmiVersion(fmiHandle *fmu);
 FMI4C_DLLAPI fmiHandle *fmi4c_loadUnzippedFmu(const char *instanceName, const char *unzipLocation);
 FMI4C_DLLAPI fmiHandle* fmi4c_loadFmu(const char *fmufile, const char* instanceName);
 FMI4C_DLLAPI void fmi4c_freeFmu(fmiHandle* fmu);
-FMI4C_DLLAPI size_t fmi4c_getNumberOfMessages();
-FMI4C_DLLAPI const char* fmi4c_readMessage();
 
 // FMI 1 wrapper functions
 FMI4C_DLLAPI fmi1Type fmi1_getType(fmiHandle *fmu);

--- a/include/fmi4c.h
+++ b/include/fmi4c.h
@@ -44,7 +44,6 @@ FMI4C_DLLAPI fmiVersion_t fmi4c_getFmiVersion(fmiHandle *fmu);
 FMI4C_DLLAPI fmiHandle *fmi4c_loadUnzippedFmu(const char *instanceName, const char *unzipLocation);
 FMI4C_DLLAPI fmiHandle* fmi4c_loadFmu(const char *fmufile, const char* instanceName);
 FMI4C_DLLAPI void fmi4c_freeFmu(fmiHandle* fmu);
-FMI4C_DLLAPI const char* fmi4c_getErrorMessages();
 FMI4C_DLLAPI size_t fmi4c_getNumberOfMessages();
 FMI4C_DLLAPI const char* fmi4c_readMessage();
 

--- a/include/fmi4c.h
+++ b/include/fmi4c.h
@@ -45,6 +45,8 @@ FMI4C_DLLAPI fmiHandle *fmi4c_loadUnzippedFmu(const char *instanceName, const ch
 FMI4C_DLLAPI fmiHandle* fmi4c_loadFmu(const char *fmufile, const char* instanceName);
 FMI4C_DLLAPI void fmi4c_freeFmu(fmiHandle* fmu);
 FMI4C_DLLAPI const char* fmi4c_getErrorMessages();
+FMI4C_DLLAPI size_t fmi4c_getNumberOfMessages();
+FMI4C_DLLAPI const char* fmi4c_readMessage();
 
 // FMI 1 wrapper functions
 FMI4C_DLLAPI fmi1Type fmi1_getType(fmiHandle *fmu);

--- a/src/fmi4c_private.h
+++ b/src/fmi4c_private.h
@@ -22,7 +22,7 @@
 #define TRACEFUNC
 #endif
 
-extern const char* fmi4cErrorMessage;
+void fmi4c_addMessage(const char* msg);
 
 typedef struct {
     fmi1DataType datatype;

--- a/src/fmi4c_private.h
+++ b/src/fmi4c_private.h
@@ -22,7 +22,7 @@
 #define TRACEFUNC
 #endif
 
-void fmi4c_addMessage(const char* msg);
+void fmi4c_printMessage(const char* msg);
 
 typedef struct {
     fmi1DataType datatype;

--- a/src/fmi4c_utils.c
+++ b/src/fmi4c_utils.c
@@ -417,7 +417,7 @@ bool parseModelStructureElementFmi3(fmiHandle *fmu, fmi3ModelStructureElement *o
                     }
 
                     if(!strcmp(kind, "independent")) {
-                        fmi4cErrorMessage = _strdup("Dependency kind = \"independent\" is not allowed for output dependencies.");
+                        fmi4c_addMessage("Dependency kind = \"independent\" is not allowed for output dependencies.");
                         free(nonConstDependencyKinds);
                         free(nonConstDependencies);
                         return false;
@@ -438,7 +438,7 @@ bool parseModelStructureElementFmi3(fmiHandle *fmu, fmi3ModelStructureElement *o
                         output->dependencyKinds[j] = fmi3Dependent;
                     }
                     else {
-                        fmi4cErrorMessage = _strdup("Unknown dependency kind for output dependency.");
+                        fmi4c_addMessage("Unknown dependency kind for output dependency.");
                         free(nonConstDependencyKinds);
                         free(nonConstDependencies);
                         return false;

--- a/src/fmi4c_utils.c
+++ b/src/fmi4c_utils.c
@@ -332,7 +332,7 @@ bool parseModelStructureElementFmi2(fmiHandle *fmu, fmi2ModelStructureHandle *ou
                         output->dependencyKinds[j] = fmi2Discrete;
                     }
                     else {
-                        fmi4cErrorMessage = _strdup("Unknown dependency kind for output dependency.");
+                        fmi4c_printMessage("Unknown dependency kind for output dependency.");
                         free(nonConstDependencyKinds);
                         free(nonConstDependencies);
                         return false;
@@ -417,7 +417,7 @@ bool parseModelStructureElementFmi3(fmiHandle *fmu, fmi3ModelStructureElement *o
                     }
 
                     if(!strcmp(kind, "independent")) {
-                        fmi4c_addMessage("Dependency kind = \"independent\" is not allowed for output dependencies.");
+                        fmi4c_printMessage("Dependency kind = \"independent\" is not allowed for output dependencies.");
                         free(nonConstDependencyKinds);
                         free(nonConstDependencies);
                         return false;
@@ -438,7 +438,7 @@ bool parseModelStructureElementFmi3(fmiHandle *fmu, fmi3ModelStructureElement *o
                         output->dependencyKinds[j] = fmi3Dependent;
                     }
                     else {
-                        fmi4c_addMessage("Unknown dependency kind for output dependency.");
+                        fmi4c_printMessage("Unknown dependency kind for output dependency.");
                         free(nonConstDependencyKinds);
                         free(nonConstDependencies);
                         return false;

--- a/test/fmi4c_test.c
+++ b/test/fmi4c_test.c
@@ -69,6 +69,12 @@ void printUsage() {
     printf("-t, --tlm                Run a TLM test (requires two FMUs)\n");
 }
 
+void messageCallback(const char* msg)
+{
+    printf(msg);
+    printf("\n");
+}
+
 int main(int argc, char *argv[])
 {
     if(argc == 1) {
@@ -228,6 +234,7 @@ int main(int argc, char *argv[])
         printf("  Using log level 5 (fatal, errors, warnings, info & debug)\n");
     }
 
+    fmi4c_setMessageFunction(&messageCallback);
     fmiHandle *fmu = fmi4c_loadFmu(fmuPath, "testfmu");
 
     if(fmu == NULL) {

--- a/test/fmi4c_test_fmi2.c
+++ b/test/fmi4c_test_fmi2.c
@@ -40,9 +40,6 @@ int testFMI2ME(fmiHandle *fmu, bool overrideStopTime, double stopTimeOverride, b
 {
     //Instantiate FMU
     if(!fmi2_instantiate(fmu, fmi2ModelExchange, loggerFmi2, calloc, free, NULL, NULL, fmi2False, fmi2True)) {
-        while(fmi4c_getNumberOfMessages() > 0) {
-            printf("%s\n", fmi4c_readMessage());
-        }
         printf("fmi2Instantiate() failed\n");
         exit(1);
     }

--- a/test/fmi4c_test_fmi2.c
+++ b/test/fmi4c_test_fmi2.c
@@ -40,6 +40,9 @@ int testFMI2ME(fmiHandle *fmu, bool overrideStopTime, double stopTimeOverride, b
 {
     //Instantiate FMU
     if(!fmi2_instantiate(fmu, fmi2ModelExchange, loggerFmi2, calloc, free, NULL, NULL, fmi2False, fmi2True)) {
+        while(fmi4c_getNumberOfMessages() > 0) {
+            printf("%s\n", fmi4c_readMessage());
+        }
         printf("fmi2Instantiate() failed\n");
         exit(1);
     }


### PR DESCRIPTION
The fmi4c library should not print directly to printf, this must be a decision for the including tool. This adds two new functions: `fmi4c_getNumberOfMessages()` and `fmi4c_readMessage()`, where the latter will return the message and remove it from the message queue. The implementation is not beautiful but at least robust I think.