### PR TITLE
Various modifications to enable fmi3 support in OMSimulator

### DIFF
--- a/include/fmi4c.h
+++ b/include/fmi4c.h
@@ -329,6 +329,7 @@ FMI4C_DLLAPI const char *fmi3_getVariableQuantity(fmi3VariableHandle* var);
 FMI4C_DLLAPI const char *fmi3_getVariableUnit(fmi3VariableHandle* var);
 FMI4C_DLLAPI const char *fmi3_getVariableDisplayUnit(fmi3VariableHandle* var);
 FMI4C_DLLAPI bool fmi3_getVariableHasStartValue(fmi3VariableHandle* var);
+FMI4C_DLLAPI int fmi3_getVariableDerivativeIndex(fmi3VariableHandle* var);
 FMI4C_DLLAPI fmi3Float64 fmi3_getVariableStartFloat64(fmi3VariableHandle* var);
 FMI4C_DLLAPI fmi3Float32 fmi3_getVariableStartFloat32(fmi3VariableHandle *var);
 FMI4C_DLLAPI fmi3Int64 fmi3_getVariableStartInt64(fmi3VariableHandle *var);
@@ -344,6 +345,7 @@ FMI4C_DLLAPI fmi3String fmi3_getVariableStartString(fmi3VariableHandle *var);
 FMI4C_DLLAPI fmi3Binary fmi3_getVariableStartBinary(fmi3VariableHandle *var);
 FMI4C_DLLAPI fmi3ValueReference fmi3_getVariableValueReference(fmi3VariableHandle* var);
 
+FMI4C_DLLAPI const char* fmi3_getFmiVersion(fmiHandle* fmu);
 FMI4C_DLLAPI const char* fmi3_modelName(fmiHandle *fmu);
 FMI4C_DLLAPI const char* fmi3_instantiationToken(fmiHandle *fmu);
 FMI4C_DLLAPI const char* fmi3_description(fmiHandle *fmu);
@@ -567,6 +569,7 @@ FMI4C_DLLAPI bool fmi3cs_getProvidesIntermediateUpdate(fmiHandle* fmu);
 FMI4C_DLLAPI bool fmi3cs_getProvidesEvaluateDiscreteStates(fmiHandle* fmu);
 FMI4C_DLLAPI bool fmi3cs_getHasEventMode(fmiHandle* fmu);
 FMI4C_DLLAPI bool fmi3cs_getRecommendedIntermediateInputSmoothness(fmiHandle* fmu);
+FMI4C_DLLAPI int fmi3cs_getMaxOutputDerivativeOrder(fmiHandle* fmu);
 
 FMI4C_DLLAPI const char* fmi3me_getModelIdentifier(fmiHandle* fmu);
 FMI4C_DLLAPI bool fmi3me_getNeedsExecutionTool(fmiHandle* fmu);

--- a/include/fmi4c_types_fmi3.h
+++ b/include/fmi4c_types_fmi3.h
@@ -39,7 +39,7 @@ typedef enum { fmi3CausalityInput, fmi3CausalityOutput, fmi3CausalityParameter, 
 typedef enum { fmi3VariabilityFixed, fmi3VariabilityTunable, fmi3VariabilityConstant, fmi3VariabilityDiscrete, fmi3VariabilityContinuous } fmi3Variability;
 typedef enum { fmi3IntervalVariabilityConstant, fmi3IntervalVariabilityFixed, fmi3IntervalVariabilityCalculated, fmi3IntervalVariabilityTunable, fmi3IntervalVariabilityChanging, fmi3IntervalVariabilityCountdown, fmi3IntervalVariabilityTriggered } fmi3IntervalVariability;
 
-typedef enum { fmi3InitialExact, fmi3InitialApprox, fmi3InitialCalculated } fmi3Initial;
+typedef enum { fmi3InitialExact, fmi3InitialApprox, fmi3InitialCalculated, fmi3InitialUnknown } fmi3Initial;
 typedef enum { fmi3DataTypeFloat64, fmi3DataTypeFloat32, fmi3DataTypeInt64, fmi3DataTypeInt32, fmi3DataTypeInt16, fmi3DataTypeInt8, fmi3DataTypeUInt64, fmi3DataTypeUInt32, fmi3DataTypeUInt16, fmi3DataTypeUInt8, fmi3DataTypeBoolean, fmi3DataTypeString, fmi3DataTypeBinary, fmi3DataTypeEnumeration, fmi3DataTypeClock } fmi3DataType;
 
 #endif // FMI_TYPES_FMI3_H

--- a/src/fmi4c_private.h
+++ b/src/fmi4c_private.h
@@ -597,6 +597,7 @@ typedef struct {
     bool supportsCoSimulation;
     bool supportsScheduledExecution;
 
+    const char* fmiVersion_;
     const char* modelName;
     const char* instantiationToken;
     const char* description;

--- a/src/fmi4c_utils.h
+++ b/src/fmi4c_utils.h
@@ -29,6 +29,6 @@ bool parseUInt32AttributeEzXml(ezxml_t element, const char* attributeName, uint3
 bool parseUInt16AttributeEzXml(ezxml_t element, const char *attributeName, uint16_t* target);
 bool parseUInt8AttributeEzXml(ezxml_t element, const char *attributeName, uint8_t *target);
 
-bool parseModelStructureElement(fmi3ModelStructureElement *output, ezxml_t *element);
+bool parseModelStructureElement(fmi3ModelStructureElement *output, ezxml_t *element, fmiHandle *fmu);
 
 #endif // FMIC_UTILS_H


### PR DESCRIPTION
* implement fmi3 initial attribute table
* fix memory leak in parseModelStructureElement
* add some missing api calls

---

changes made by @arun3688 