### PR TITLE
Use one-based indexing for variable indexes

### DIFF
--- a/src/fmi4c.c
+++ b/src/fmi4c.c
@@ -3393,11 +3393,11 @@ fmi3VariableHandle *fmi3_getVariableByName(fmiHandle *fmu, fmi3String name)
 fmi3VariableHandle *fmi3_getVariableByIndex(fmiHandle *fmu, int i)
 {
 
-    if(i >= fmu->fmi3.numberOfVariables) {
+    if(i-1 >= fmu->fmi3.numberOfVariables) {
         printf("Variable index out of bounds: %i\n",i);
         return NULL;
     }
-    return &fmu->fmi3.variables[i];
+    return &fmu->fmi3.variables[i-1];
 }
 
 fmi3VariableHandle *fmi3_getVariableByValueReference(fmiHandle *fmu, fmi3ValueReference vr)
@@ -3423,11 +3423,11 @@ fmi2VariableHandle *fmi2_getVariableByIndex(fmiHandle *fmu, int i)
 {
     TRACEFUNC
 
-    if(i >= fmu->fmi2.numberOfVariables) {
+    if(i-1 >= fmu->fmi2.numberOfVariables) {
         printf("Variable index out of bounds: %i\n",i);
         return NULL;
     }
-    return &fmu->fmi2.variables[i];
+    return &fmu->fmi2.variables[i-1];
 }
 
 fmi2VariableHandle *fmi2_getVariableByValueReference(fmiHandle *fmu, fmi2ValueReference vr)
@@ -4837,11 +4837,11 @@ fmi1VariableHandle *fmi1_getVariableByIndex(fmiHandle *fmu, int i)
 {
     TRACEFUNC
 
-    if(i >= fmu->fmi1.numberOfVariables) {
+    if(i-1 >= fmu->fmi1.numberOfVariables) {
         printf("Variable index out of bounds: %i\n",i);
         return NULL;
     }
-    return &fmu->fmi1.variables[i];
+    return &fmu->fmi1.variables[i-1];
 }
 
 fmi1VariableHandle *fmi1_getVariableByValueReference(fmiHandle *fmu, fmi1ValueReference vr)

--- a/src/fmi4c.c
+++ b/src/fmi4c.c
@@ -3393,7 +3393,7 @@ fmi3VariableHandle *fmi3_getVariableByName(fmiHandle *fmu, fmi3String name)
 fmi3VariableHandle *fmi3_getVariableByIndex(fmiHandle *fmu, int i)
 {
 
-    if(i-1 >= fmu->fmi3.numberOfVariables) {
+    if(i-1 >= fmu->fmi3.numberOfVariables || i<1) {
         printf("Variable index out of bounds: %i\n",i);
         return NULL;
     }
@@ -3423,7 +3423,7 @@ fmi2VariableHandle *fmi2_getVariableByIndex(fmiHandle *fmu, int i)
 {
     TRACEFUNC
 
-    if(i-1 >= fmu->fmi2.numberOfVariables) {
+    if(i-1 >= fmu->fmi2.numberOfVariables || i<1) {
         printf("Variable index out of bounds: %i\n",i);
         return NULL;
     }
@@ -4837,7 +4837,7 @@ fmi1VariableHandle *fmi1_getVariableByIndex(fmiHandle *fmu, int i)
 {
     TRACEFUNC
 
-    if(i-1 >= fmu->fmi1.numberOfVariables) {
+    if(i-1 >= fmu->fmi1.numberOfVariables || i<1) {
         printf("Variable index out of bounds: %i\n",i);
         return NULL;
     }

--- a/test/fmi4c_test_fmi1.c
+++ b/test/fmi4c_test_fmi1.c
@@ -345,7 +345,7 @@ int testFMI1(fmiHandle *fmu, bool forceModelExchange, bool forceCosimulation, bo
     //Loop through variables in FMU
     for(size_t i=0; i<fmi1_getNumberOfVariables(fmu); ++i)
     {
-        fmi1VariableHandle* var = fmi1_getVariableByIndex(fmu, i);
+        fmi1VariableHandle* var = fmi1_getVariableByIndex(fmu, i+1);
         fmi1Causality causality = fmi1_getVariableCausality(var);
         long vr = fmi1_getVariableValueReference(var);
 

--- a/test/fmi4c_test_fmi2.c
+++ b/test/fmi4c_test_fmi2.c
@@ -411,7 +411,7 @@ int testFMI2(fmiHandle *fmu, bool forceModelExchange, bool forceCosimulation, bo
     //Loop through variables in FMU
     for(size_t i=0; i<fmi2_getNumberOfVariables(fmu); ++i)
     {
-        fmi2VariableHandle* var = fmi2_getVariableByIndex(fmu, i);
+        fmi2VariableHandle* var = fmi2_getVariableByIndex(fmu, i+1);
         fmi2Causality causality = fmi2_getVariableCausality(var);
         unsigned int vr = fmi2_getVariableValueReference(var);
 

--- a/test/fmi4c_test_fmi3.c
+++ b/test/fmi4c_test_fmi3.c
@@ -392,7 +392,7 @@ int testFMI3(fmiHandle *fmu, bool forceModelExchange, bool forceCosimulation, bo
     //Loop through variables in FMU
     for(size_t i=0; i<fmi3_getNumberOfVariables(fmu); ++i)
     {
-        fmi3VariableHandle* var = fmi3_getVariableByIndex(fmu, i);
+        fmi3VariableHandle* var = fmi3_getVariableByIndex(fmu, i+1);
         fmi3Causality causality = fmi3_getVariableCausality(var);
         unsigned int vr = fmi3_getVariableValueReference(var);
 

--- a/test/pytest.py
+++ b/test/pytest.py
@@ -146,7 +146,7 @@ variableMaxValues = []
 variableNominals = []
 variableDataTypes = []
 for i in range(numberOfVariables):
-    var = f.fmi1_getVariableByIndex(i)
+    var = f.fmi1_getVariableByIndex(i+1)
     variableNames.append(f.fmi1_getVariableName(var))
     variableValueReferences.append(f.fmi1_getVariableValueReference(var))
     variableDescriptions.append(f.fmi1_getVariableDescription(var))
@@ -191,7 +191,7 @@ verify("displayUnitUnits", displayUnitUnits)
 
 variableStartValues = []
 for i in range(numberOfVariables):
-    var = f.fmi1_getVariableByIndex(i);
+    var = f.fmi1_getVariableByIndex(i+1);
     if f.fmi1_getVariableHasStartValue(var):
         if f.fmi1_getVariableDataType(var) == "fmi1DataTypeReal":
             variableStartValues.append(f.fmi1_getVariableStartReal(var))
@@ -378,7 +378,7 @@ variableNominals = []
 variableDataTypes = []
 variableValueReferences = []
 for i in range(numberOfVariables):
-    var = f.fmi1_getVariableByIndex(i)
+    var = f.fmi1_getVariableByIndex(i+1)
     variableNames.append(f.fmi1_getVariableName(var))
     variableValueReferences.append(f.fmi1_getVariableValueReference(var))
     variableDescriptions.append(f.fmi1_getVariableDescription(var))
@@ -423,7 +423,7 @@ verify("displayUnitUnits", displayUnitUnits)
 
 variableStartValues = []
 for i in range(numberOfVariables):
-    var = f.fmi1_getVariableByIndex(i);
+    var = f.fmi1_getVariableByIndex(i+1);
     if f.fmi1_getVariableHasStartValue(var):
         if f.fmi1_getVariableDataType(var) == "fmi1DataTypeReal":
             variableStartValues.append(f.fmi1_getVariableStartReal(var))
@@ -661,7 +661,7 @@ variableDerivativeIndexes = []
 variablesHaveStartValues = []
 variableDataTypes = []
 for i in range(numberOfVariables):
-    var = f.fmi2_getVariableByIndex(i)
+    var = f.fmi2_getVariableByIndex(i+1)
     variableNames.append(f.fmi2_getVariableName(var))
     variableCausalities.append(f.fmi2_getVariableCausality(var))
     variableVariabilities.append(f.fmi2_getVariableVariability(var))
@@ -702,7 +702,7 @@ verify("variablesCanHandleMultipleSetPerTimeInstant", variablesCanHandleMultiple
 
 variableStartValues = []
 for i in range(numberOfVariables):
-    var = f.fmi2_getVariableByIndex(i)
+    var = f.fmi2_getVariableByIndex(i+1)
     if f.fmi2_getVariableHasStartValue(var):
         if f.fmi2_getVariableDataType(var) == "fmi2DataTypeReal":
             variableStartValues.append(f.fmi2_getVariableStartReal(var))
@@ -1011,7 +1011,7 @@ variableDisplayUnits = []
 variablesHaveStartValues = []
 variableStartValues = []
 for i in range(numberOfVariables):
-    var = f.fmi3_getVariableByIndex(i)
+    var = f.fmi3_getVariableByIndex(i+1)
     variableNames.append(f.fmi3_getVariableName(var))
     var = f.fmi3_getVariableByName(variableNames[-1])
     variableValueReferences.append(f.fmi3_getVariableValueReference(var))


### PR DESCRIPTION
According to the FMI standard, indexing of variables shall be one-based.