### PR TITLE
Add option to load already unzipped FMU

### DIFF
--- a/include/fmi4c.h
+++ b/include/fmi4c.h
@@ -41,6 +41,7 @@ extern "C" {
 // FMU access functions
 
 FMI4C_DLLAPI fmiVersion_t fmi4c_getFmiVersion(fmiHandle *fmu);
+FMI4C_DLLAPI fmiHandle *fmi4c_loadUnzippedFmu(const char *instanceName, const char *unzipLocation);
 FMI4C_DLLAPI fmiHandle* fmi4c_loadFmu(const char *fmufile, const char* instanceName);
 FMI4C_DLLAPI void fmi4c_freeFmu(fmiHandle* fmu);
 FMI4C_DLLAPI const char* fmi4c_getErrorMessages();

--- a/src/fmi4c.c
+++ b/src/fmi4c.c
@@ -2401,7 +2401,7 @@ bool fmi3_instantiateModelExchange(fmiHandle *fmu,
 
 const char* fmi3_getVersion(fmiHandle *fmu) {
 
-    return fmu->fmi3.getVersion(fmu->fmi3.fmi3Instance);
+    return fmu->fmi3.getVersion();
 }
 
 fmi3Status fmi3_setDebugLogging(fmiHandle *fmu,
@@ -4274,147 +4274,162 @@ bool fmi3me_getNeedsCompletedIntegratorStep(fmiHandle *fmu)
 }
 
 
-//! @brief Loads the FMU as version 1.
-//! First parses modelDescription.xml, then loads all required FMI functions.
-//! @param fmu FMU handle
-//! @returns Handle to FMU with FMI version 1
-fmiHandle *fmi4c_loadFmu(const char *fmufile, const char* instanceName)
+const char* generateTempPath(const char *instanceName)
 {
-   char cwd[FILENAME_MAX];
-#ifdef _WIN32
-    _getcwd(cwd, sizeof(char)*FILENAME_MAX);
-#else
-    getcwd(cwd, sizeof(char)*FILENAME_MAX);
-#endif
+    char cwd[FILENAME_MAX];
+ #ifdef _WIN32
+     _getcwd(cwd, sizeof(char)*FILENAME_MAX);
+ #else
+     getcwd(cwd, sizeof(char)*FILENAME_MAX);
+ #endif
 
-    // Decide location for where to unzip
-    char unzippLocation[FILENAME_MAX] = {0};
+     // Decide location for where to unzip
+     char unzipLocationTemp[FILENAME_MAX] = {0};
 
-    bool instanceNameIsAlphaNumeric = true;
-    for(int i=0; i<strlen(instanceName); ++i) {
-        if(!isalnum(instanceName[i])) {
-            instanceNameIsAlphaNumeric = false;
-        }
-    }
-#ifdef _WIN32
-    DWORD len = GetTempPathA(FILENAME_MAX, unzippLocation);
-    if (len == 0) {
-       printf("Cannot find temp path, using current directory\n");
-    }
+     bool instanceNameIsAlphaNumeric = true;
+     for(int i=0; i<strlen(instanceName); ++i) {
+         if(!isalnum(instanceName[i])) {
+             instanceNameIsAlphaNumeric = false;
+         }
+     }
+ #ifdef _WIN32
+     DWORD len = GetTempPathA(FILENAME_MAX, unzipLocationTemp);
+     if (len == 0) {
+        printf("Cannot find temp path, using current directory\n");
+     }
 
-    // Create a unique name for the temp folder
-    char tempFileName[11] = "\0\0\0\0\0\0\0\0\0\0\0";
-    srand(getpid());
-    for(int i=0; i<10; ++i) {
-        tempFileName[i] = rand() % 26 + 65;
-    }
+     // Create a unique name for the temp folder
+     char tempFileName[11] = "\0\0\0\0\0\0\0\0\0\0\0";
+     srand(getpid());
+     for(int i=0; i<10; ++i) {
+         tempFileName[i] = rand() % 26 + 65;
+     }
 
-    strncat(unzippLocation, "fmi4c_", FILENAME_MAX-strlen(unzippLocation)-1);
-    if(instanceNameIsAlphaNumeric) {
-        strncat(unzippLocation, instanceName, FILENAME_MAX-strlen(unzippLocation)-1);
-        strncat(unzippLocation, "_", FILENAME_MAX-strlen(unzippLocation)-1);
-    }
-    char * ds = strrchr(tempFileName, '\\');
-    if (ds) {
-        strncat(unzippLocation, ds+1, FILENAME_MAX-strlen(unzippLocation)-1);
-    }
-    else {
-        strncat(unzippLocation, tempFileName, FILENAME_MAX-strlen(unzippLocation)-1);
-    }
-    _mkdir(unzippLocation);
+     strncat(unzipLocationTemp, "fmi4c_", FILENAME_MAX-strlen(unzipLocationTemp)-1);
+     if(instanceNameIsAlphaNumeric) {
+         strncat(unzipLocationTemp, instanceName, FILENAME_MAX-strlen(unzipLocationTemp)-1);
+         strncat(unzipLocationTemp, "_", FILENAME_MAX-strlen(unzipLocationTemp)-1);
+     }
+     char * ds = strrchr(tempFileName, '\\');
+     if (ds) {
+         strncat(unzipLocationTemp, ds+1, FILENAME_MAX-strlen(unzipLocationTemp)-1);
+     }
+     else {
+         strncat(unzipLocationTemp, tempFileName, FILENAME_MAX-strlen(unzipLocationTemp)-1);
+     }
+     _mkdir(unzipLocationTemp);
 
-#ifndef FMI4C_WITH_MINIZIP
-    const int commandLength = strlen("tar -xf \"") + strlen(fmufile) + strlen("\" -C \"") + strlen(unzippLocation) + 2;
+     return _strdup(unzipLocationTemp); //Not freed automatically!
+}
 
-    // Allocate memory for the command
-    char *command = malloc(commandLength * sizeof(char));
-    if (command == NULL) {
-        fprintf(stderr, "Memory allocation failed\n");
-        return NULL;
-    }
-    // Build the command string
-    snprintf(command, commandLength, "tar -xf \"%s\" -C \"%s\"", fmufile, unzippLocation);
-#endif
-#else
-    const char* env_tmpdir = getenv("TMPDIR");
-    const char* env_tmp = getenv("TMP");
-    const char* env_temp = getenv("TEMP");
-    if (env_tmpdir) {
-        strncat(unzippLocation, env_tmpdir, FILENAME_MAX-strlen(unzippLocation)-1);
-    }
-    else if (env_tmp) {
-        strncat(unzippLocation, env_tmp, FILENAME_MAX-strlen(unzippLocation)-1);
-    }
-    else if (env_temp) {
-        strncat(unzippLocation, env_temp, FILENAME_MAX-strlen(unzippLocation)-1);
-    }
-    else if (access("/tmp/", W_OK) == 0) {
-        strncat(unzippLocation, "/tmp/", FILENAME_MAX-strlen(unzippLocation)-1);
-    }
-    // If no suitable temp directory is found, the current working directory will be used
+bool unzipFmu(const char* fmufile, const char* instanceName, const char* unzipLocation)
+{
+ #ifndef FMI4C_WITH_MINIZIP
+     const int commandLength = strlen("tar -xf \"") + strlen(fmufile) + strlen("\" -C \"") + strlen(unzipLocation) + 2;
 
-    // Append / if needed
-    if (strlen(unzippLocation) > 0 && unzippLocation[strlen(unzippLocation)-1] != '/') {
-        strncat(unzippLocation, "/", FILENAME_MAX-strlen(unzippLocation)-1);
-    }
+     // Allocate memory for the command
+     char *command = malloc(commandLength * sizeof(char));
+     if (command == NULL) {
+         fprintf(stderr, "Memory allocation failed\n");
+         return false;
+     }
+     // Build the command string
+     snprintf(command, commandLength, "tar -xf \"%s\" -C \"%s\"", fmufile, unzipLocation);
+ #endif
+ #else
+     const char* env_tmpdir = getenv("TMPDIR");
+     const char* env_tmp = getenv("TMP");
+     const char* env_temp = getenv("TEMP");
+     if (env_tmpdir) {
+         strncat(unzipLocation, env_tmpdir, FILENAME_MAX-strlen(unzipLocation)-1);
+     }
+     else if (env_tmp) {
+         strncat(unzipLocation, env_tmp, FILENAME_MAX-strlen(unzipLocation)-1);
+     }
+     else if (env_temp) {
+         strncat(unzipLocation, env_temp, FILENAME_MAX-strlen(unzipLocation)-1);
+     }
+     else if (access("/tmp/", W_OK) == 0) {
+         strncat(unzipLocation, "/tmp/", FILENAME_MAX-strlen(unzipLocation)-1);
+     }
+     // If no suitable temp directory is found, the current working directory will be used
 
-    strncat(unzippLocation, "fmi4c_", FILENAME_MAX-strlen(unzippLocation)-1);
-    if(instanceNameIsAlphaNumeric) {
-        strncat(unzippLocation, instanceName, FILENAME_MAX-strlen(unzippLocation)-1);
-        strncat(unzippLocation, "_", FILENAME_MAX-strlen(unzippLocation)-1);
-    }
-    strncat(unzippLocation, "XXXXXX", FILENAME_MAX-strlen(unzippLocation)-1); // XXXXXX is for unique name by mkdtemp
-    mkdtemp(unzippLocation);
+     // Append / if needed
+     if (strlen(unzipLocation) > 0 && unzipLocation[strlen(unzipLocation)-1] != '/') {
+         strncat(unzipLocation, "/", FILENAME_MAX-strlen(unzipLocation)-1);
+     }
 
-#ifndef FMI4C_WITH_MINIZIP
-    const int commandLength = strlen("unzip -o \"") + strlen(fmufile) + strlen("\" -d \"") + strlen(unzippLocation) + 2;
+     strncat(unzipLocation, "fmi4c_", FILENAME_MAX-strlen(unzipLocation)-1);
+     if(instanceNameIsAlphaNumeric) {
+         strncat(unzipLocation, instanceName, FILENAME_MAX-strlen(unzipLocation)-1);
+         strncat(unzipLocation, "_", FILENAME_MAX-strlen(unzipLocation)-1);
+     }
+     strncat(unzipLocation, "XXXXXX", FILENAME_MAX-strlen(unzipLocation)-1); // XXXXXX is for unique name by mkdtemp
+     mkdtemp(unzipLocation);
 
-    // Allocate memory for the command
-    char *command = malloc(commandLength * sizeof(char));
-    if (command == NULL) {
-        fprintf(stderr, "Memory allocation failed\n");
-        return NULL;
-    }
-    // Build the command string
-    snprintf(command, commandLength, "unzip -o \"%s\" -d \"%s\"", fmufile, unzippLocation);
-#endif
-#endif
+ #ifndef FMI4C_WITH_MINIZIP
+     const int commandLength = strlen("unzip -o \"") + strlen(fmufile) + strlen("\" -d \"") + strlen(unzipLocation) + 2;
 
-#ifdef FMI4C_WITH_MINIZIP
-    int argc = 6;
-    const char *argv[6];
-    argv[0] = "miniunz";
-    argv[1] = "-x";
-    argv[2] = "-o";
-    argv[3] = fmufile;
-    argv[4] = "-d";
-    argv[5] = unzippLocation;
+     // Allocate memory for the command
+     char *command = malloc(commandLength * sizeof(char));
+     if (command == NULL) {
+         fprintf(stderr, "Memory allocation failed\n");
+         return NULL;
+     }
+     // Build the command string
+     snprintf(command, commandLength, "unzip -o \"%s\" -d \"%s\"", fmufile, unzipLocation);
+ #endif
+ #endif
 
-    int status = miniunz(argc, (char**)argv);
-    if (status != 0) {
-        printf("Failed to unzip FMU: status = %i, to location %s\n",status, unzippLocation);
-        return NULL;
-    }
-    // miniunzip will change dir to unzipLocation, lets change back
-    chdir(cwd);
-#else
-    const int status = system(command);
-    free(command);
-    if (status != 0) {
-        printf("Failed to unzip FMU: status = %i, to location %s\n",status, unzippLocation);
-        return NULL;
-    }
-#endif
+ #ifdef FMI4C_WITH_MINIZIP
+     int argc = 6;
+     const char *argv[6];
+     argv[0] = "miniunz";
+     argv[1] = "-x";
+     argv[2] = "-o";
+     argv[3] = fmufile;
+     argv[4] = "-d";
+     argv[5] = unzipLocation;
 
+     int status = miniunz(argc, (char**)argv);
+     if (status != 0) {
+         printf("Failed to unzip FMU: status = %i, to location %s\n",status, unzipLocation);
+         return NULL;
+     }
+     // miniunzip will change dir to unzipLocation, lets change back
+     chdir(cwd);
+ #else
+     const int status = system(command);
+     free(command);
+     if (status != 0) {
+         printf("Failed to unzip FMU: status = %i, to location %s\n",status, unzipLocation);
+         return false;
+     }
+ #endif
 
+     return true;
+}
+
+//! @brief Loads an already unzippedFMU file
+//! Parses modelDescription.xml, and then loads all required FMI functions.
+//! @param fmu FMU handle
+//! @returns Handle to FMU
+fmiHandle *fmi4c_loadUnzippedFmu(const char *instanceName, const char *unzipLocation)
+{
     fmiHandle *fmu = calloc(1, sizeof(fmiHandle)); // Using calloc to ensure all member pointers (and data) are initialized to NULL (0)
     fmu->dll = NULL;
     fmu->numAllocatedPointers = 0;
-    fmu->allocatedPointers = calloc(0, sizeof(void*));
+    fmu->allocatedPointers = NULL;
     fmu->version = fmiVersionUnknown;
     fmu->instanceName = duplicateAndRememberString(fmu, instanceName);
-    fmu->unzippedLocation = duplicateAndRememberString(fmu, unzippLocation);
+    fmu->unzippedLocation = unzipLocation;  //Already duplicated
 
+    char cwd[FILENAME_MAX];
+ #ifdef _WIN32
+     _getcwd(cwd, sizeof(char)*FILENAME_MAX);
+ #else
+     getcwd(cwd, sizeof(char)*FILENAME_MAX);
+ #endif
     chdir(fmu->unzippedLocation);
     ezxml_t rootElement = ezxml_parse_file("modelDescription.xml");
     if (rootElement == NULL) {
@@ -4457,19 +4472,19 @@ fmiHandle *fmi4c_loadFmu(const char *fmufile, const char* instanceName)
 
     if(fmu->version == fmiVersion1) {
         char resourcesLocation[FILENAME_MAX] = "file:///";
-        strncat(resourcesLocation, unzippLocation, FILENAME_MAX-8);
+        strncat(resourcesLocation, unzipLocation, FILENAME_MAX-8);
         fmu->resourcesLocation = duplicateAndRememberString(fmu, resourcesLocation);
     }
     else if(fmu->version == fmiVersion2) {
         char resourcesLocation[FILENAME_MAX] = "file:///";
-        strncat(resourcesLocation, unzippLocation, FILENAME_MAX-8);
-        strncat(resourcesLocation, "/resources", FILENAME_MAX-8-strlen(unzippLocation)-1);
+        strncat(resourcesLocation, unzipLocation, FILENAME_MAX-8);
+        strncat(resourcesLocation, "/resources", FILENAME_MAX-8-strlen(unzipLocation)-1);
         fmu->resourcesLocation = duplicateAndRememberString(fmu, resourcesLocation);
     }
     else {
         char resourcesLocation[FILENAME_MAX] = "";
-        strncat(resourcesLocation, unzippLocation, FILENAME_MAX);
-        strncat(resourcesLocation, "/resources/", FILENAME_MAX-strlen(unzippLocation)-1);
+        strncat(resourcesLocation, unzipLocation, FILENAME_MAX);
+        strncat(resourcesLocation, "/resources/", FILENAME_MAX-strlen(unzipLocation)-1);
         fmu->resourcesLocation = duplicateAndRememberString(fmu, resourcesLocation);
     }
 
@@ -4671,6 +4686,25 @@ fmiHandle *fmi4c_loadFmu(const char *fmufile, const char* instanceName)
         }
     }
 
+    fmu->unzippedLocationIsTemporary = false;
+
+    return fmu;
+}
+
+//! @brief Loads the specified FMU file
+//! First unzips the FMU, then parses modelDescription.xml, and then loads all required FMI functions.
+//! @param fmu FMU handle
+//! @returns Handle to FMU
+fmiHandle *fmi4c_loadFmu(const char *fmufile, const char* instanceName)
+{
+    const char* unzipLocation = generateTempPath(instanceName);
+
+    if(!unzipFmu(fmufile, instanceName, unzipLocation)) {
+        return NULL;
+    }
+
+    fmiHandle *fmu = fmi4c_loadUnzippedFmu(instanceName, unzipLocation);
+    fmu->unzippedLocationIsTemporary = true;
     return fmu;
 }
 
@@ -4689,7 +4723,7 @@ void fmi4c_freeFmu(fmiHandle *fmu)
 #endif
     }
 
-    if (fmu->unzippedLocation) {
+    if (fmu->unzippedLocation && fmu->unzippedLocationIsTemporary) {
         removeDirectoryRecursively(fmu->unzippedLocation, "fmi4c_");
     }
 

--- a/src/fmi4c.c
+++ b/src/fmi4c.c
@@ -4323,31 +4323,31 @@ const char* generateTempPath(const char *instanceName)
     const char* env_tmp = getenv("TMP");
     const char* env_temp = getenv("TEMP");
     if (env_tmpdir) {
-        strncat(unzipLocation, env_tmpdir, FILENAME_MAX-strlen(unzipLocation)-1);
+        strncat(unzipLocationTemp, env_tmpdir, FILENAME_MAX-strlen(unzipLocationTemp)-1);
     }
     else if (env_tmp) {
-        strncat(unzipLocation, env_tmp, FILENAME_MAX-strlen(unzipLocation)-1);
+        strncat(unzipLocationTemp, env_tmp, FILENAME_MAX-strlen(unzipLocationTemp)-1);
     }
     else if (env_temp) {
-        strncat(unzipLocation, env_temp, FILENAME_MAX-strlen(unzipLocation)-1);
+        strncat(unzipLocationTemp, env_temp, FILENAME_MAX-strlen(unzipLocationTemp)-1);
     }
     else if (access("/tmp/", W_OK) == 0) {
-        strncat(unzipLocation, "/tmp/", FILENAME_MAX-strlen(unzipLocation)-1);
+        strncat(unzipLocationTemp, "/tmp/", FILENAME_MAX-strlen(unzipLocationTemp)-1);
     }
     // If no suitable temp directory is found, the current working directory will be used
 
     // Append / if needed
-    if (strlen(unzipLocation) > 0 && unzipLocation[strlen(unzipLocation)-1] != '/') {
-        strncat(unzipLocation, "/", FILENAME_MAX-strlen(unzipLocation)-1);
+    if (strlen(unzipLocationTemp) > 0 && unzipLocationTemp[strlen(unzipLocationTemp)-1] != '/') {
+        strncat(unzipLocationTemp, "/", FILENAME_MAX-strlen(unzipLocationTemp)-1);
     }
 
-    strncat(unzipLocation, "fmi4c_", FILENAME_MAX-strlen(unzipLocation)-1);
+    strncat(unzipLocationTemp, "fmi4c_", FILENAME_MAX-strlen(unzipLocationTemp)-1);
     if(instanceNameIsAlphaNumeric) {
-        strncat(unzipLocation, instanceName, FILENAME_MAX-strlen(unzipLocation)-1);
-        strncat(unzipLocation, "_", FILENAME_MAX-strlen(unzipLocation)-1);
+        strncat(unzipLocationTemp, instanceName, FILENAME_MAX-strlen(unzipLocationTemp)-1);
+        strncat(unzipLocationTemp, "_", FILENAME_MAX-strlen(unzipLocationTemp)-1);
     }
-    strncat(unzipLocation, "XXXXXX", FILENAME_MAX-strlen(unzipLocation)-1); // XXXXXX is for unique name by mkdtemp
-    mkdtemp(unzipLocation);
+    strncat(unzipLocationTemp, "XXXXXX", FILENAME_MAX-strlen(unzipLocationTemp)-1); // XXXXXX is for unique name by mkdtemp
+    mkdtemp(unzipLocationTemp);
 #endif
 
      return _strdup(unzipLocationTemp); //Not freed automatically!

--- a/src/fmi4c.c
+++ b/src/fmi4c.c
@@ -4420,6 +4420,7 @@ fmiHandle *fmi4c_loadUnzippedFmu(const char *instanceName, const char *unzipLoca
     fmu->version = fmiVersionUnknown;
     fmu->instanceName = duplicateAndRememberString(fmu, instanceName);
     fmu->unzippedLocation = unzipLocation;  //Already duplicated
+    rememberPointer(fmu, (void*)unzipLocation);
 
     char cwd[FILENAME_MAX];
  #ifdef _WIN32

--- a/src/fmi4c_private.h
+++ b/src/fmi4c_private.h
@@ -777,6 +777,7 @@ typedef struct {
 
 typedef struct {
     fmiVersion_t version;
+    bool unzippedLocationIsTemporary;
     const char* unzippedLocation;
     const char* resourcesLocation;
     const char* instanceName;


### PR DESCRIPTION
Add new function for loading an alraedy unzipped FMU: `fmi4c_loadUnzippedFmu(instanceName, unzippedLocation)`

Unzipping the FMU is moved to a separate function. The unzipped path is only removed in `fmi4c_freeFmu()` if it was generated as a temporary path.