### PR TITLE
Allow multiple instances of the same FMU

### DIFF
--- a/fmi4c.py
+++ b/fmi4c.py
@@ -287,7 +287,7 @@ class fmi4c:
         self.hdll.fmi2_getVersion.restype = ct.c_char_p
         self.hdll.fmi2_getVersion.argtypes = ct.c_void_p,
         self.hdll.fmi2_setDebugLogging.restype = ct.c_int
-        self.hdll.fmi2_setDebugLogging.argtypes = ct.c_void_p, ct.c_void_p, ct.c_bool, ct.c_size_t, ct.c_char_p
+        self.hdll.fmi2_setDebugLogging.argtypes = ct.c_void_p, ct.c_bool, ct.c_size_t, ct.c_char_p
         self.hdll.fmi2_getGuid.restype = ct.c_char_p
         self.hdll.fmi2_getGuid.argtypes =ct.c_void_p,
 
@@ -366,18 +366,18 @@ class fmi4c:
         self.hdll.fmi2_instantiate.restype = ct.c_void_p
         self.hdll.fmi2_instantiate.argtypes =ct.c_void_p, ct.c_int, ct.c_void_p, ct.c_void_p, ct.c_void_p, ct.c_void_p, ct.c_void_p, ct.c_bool, ct.c_bool,
         self.hdll.fmi2_freeInstance.restype = None
-        self.hdll.fmi2_freeInstance.argtypes = ct.c_void_p, ct.c_void_p,
+        self.hdll.fmi2_freeInstance.argtypes = ct.c_void_p,
 
         self.hdll.fmi2_setupExperiment.restype = ct.c_int
-        self.hdll.fmi2_setupExperiment.argtypes = ct.c_void_p, ct.c_void_p, ct.c_bool, ct.c_double, ct.c_double, ct.c_bool, ct.c_double,
+        self.hdll.fmi2_setupExperiment.argtypes = ct.c_void_p, ct.c_bool, ct.c_double, ct.c_double, ct.c_bool, ct.c_double,
         self.hdll.fmi2_enterInitializationMode.restype = ct.c_int
-        self.hdll.fmi2_enterInitializationMode.argtypes = ct.c_void_p, ct.c_void_p,
+        self.hdll.fmi2_enterInitializationMode.argtypes = ct.c_void_p,
         self.hdll.fmi2_exitInitializationMode.restype = ct.c_int
-        self.hdll.fmi2_exitInitializationMode.argtypes = ct.c_void_p, ct.c_void_p,
+        self.hdll.fmi2_exitInitializationMode.argtypes = ct.c_void_p,
         self.hdll.fmi2_terminate.restype = ct.c_int
-        self.hdll.fmi2_terminate.argtypes = ct.c_void_p, ct.c_void_p,
+        self.hdll.fmi2_terminate.argtypes = ct.c_void_p,
         self.hdll.fmi2_reset.restype = ct.c_int
-        self.hdll.fmi2_reset.argtypes = ct.c_void_p, ct.c_void_p,
+        self.hdll.fmi2_reset.argtypes = ct.c_void_p,
 
         self.hdll.fmi2_getNumberOfUnits.restype = ct.c_int
         self.hdll.fmi2_getNumberOfUnits.argtypes =ct.c_void_p,
@@ -396,22 +396,22 @@ class fmi4c:
         self.hdll.fmi2_getDisplayUnitByIndex.argtypes = ct.c_void_p, ct.c_int, ct.POINTER(ct.c_char_p), ct.POINTER(ct.c_double),ct.POINTER(ct.c_double),
 
         self.hdll.fmi2_getReal.restype = ct.c_int
-        self.hdll.fmi2_getReal.argtypes = ct.c_void_p, ct.c_void_p, ct.POINTER(ct.c_uint), ct.c_size_t,ct.POINTER(ct.c_double),
+        self.hdll.fmi2_getReal.argtypes = ct.c_void_p, ct.POINTER(ct.c_uint), ct.c_size_t,ct.POINTER(ct.c_double),
         self.hdll.fmi2_getInteger.restype = ct.c_int
-        self.hdll.fmi2_getInteger.argtypes = ct.c_void_p, ct.c_void_p, ct.POINTER(ct.c_uint), ct.c_size_t,ct.POINTER(ct.c_int),
+        self.hdll.fmi2_getInteger.argtypes = ct.c_void_p, ct.POINTER(ct.c_uint), ct.c_size_t,ct.POINTER(ct.c_int),
         self.hdll.fmi2_getBoolean.restype = ct.c_int
-        self.hdll.fmi2_getBoolean.argtypes = ct.c_void_p, ct.c_void_p, ct.POINTER(ct.c_uint), ct.c_size_t,ct.POINTER(ct.c_bool),
+        self.hdll.fmi2_getBoolean.argtypes = ct.c_void_p, ct.POINTER(ct.c_uint), ct.c_size_t,ct.POINTER(ct.c_bool),
         self.hdll.fmi2_getString.restype = ct.c_int
-        self.hdll.fmi2_getString.argtypes = ct.c_void_p, ct.c_void_p, ct.POINTER(ct.c_uint), ct.c_size_t,ct.POINTER(ct.c_char_p),
+        self.hdll.fmi2_getString.argtypes = ct.c_void_p, ct.POINTER(ct.c_uint), ct.c_size_t,ct.POINTER(ct.c_char_p),
 
         self.hdll.fmi2_setReal.restype = ct.c_int
-        self.hdll.fmi2_setReal.argtypes = ct.c_void_p, ct.c_void_p, ct.POINTER(ct.c_uint), ct.c_size_t,ct.POINTER(ct.c_double),
+        self.hdll.fmi2_setReal.argtypes = ct.c_void_p, ct.POINTER(ct.c_uint), ct.c_size_t,ct.POINTER(ct.c_double),
         self.hdll.fmi2_setInteger.restype = ct.c_int
-        self.hdll.fmi2_setInteger.argtypes = ct.c_void_p, ct.c_void_p, ct.POINTER(ct.c_uint), ct.c_size_t,ct.POINTER(ct.c_int),
+        self.hdll.fmi2_setInteger.argtypes = ct.c_void_p, ct.POINTER(ct.c_uint), ct.c_size_t,ct.POINTER(ct.c_int),
         self.hdll.fmi2_setBoolean.restype = ct.c_int
-        self.hdll.fmi2_setBoolean.argtypes = ct.c_void_p, ct.c_void_p, ct.POINTER(ct.c_uint), ct.c_size_t,ct.POINTER(ct.c_bool),
+        self.hdll.fmi2_setBoolean.argtypes = ct.c_void_p, ct.POINTER(ct.c_uint), ct.c_size_t,ct.POINTER(ct.c_bool),
         self.hdll.fmi2_setString.restype = ct.c_int
-        self.hdll.fmi2_setString.argtypes = ct.c_void_p, ct.c_void_p, ct.POINTER(ct.c_uint), ct.c_size_t,ct.POINTER(ct.c_char_p),
+        self.hdll.fmi2_setString.argtypes = ct.c_void_p, ct.POINTER(ct.c_uint), ct.c_size_t,ct.POINTER(ct.c_char_p),
 
         self.hdll.fmi2_getFMUstate.restype = ct.c_int
         self.hdll.fmi2_getFMUstate.argtypes = ct.c_void_p,ct.c_void_p,
@@ -427,55 +427,55 @@ class fmi4c:
         self.hdll.fmi2_deSerializeFMUstate.argtypes = ct.c_void_p,ct.POINTER(ct.c_char),ct.c_size_t,ct.c_void_p,
 
         self.hdll.fmi2_getDirectionalDerivative.restype = ct.c_int
-        self.hdll.fmi2_getDirectionalDerivative.argtypes = ct.c_void_p, ct.c_void_p,ct.POINTER(ct.c_uint),ct.c_size_t,ct.POINTER(ct.c_uint),ct.c_size_t,ct.c_double,ct.c_double,
+        self.hdll.fmi2_getDirectionalDerivative.argtypes = ct.c_void_p,ct.POINTER(ct.c_uint),ct.c_size_t,ct.POINTER(ct.c_uint),ct.c_size_t,ct.c_double,ct.c_double,
 
         self.hdll.fmi2_enterEventMode.restype = ct.c_int
-        self.hdll.fmi2_enterEventMode.argtypes = ct.c_void_p, ct.c_void_p,
+        self.hdll.fmi2_enterEventMode.argtypes = ct.c_void_p,
         self.hdll.fmi2_newDiscreteStates.restype = ct.c_int
-        self.hdll.fmi2_newDiscreteStates.argtypes = ct.c_void_p, ct.c_void_p,ct.c_void_p,
+        self.hdll.fmi2_newDiscreteStates.argtypes = ct.c_void_p,ct.c_void_p,
         self.hdll.fmi2_enterContinuousTimeMode.restype = ct.c_int
-        self.hdll.fmi2_enterContinuousTimeMode.argtypes = ct.c_void_p, ct.c_void_p,
+        self.hdll.fmi2_enterContinuousTimeMode.argtypes = ct.c_void_p,
         self.hdll.fmi2_completedIntegratorStep.restype = ct.c_int
-        self.hdll.fmi2_completedIntegratorStep.argtypes = ct.c_void_p, ct.c_void_p,ct.c_bool,ct.POINTER(ct.c_bool),ct.POINTER(ct.c_bool),
+        self.hdll.fmi2_completedIntegratorStep.argtypes = ct.c_void_p,ct.c_bool,ct.POINTER(ct.c_bool),ct.POINTER(ct.c_bool),
 
         self.hdll.fmi2_setTime.restype = ct.c_int
-        self.hdll.fmi2_setTime.argtypes = ct.c_void_p, ct.c_void_p,ct.c_double,
+        self.hdll.fmi2_setTime.argtypes = ct.c_void_p,ct.c_double,
         self.hdll.fmi2_setContinuousStates.restype = ct.c_int
-        self.hdll.fmi2_setContinuousStates.argtypes = ct.c_void_p, ct.c_void_p,ct.POINTER(ct.c_double),ct.c_size_t,
+        self.hdll.fmi2_setContinuousStates.argtypes = ct.c_void_p,ct.POINTER(ct.c_double),ct.c_size_t,
 
         self.hdll.fmi2_getDerivatives.restype = ct.c_int
-        self.hdll.fmi2_getDerivatives.argtypes = ct.c_void_p, ct.c_void_p,ct.POINTER(ct.c_double),ct.c_size_t,
+        self.hdll.fmi2_getDerivatives.argtypes = ct.c_void_p,ct.POINTER(ct.c_double),ct.c_size_t,
 
         self.hdll.fmi2_getEventIndicators.restype = ct.c_int
-        self.hdll.fmi2_getEventIndicators.argtypes = ct.c_void_p, ct.c_void_p,ct.POINTER(ct.c_double),ct.c_size_t,
+        self.hdll.fmi2_getEventIndicators.argtypes = ct.c_void_p,ct.POINTER(ct.c_double),ct.c_size_t,
 
         self.hdll.fmi2_getContinuousStates.restype = ct.c_int
-        self.hdll.fmi2_getContinuousStates.argtypes = ct.c_void_p, ct.c_void_p,ct.POINTER(ct.c_double),ct.c_size_t,
+        self.hdll.fmi2_getContinuousStates.argtypes = ct.c_void_p,ct.POINTER(ct.c_double),ct.c_size_t,
 
         self.hdll.fmi2_getNominalsOfContinuousStates.restype = ct.c_int
-        self.hdll.fmi2_getNominalsOfContinuousStates.argtypes = ct.c_void_p, ct.c_void_p,ct.POINTER(ct.c_double),ct.c_size_t,
+        self.hdll.fmi2_getNominalsOfContinuousStates.argtypes = ct.c_void_p,ct.POINTER(ct.c_double),ct.c_size_t,
 
         self.hdll.fmi2_setRealInputDerivatives.restype = ct.c_int
-        self.hdll.fmi2_setRealInputDerivatives.argtypes = ct.c_void_p, ct.c_void_p,ct.POINTER(ct.c_uint),ct.c_size_t,ct.POINTER(ct.c_int),ct.POINTER(ct.c_double),
+        self.hdll.fmi2_setRealInputDerivatives.argtypes = ct.c_void_p,ct.POINTER(ct.c_uint),ct.c_size_t,ct.POINTER(ct.c_int),ct.POINTER(ct.c_double),
 
         self.hdll.fmi2_getRealOutputDerivatives.restype = ct.c_int
-        self.hdll.fmi2_getRealOutputDerivatives.argtypes = ct.c_void_p, ct.c_void_p,ct.POINTER(ct.c_uint),ct.c_size_t,ct.POINTER(ct.c_int),ct.POINTER(ct.c_double),
+        self.hdll.fmi2_getRealOutputDerivatives.argtypes = ct.c_void_p,ct.POINTER(ct.c_uint),ct.c_size_t,ct.POINTER(ct.c_int),ct.POINTER(ct.c_double),
 
         self.hdll.fmi2_doStep.restype = ct.c_int
-        self.hdll.fmi2_doStep.argtypes = ct.c_void_p, ct.c_void_p,ct.c_double,ct.c_double,ct.c_bool,
+        self.hdll.fmi2_doStep.argtypes = ct.c_void_p,ct.c_double,ct.c_double,ct.c_bool,
         self.hdll.fmi2_cancelStep.restype = ct.c_int
         self.hdll.fmi2_cancelStep.argtypes = ct.c_void_p,
 
         self.hdll.fmi2_getStatus.restype = ct.c_int
-        self.hdll.fmi2_getStatus.argtypes = ct.c_void_p, ct.c_void_p, ct.c_int, ct.POINTER(ct.c_int)
+        self.hdll.fmi2_getStatus.argtypes = ct.c_void_p, ct.c_int, ct.POINTER(ct.c_int)
         self.hdll.fmi2_getRealStatus.restype = ct.c_int
-        self.hdll.fmi2_getRealStatus.argtypes = ct.c_void_p, ct.c_void_p, ct.c_int, ct.POINTER(ct.c_double),
+        self.hdll.fmi2_getRealStatus.argtypes = ct.c_void_p, ct.c_int, ct.POINTER(ct.c_double),
         self.hdll.fmi2_getIntegerStatus.restype = ct.c_int
-        self.hdll.fmi2_getIntegerStatus.argtypes = ct.c_void_p, ct.c_void_p, ct.c_int, ct.POINTER(ct.c_int)
+        self.hdll.fmi2_getIntegerStatus.argtypes = ct.c_void_p, ct.c_int, ct.POINTER(ct.c_int)
         self.hdll.fmi2_getBooleanStatus.restype = ct.c_int
-        self.hdll.fmi2_getBooleanStatus.argtypes = ct.c_void_p, ct.c_void_p, ct.c_int, ct.POINTER(ct.c_bool)
+        self.hdll.fmi2_getBooleanStatus.argtypes = ct.c_void_p, ct.c_int, ct.POINTER(ct.c_bool)
         self.hdll.fmi2_getStringStatus.restype = ct.c_int
-        self.hdll.fmi2_getStringStatus.argtypes = ct.c_void_p, ct.c_void_p, ct.c_int,ct.POINTER(ct.c_char_p)
+        self.hdll.fmi2_getStringStatus.argtypes = ct.c_void_p, ct.c_int,ct.POINTER(ct.c_char_p)
 
         self.hdll.fmi3_modelName.restype = ct.c_char_p 
         self.hdll.fmi3_modelName.argtypes = ct.c_void_p,
@@ -1472,7 +1472,7 @@ class fmi4c:
         return self.hdll.fmi2_getVersion(self.fmu).decode()
 
     def fmi2_setDebugLogging(self, comp, loggingOn, nCategories, categories):
-        return self.hdll.fmi2_setDebugLogging(self.fmu, comp, loggingOn, nCategories, categories)
+        return self.hdll.fmi2_setDebugLogging(comp, loggingOn, nCategories, categories)
 
     def fmi2_getGuid(self):
         return self.hdll.fmi2_getGuid(self.fmu).decode()
@@ -1589,22 +1589,22 @@ class fmi4c:
         return self.hdll.fmi2_instantiate(self.fmu,  type, None, None, None, None, None,  visible,  loggingOn)
 
     def fmi2_freeInstance(self, comp):
-        return self.hdll.fmi2_freeInstance(self.fmu, comp)
+        return self.hdll.fmi2_freeInstance(comp)
 
     def fmi2_setupExperiment(self, comp, toleranceDefined, tolerance, startTime, stopTimeDefined, stopTime):
-        return self.hdll.fmi2_setupExperiment(self.fmu, comp, toleranceDefined, tolerance, startTime, stopTimeDefined, stopTime)
+        return self.hdll.fmi2_setupExperiment(comp, toleranceDefined, tolerance, startTime, stopTimeDefined, stopTime)
 
     def fmi2_enterInitializationMode(self, comp):
-        return self.hdll.fmi2_enterInitializationMode(self.fmu, comp)
+        return self.hdll.fmi2_enterInitializationMode(comp)
 
     def fmi2_exitInitializationMode(self, comp):
-        return self.hdll.fmi2_exitInitializationMode(self.fmu, comp)
+        return self.hdll.fmi2_exitInitializationMode(comp)
 
     def fmi2_terminate(self, comp):
-        return self.hdll.fmi2_terminate(self.fmu, comp)
+        return self.hdll.fmi2_terminate(comp)
 
     def fmi2_reset(self, comp):
-        return self.hdll.fmi2_reset(self.fmu, comp)
+        return self.hdll.fmi2_reset(comp)
 
     def fmi2_getNumberOfUnits(self):
         return self.hdll.fmi2_getNumberOfUnits(self.fmu)
@@ -1647,7 +1647,7 @@ class fmi4c:
         double_array_type = ct.c_double * nValueReferences
         valueReferencesArray = uint_array_type(*valueReferences)
         valuesArray = double_array_type()
-        success = self.hdll.fmi2_getReal(self.fmu, comp, valueReferencesArray, nValueReferences, valuesArray)
+        success = self.hdll.fmi2_getReal(comp, valueReferencesArray, nValueReferences, valuesArray)
         return [success, list(valuesArray)]
 
     def fmi2_getInteger(self, comp, valueReferences, nValueReferences):
@@ -1655,7 +1655,7 @@ class fmi4c:
         double_array_type = ct.c_int * nValueReferences
         valueReferencesArray = uint_array_type(*valueReferences)
         valuesArray = double_array_type(*[1]*nValueReferences)
-        success = self.hdll.fmi2_getInteger(self.fmu, comp, valueReferencesArray, nValueReferences, valuesArray)
+        success = self.hdll.fmi2_getInteger(comp, valueReferencesArray, nValueReferences, valuesArray)
         return [success, list(valuesArray)]
 
     def fmi2_getBoolean(self, comp, valueReferences, nValueReferences):
@@ -1663,7 +1663,7 @@ class fmi4c:
         double_array_type = ct.c_bool * nValueReferences
         valueReferencesArray = uint_array_type(*valueReferences)
         valuesArray = double_array_type(*[1]*nValueReferences)
-        success = self.hdll.fmi2_getBoolean(self.fmu, comp, valueReferencesArray, nValueReferences, valuesArray)
+        success = self.hdll.fmi2_getBoolean(comp, valueReferencesArray, nValueReferences, valuesArray)
         return [success, list(valuesArray)]
 
     def fmi2_getString(self, comp, valueReferences, nValueReferences):
@@ -1671,7 +1671,7 @@ class fmi4c:
         double_array_type = ct.c_char_p * nValueReferences
         valueReferencesArray = uint_array_type(*valueReferences)
         valuesArray = double_array_type(*[1]*nValueReferences)
-        success = self.hdll.fmi2_getString(self.fmu, comp, valueReferencesArray, nValueReferences, valuesArray)
+        success = self.hdll.fmi2_getString(comp, valueReferencesArray, nValueReferences, valuesArray)
         return [success, list(valuesArray)]
 
     def fmi2_setReal(self, comp, valueReferences,  nValueReferences, values):
@@ -1679,123 +1679,123 @@ class fmi4c:
         double_array_type = ct.c_double * nValueReferences
         valueReferencesArray = uint_array_type(*valueReferences)
         valuesArray = double_array_type(*values)
-        return self.hdll.fmi2_setReal(self.fmu, comp, valueReferencesArray, nValueReferences, valuesArray)
+        return self.hdll.fmi2_setReal(comp, valueReferencesArray, nValueReferences, valuesArray)
 
     def fmi2_setInteger(self, comp, valueReferences, nValueReferences, values):
         uint_array_type = ct.c_uint * nValueReferences
         double_array_type = ct.c_int * nValueReferences
         valueReferencesArray = uint_array_type(*valueReferences)
         valuesArray = double_array_type(*values)
-        return self.hdll.fmi2_setInteger(self.fmu, comp, valueReferencesArray, nValueReferences, valuesArray)
+        return self.hdll.fmi2_setInteger(comp, valueReferencesArray, nValueReferences, valuesArray)
 
     def fmi2_setBoolean(self, comp, valueReferences, nValueReferences, values):
         uint_array_type = ct.c_uint * nValueReferences
         double_array_type = ct.c_bool * nValueReferences
         valueReferencesArray = uint_array_type(*valueReferences)
         valuesArray = double_array_type(*values)
-        return self.hdll.fmi2_setBoolean(self.fmu, comp, valueReferencesArray, nValueReferences, valuesArray)
+        return self.hdll.fmi2_setBoolean(comp, valueReferencesArray, nValueReferences, valuesArray)
 
     def fmi2_setString(self, comp, valueReferences, nValueReferences, values):
         uint_array_type = ct.c_uint * nValueReferences
         double_array_type = ct.c_char_p * nValueReferences
         valueReferencesArray = uint_array_type(*valueReferences)
         valuesArray = double_array_type(*values)
-        return self.hdll.fmi2_setString(self.fmu, comp, valueReferencesArray, nValueReferences, valuesArray)
+        return self.hdll.fmi2_setString(comp, valueReferencesArray, nValueReferences, valuesArray)
 
     def fmi2_getFMUstate(self, comp, FMUstate):
-        return self.hdll.fmi2_getFMUstate(self.fmu, comp, FMUstate)
+        return self.hdll.fmi2_getFMUstate(comp, FMUstate)
 
     def fmi2_setFMUstate(self, comp, FMUstate):
-        return self.hdll.fmi2_setFMUstate(self.fmu, comp, FMUstate)
+        return self.hdll.fmi2_setFMUstate(comp, FMUstate)
 
     def fmi2_freeFMUstate(self, comp, FMUstate):
-        return self.hdll.fmi2_freeFMUstate(self.fmu, comp, FMUstate)
+        return self.hdll.fmi2_freeFMUstate(comp, FMUstate)
 
     def fmi2_serializedFMUstateSize(self, comp, FMUstate,  size):
-        return self.hdll.fmi2_serializedFMUstateSize(self.fmu, comp, FMUstate,  size)
+        return self.hdll.fmi2_serializedFMUstateSize(comp, FMUstate,  size)
 
     def fmi2_serializeFMUstate(self, comp, FMUstate, serializedState,  size):
-        return self.hdll.fmi2_serializeFMUstate(self.fmu, comp, FMUstate, serializedState,  size)
+        return self.hdll.fmi2_serializeFMUstate(comp, FMUstate, serializedState,  size)
 
     def fmi2_deSerializeFMUstate(self, comp, serializedState,  size, FMUstate):
-        return self.hdll.fmi2_deSerializeFMUstate(self.fmu, comp, serializedState,  size, FMUstate)
+        return self.hdll.fmi2_deSerializeFMUstate(comp, serializedState,  size, FMUstate)
 
     def fmi2_getDirectionalDerivative(self, comp, unknownReferences,  nUnknown, knownReferences,  nKnown, dvKnown, dvUnknown):
-        return self.hdll.fmi2_getDirectionalDerivative(self.fmu, comp, unknownReferences,  nUnknown, knownReferences,  nKnown, dvKnown, dvUnknown)
+        return self.hdll.fmi2_getDirectionalDerivative(comp, unknownReferences,  nUnknown, knownReferences,  nKnown, dvKnown, dvUnknown)
 
     def fmi2_enterEventMode(self, comp):
-        return self.hdll.fmi2_enterEventMode(self.fmu, comp)
+        return self.hdll.fmi2_enterEventMode(comp)
 
     def fmi2_newDiscreteStates(self, comp, eventInfo):
-        return self.hdll.fmi2_newDiscreteStates(self.fmu, comp, eventInfo)
+        return self.hdll.fmi2_newDiscreteStates(comp, eventInfo)
 
     def fmi2_enterContinuousTimeMode(self, comp):
-        return self.hdll.fmi2_enterContinuousTimeMode(self.fmu, comp)
+        return self.hdll.fmi2_enterContinuousTimeMode(comp)
 
     def fmi2_completedIntegratorStep(self, comp, noSetFMUStatePriorToCurrentPoint):
         enterEventMode = ct.c_bool()
         terminateSimulation = ct.c_bool()
-        success = self.hdll.fmi2_completedIntegratorStep(self.fmu, comp,  noSetFMUStatePriorToCurrentPoint,  ct.byref(enterEventMode),  ct.byref(terminateSimulation))
+        success = self.hdll.fmi2_completedIntegratorStep(comp,  noSetFMUStatePriorToCurrentPoint,  ct.byref(enterEventMode),  ct.byref(terminateSimulation))
         return (success, enterEventMode.value, terminateSimulation.value)
 
     def fmi2_setTime(self, comp, time):
-        return self.hdll.fmi2_setTime(self.fmu, comp, time)
+        return self.hdll.fmi2_setTime(comp, time)
 
     def fmi2_setContinuousStates(self, comp, continuousStates, nContinuousStates):
         double_array_type = ct.c_double * nContinuousStates
         continuousStatesArray = double_array_type(*continuousStates)
-        return self.hdll.fmi2_setContinuousStates(self.fmu, comp, continuousStatesArray, nContinuousStates)
+        return self.hdll.fmi2_setContinuousStates(comp, continuousStatesArray, nContinuousStates)
 
     def fmi2_getDerivatives(self, comp, nx):
         double_array_type = ct.c_double * nx
         derivativesArray = double_array_type()
-        success = self.hdll.fmi2_getDerivatives(self.fmu, comp, derivativesArray, nx)
+        success = self.hdll.fmi2_getDerivatives(comp, derivativesArray, nx)
         return [success, list(derivativesArray)]
 
     def fmi2_getEventIndicators(self, comp, eventIndicators,  ni):
         double_array_type = ct.c_double * nx
         eventIndicatorsArray = double_array_type()
-        success =  self.hdll.fmi2_getEventIndicators(self.fmu, comp, eventIndicatorsArray,  ni)
+        success =  self.hdll.fmi2_getEventIndicators(comp, eventIndicatorsArray,  ni)
         return [success, list(eventIndicatorsArray)]
     
     def fmi2_getContinuousStates(self, comp, nStates):
         double_array_type = ct.c_double * nStates
         statesArray = double_array_type()
-        success = self.hdll.fmi2_getContinuousStates(self.fmu, comp, statesArray, nStates)
+        success = self.hdll.fmi2_getContinuousStates(comp, statesArray, nStates)
         return [success, list(statesArray)]
 
     def fmi2_getNominalsOfContinuousStates(self, comp, nNominals):
         double_array_type = ct.c_double * nNominals
         nominalsArray = double_array_type()
-        success = self.hdll.fmi2_getNominalsOfContinuousStates(self.fmu, comp, nominalsArray, nNominals)
+        success = self.hdll.fmi2_getNominalsOfContinuousStates(comp, nominalsArray, nNominals)
         return [success, list(nominalsArray)]
         
     def fmi2_setRealInputDerivatives(self, comp, vr,  nvr,  order, value):
-        return self.hdll.fmi2_setRealInputDerivatives(self.fmu, comp, vr,  nvr,  order, value)
+        return self.hdll.fmi2_setRealInputDerivatives(comp, vr,  nvr,  order, value)
 
     def fmi2_getRealOutputDerivatives(self, comp, vr,  nvr,  order, value):
-        return self.hdll.fmi2_getRealOutputDerivatives(self.fmu, comp, vr,  nvr,  order, value)
+        return self.hdll.fmi2_getRealOutputDerivatives(comp, vr,  nvr,  order, value)
 
     def fmi2_doStep(self, comp, currentCommunicationPoint, communicationStepSize, noSetFMUStatePriorToCurrentPoint):
-        return self.hdll.fmi2_doStep(self.fmu, comp, currentCommunicationPoint, communicationStepSize, noSetFMUStatePriorToCurrentPoint)
+        return self.hdll.fmi2_doStep(comp, currentCommunicationPoint, communicationStepSize, noSetFMUStatePriorToCurrentPoint)
 
     def fmi2_cancelStep(self, comp):
-        return self.hdll.fmi2_cancelStep(self.fmu, comp)
+        return self.hdll.fmi2_cancelStep(comp)
 
     def fmi2_getStatus(self, comp, s, value):
-        return self.hdll.fmi2_getStatus(self.fmu, comp, s, value)
+        return self.hdll.fmi2_getStatus(comp, s, value)
 
     def fmi2_getRealStatus(self, comp, s, value):
-        return self.hdll.fmi2_getRealStatus(self.fmu, comp, s, value)
+        return self.hdll.fmi2_getRealStatus(comp, s, value)
 
     def fmi2_getIntegerStatus(self, comp, s, value):
-        return self.hdll.fmi2_getIntegerStatus(self.fmu, comp, s, value)
+        return self.hdll.fmi2_getIntegerStatus(comp, s, value)
 
     def fmi2_getBooleanStatus(self, comp, s,  value):
-        return self.hdll.fmi2_getBooleanStatus(self.fmu, comp, s,  value)
+        return self.hdll.fmi2_getBooleanStatus(comp, s,  value)
 
     def fmi2_getStringStatus(self, comp, s, value):
-        return self.hdll.fmi2_getStringStatus(self.fmu, comp, s, value)
+        return self.hdll.fmi2_getStringStatus(comp, s, value)
 
     #FMI3 functions
 

--- a/fmi4c.py
+++ b/fmi4c.py
@@ -287,7 +287,7 @@ class fmi4c:
         self.hdll.fmi2_getVersion.restype = ct.c_char_p
         self.hdll.fmi2_getVersion.argtypes = ct.c_void_p,
         self.hdll.fmi2_setDebugLogging.restype = ct.c_int
-        self.hdll.fmi2_setDebugLogging.argtypes = ct.c_void_p, ct.c_bool, ct.c_size_t, ct.c_char_p
+        self.hdll.fmi2_setDebugLogging.argtypes = ct.c_void_p, ct.c_void_p, ct.c_bool, ct.c_size_t, ct.c_char_p
         self.hdll.fmi2_getGuid.restype = ct.c_char_p
         self.hdll.fmi2_getGuid.argtypes =ct.c_void_p,
 
@@ -363,21 +363,21 @@ class fmi4c:
         self.hdll.fmi2_getModelStructureDependencyKinds.restype = None
         self.hdll.fmi2_getModelStructureDependencyKinds.argtypes = ct.c_void_p, ct.POINTER(ct.c_int), ct.c_size_t,
 
-        self.hdll.fmi2_instantiate.restype = ct.c_bool
+        self.hdll.fmi2_instantiate.restype = ct.c_void_p
         self.hdll.fmi2_instantiate.argtypes =ct.c_void_p, ct.c_int, ct.c_void_p, ct.c_void_p, ct.c_void_p, ct.c_void_p, ct.c_void_p, ct.c_bool, ct.c_bool,
         self.hdll.fmi2_freeInstance.restype = None
-        self.hdll.fmi2_freeInstance.argtypes = ct.c_void_p,
+        self.hdll.fmi2_freeInstance.argtypes = ct.c_void_p, ct.c_void_p,
 
         self.hdll.fmi2_setupExperiment.restype = ct.c_int
-        self.hdll.fmi2_setupExperiment.argtypes = ct.c_void_p, ct.c_bool, ct.c_double, ct.c_double, ct.c_bool, ct.c_double,
+        self.hdll.fmi2_setupExperiment.argtypes = ct.c_void_p, ct.c_void_p, ct.c_bool, ct.c_double, ct.c_double, ct.c_bool, ct.c_double,
         self.hdll.fmi2_enterInitializationMode.restype = ct.c_int
-        self.hdll.fmi2_enterInitializationMode.argtypes = ct.c_void_p,
+        self.hdll.fmi2_enterInitializationMode.argtypes = ct.c_void_p, ct.c_void_p,
         self.hdll.fmi2_exitInitializationMode.restype = ct.c_int
-        self.hdll.fmi2_exitInitializationMode.argtypes = ct.c_void_p,
+        self.hdll.fmi2_exitInitializationMode.argtypes = ct.c_void_p, ct.c_void_p,
         self.hdll.fmi2_terminate.restype = ct.c_int
-        self.hdll.fmi2_terminate.argtypes = ct.c_void_p,
+        self.hdll.fmi2_terminate.argtypes = ct.c_void_p, ct.c_void_p,
         self.hdll.fmi2_reset.restype = ct.c_int
-        self.hdll.fmi2_reset.argtypes = ct.c_void_p,
+        self.hdll.fmi2_reset.argtypes = ct.c_void_p, ct.c_void_p,
 
         self.hdll.fmi2_getNumberOfUnits.restype = ct.c_int
         self.hdll.fmi2_getNumberOfUnits.argtypes =ct.c_void_p,
@@ -396,22 +396,22 @@ class fmi4c:
         self.hdll.fmi2_getDisplayUnitByIndex.argtypes = ct.c_void_p, ct.c_int, ct.POINTER(ct.c_char_p), ct.POINTER(ct.c_double),ct.POINTER(ct.c_double),
 
         self.hdll.fmi2_getReal.restype = ct.c_int
-        self.hdll.fmi2_getReal.argtypes = ct.c_void_p, ct.POINTER(ct.c_uint), ct.c_size_t,ct.POINTER(ct.c_double),
+        self.hdll.fmi2_getReal.argtypes = ct.c_void_p, ct.c_void_p, ct.POINTER(ct.c_uint), ct.c_size_t,ct.POINTER(ct.c_double),
         self.hdll.fmi2_getInteger.restype = ct.c_int
-        self.hdll.fmi2_getInteger.argtypes = ct.c_void_p, ct.POINTER(ct.c_uint), ct.c_size_t,ct.POINTER(ct.c_int),
+        self.hdll.fmi2_getInteger.argtypes = ct.c_void_p, ct.c_void_p, ct.POINTER(ct.c_uint), ct.c_size_t,ct.POINTER(ct.c_int),
         self.hdll.fmi2_getBoolean.restype = ct.c_int
-        self.hdll.fmi2_getBoolean.argtypes = ct.c_void_p, ct.POINTER(ct.c_uint), ct.c_size_t,ct.POINTER(ct.c_bool),
+        self.hdll.fmi2_getBoolean.argtypes = ct.c_void_p, ct.c_void_p, ct.POINTER(ct.c_uint), ct.c_size_t,ct.POINTER(ct.c_bool),
         self.hdll.fmi2_getString.restype = ct.c_int
-        self.hdll.fmi2_getString.argtypes = ct.c_void_p, ct.POINTER(ct.c_uint), ct.c_size_t,ct.POINTER(ct.c_char_p),
+        self.hdll.fmi2_getString.argtypes = ct.c_void_p, ct.c_void_p, ct.POINTER(ct.c_uint), ct.c_size_t,ct.POINTER(ct.c_char_p),
 
         self.hdll.fmi2_setReal.restype = ct.c_int
-        self.hdll.fmi2_setReal.argtypes = ct.c_void_p, ct.POINTER(ct.c_uint), ct.c_size_t,ct.POINTER(ct.c_double),
+        self.hdll.fmi2_setReal.argtypes = ct.c_void_p, ct.c_void_p, ct.POINTER(ct.c_uint), ct.c_size_t,ct.POINTER(ct.c_double),
         self.hdll.fmi2_setInteger.restype = ct.c_int
-        self.hdll.fmi2_setInteger.argtypes = ct.c_void_p, ct.POINTER(ct.c_uint), ct.c_size_t,ct.POINTER(ct.c_int),
+        self.hdll.fmi2_setInteger.argtypes = ct.c_void_p, ct.c_void_p, ct.POINTER(ct.c_uint), ct.c_size_t,ct.POINTER(ct.c_int),
         self.hdll.fmi2_setBoolean.restype = ct.c_int
-        self.hdll.fmi2_setBoolean.argtypes = ct.c_void_p, ct.POINTER(ct.c_uint), ct.c_size_t,ct.POINTER(ct.c_bool),
+        self.hdll.fmi2_setBoolean.argtypes = ct.c_void_p, ct.c_void_p, ct.POINTER(ct.c_uint), ct.c_size_t,ct.POINTER(ct.c_bool),
         self.hdll.fmi2_setString.restype = ct.c_int
-        self.hdll.fmi2_setString.argtypes = ct.c_void_p, ct.POINTER(ct.c_uint), ct.c_size_t,ct.POINTER(ct.c_char_p),
+        self.hdll.fmi2_setString.argtypes = ct.c_void_p, ct.c_void_p, ct.POINTER(ct.c_uint), ct.c_size_t,ct.POINTER(ct.c_char_p),
 
         self.hdll.fmi2_getFMUstate.restype = ct.c_int
         self.hdll.fmi2_getFMUstate.argtypes = ct.c_void_p,ct.c_void_p,
@@ -427,55 +427,55 @@ class fmi4c:
         self.hdll.fmi2_deSerializeFMUstate.argtypes = ct.c_void_p,ct.POINTER(ct.c_char),ct.c_size_t,ct.c_void_p,
 
         self.hdll.fmi2_getDirectionalDerivative.restype = ct.c_int
-        self.hdll.fmi2_getDirectionalDerivative.argtypes = ct.c_void_p,ct.POINTER(ct.c_uint),ct.c_size_t,ct.POINTER(ct.c_uint),ct.c_size_t,ct.c_double,ct.c_double,
+        self.hdll.fmi2_getDirectionalDerivative.argtypes = ct.c_void_p, ct.c_void_p,ct.POINTER(ct.c_uint),ct.c_size_t,ct.POINTER(ct.c_uint),ct.c_size_t,ct.c_double,ct.c_double,
 
         self.hdll.fmi2_enterEventMode.restype = ct.c_int
-        self.hdll.fmi2_enterEventMode.argtypes = ct.c_void_p,
+        self.hdll.fmi2_enterEventMode.argtypes = ct.c_void_p, ct.c_void_p,
         self.hdll.fmi2_newDiscreteStates.restype = ct.c_int
-        self.hdll.fmi2_newDiscreteStates.argtypes = ct.c_void_p,ct.c_void_p,
+        self.hdll.fmi2_newDiscreteStates.argtypes = ct.c_void_p, ct.c_void_p,ct.c_void_p,
         self.hdll.fmi2_enterContinuousTimeMode.restype = ct.c_int
-        self.hdll.fmi2_enterContinuousTimeMode.argtypes = ct.c_void_p,
+        self.hdll.fmi2_enterContinuousTimeMode.argtypes = ct.c_void_p, ct.c_void_p,
         self.hdll.fmi2_completedIntegratorStep.restype = ct.c_int
-        self.hdll.fmi2_completedIntegratorStep.argtypes = ct.c_void_p,ct.c_bool,ct.POINTER(ct.c_bool),ct.POINTER(ct.c_bool),
+        self.hdll.fmi2_completedIntegratorStep.argtypes = ct.c_void_p, ct.c_void_p,ct.c_bool,ct.POINTER(ct.c_bool),ct.POINTER(ct.c_bool),
 
         self.hdll.fmi2_setTime.restype = ct.c_int
-        self.hdll.fmi2_setTime.argtypes = ct.c_void_p,ct.c_double,
+        self.hdll.fmi2_setTime.argtypes = ct.c_void_p, ct.c_void_p,ct.c_double,
         self.hdll.fmi2_setContinuousStates.restype = ct.c_int
-        self.hdll.fmi2_setContinuousStates.argtypes = ct.c_void_p,ct.POINTER(ct.c_double),ct.c_size_t,
+        self.hdll.fmi2_setContinuousStates.argtypes = ct.c_void_p, ct.c_void_p,ct.POINTER(ct.c_double),ct.c_size_t,
 
         self.hdll.fmi2_getDerivatives.restype = ct.c_int
-        self.hdll.fmi2_getDerivatives.argtypes = ct.c_void_p,ct.POINTER(ct.c_double),ct.c_size_t,
+        self.hdll.fmi2_getDerivatives.argtypes = ct.c_void_p, ct.c_void_p,ct.POINTER(ct.c_double),ct.c_size_t,
 
         self.hdll.fmi2_getEventIndicators.restype = ct.c_int
-        self.hdll.fmi2_getEventIndicators.argtypes = ct.c_void_p,ct.POINTER(ct.c_double),ct.c_size_t,
+        self.hdll.fmi2_getEventIndicators.argtypes = ct.c_void_p, ct.c_void_p,ct.POINTER(ct.c_double),ct.c_size_t,
 
         self.hdll.fmi2_getContinuousStates.restype = ct.c_int
-        self.hdll.fmi2_getContinuousStates.argtypes = ct.c_void_p,ct.POINTER(ct.c_double),ct.c_size_t,
+        self.hdll.fmi2_getContinuousStates.argtypes = ct.c_void_p, ct.c_void_p,ct.POINTER(ct.c_double),ct.c_size_t,
 
         self.hdll.fmi2_getNominalsOfContinuousStates.restype = ct.c_int
-        self.hdll.fmi2_getNominalsOfContinuousStates.argtypes = ct.c_void_p,ct.POINTER(ct.c_double),ct.c_size_t,
+        self.hdll.fmi2_getNominalsOfContinuousStates.argtypes = ct.c_void_p, ct.c_void_p,ct.POINTER(ct.c_double),ct.c_size_t,
 
         self.hdll.fmi2_setRealInputDerivatives.restype = ct.c_int
-        self.hdll.fmi2_setRealInputDerivatives.argtypes = ct.c_void_p,ct.POINTER(ct.c_uint),ct.c_size_t,ct.POINTER(ct.c_int),ct.POINTER(ct.c_double),
+        self.hdll.fmi2_setRealInputDerivatives.argtypes = ct.c_void_p, ct.c_void_p,ct.POINTER(ct.c_uint),ct.c_size_t,ct.POINTER(ct.c_int),ct.POINTER(ct.c_double),
 
         self.hdll.fmi2_getRealOutputDerivatives.restype = ct.c_int
-        self.hdll.fmi2_getRealOutputDerivatives.argtypes = ct.c_void_p,ct.POINTER(ct.c_uint),ct.c_size_t,ct.POINTER(ct.c_int),ct.POINTER(ct.c_double),
+        self.hdll.fmi2_getRealOutputDerivatives.argtypes = ct.c_void_p, ct.c_void_p,ct.POINTER(ct.c_uint),ct.c_size_t,ct.POINTER(ct.c_int),ct.POINTER(ct.c_double),
 
         self.hdll.fmi2_doStep.restype = ct.c_int
-        self.hdll.fmi2_doStep.argtypes = ct.c_void_p,ct.c_double,ct.c_double,ct.c_bool,
+        self.hdll.fmi2_doStep.argtypes = ct.c_void_p, ct.c_void_p,ct.c_double,ct.c_double,ct.c_bool,
         self.hdll.fmi2_cancelStep.restype = ct.c_int
         self.hdll.fmi2_cancelStep.argtypes = ct.c_void_p,
 
         self.hdll.fmi2_getStatus.restype = ct.c_int
-        self.hdll.fmi2_getStatus.argtypes = ct.c_void_p, ct.c_int, ct.POINTER(ct.c_int)
+        self.hdll.fmi2_getStatus.argtypes = ct.c_void_p, ct.c_void_p, ct.c_int, ct.POINTER(ct.c_int)
         self.hdll.fmi2_getRealStatus.restype = ct.c_int
-        self.hdll.fmi2_getRealStatus.argtypes = ct.c_void_p, ct.c_int, ct.POINTER(ct.c_double),
+        self.hdll.fmi2_getRealStatus.argtypes = ct.c_void_p, ct.c_void_p, ct.c_int, ct.POINTER(ct.c_double),
         self.hdll.fmi2_getIntegerStatus.restype = ct.c_int
-        self.hdll.fmi2_getIntegerStatus.argtypes = ct.c_void_p, ct.c_int, ct.POINTER(ct.c_int)
+        self.hdll.fmi2_getIntegerStatus.argtypes = ct.c_void_p, ct.c_void_p, ct.c_int, ct.POINTER(ct.c_int)
         self.hdll.fmi2_getBooleanStatus.restype = ct.c_int
-        self.hdll.fmi2_getBooleanStatus.argtypes = ct.c_void_p, ct.c_int, ct.POINTER(ct.c_bool)
+        self.hdll.fmi2_getBooleanStatus.argtypes = ct.c_void_p, ct.c_void_p, ct.c_int, ct.POINTER(ct.c_bool)
         self.hdll.fmi2_getStringStatus.restype = ct.c_int
-        self.hdll.fmi2_getStringStatus.argtypes = ct.c_void_p, ct.c_int,ct.POINTER(ct.c_char_p)
+        self.hdll.fmi2_getStringStatus.argtypes = ct.c_void_p, ct.c_void_p, ct.c_int,ct.POINTER(ct.c_char_p)
 
         self.hdll.fmi3_modelName.restype = ct.c_char_p 
         self.hdll.fmi3_modelName.argtypes = ct.c_void_p,
@@ -939,9 +939,6 @@ class fmi4c:
     
     def fmi4c_getFmiVersion(self):
         return self.translateFmiVersion(self.hdll.fmi4c_getFmiVersion(self.fmu))
-
-    def fmi4c_getErrorMessages(self):
-        return self.hdll.fmi4c_getErrorMessages()
 
     def fmi4c_loadFmu(self, path, instanceName):
         self.fmu = self.hdll.fmi4c_loadFmu(path.encode(), instanceName.encode())
@@ -1474,8 +1471,8 @@ class fmi4c:
     def fmi2_getVersion(self):
         return self.hdll.fmi2_getVersion(self.fmu).decode()
 
-    def fmi2_setDebugLogging(self, loggingOn, nCategories, categories):
-        return self.hdll.fmi2_setDebugLogging(self.fmu, loggingOn, nCategories, categories)
+    def fmi2_setDebugLogging(self, comp, loggingOn, nCategories, categories):
+        return self.hdll.fmi2_setDebugLogging(self.fmu, comp, loggingOn, nCategories, categories)
 
     def fmi2_getGuid(self):
         return self.hdll.fmi2_getGuid(self.fmu).decode()
@@ -1591,23 +1588,23 @@ class fmi4c:
     def fmi2_instantiate(self, type, visible,  loggingOn):
         return self.hdll.fmi2_instantiate(self.fmu,  type, None, None, None, None, None,  visible,  loggingOn)
 
-    def fmi2_freeInstance(self):
-        return self.hdll.fmi2_freeInstance(self.fmu)
+    def fmi2_freeInstance(self, comp):
+        return self.hdll.fmi2_freeInstance(self.fmu, comp)
 
-    def fmi2_setupExperiment(self, toleranceDefined, tolerance, startTime, stopTimeDefined, stopTime):
-        return self.hdll.fmi2_setupExperiment(self.fmu, toleranceDefined, tolerance, startTime, stopTimeDefined, stopTime)
+    def fmi2_setupExperiment(self, comp, toleranceDefined, tolerance, startTime, stopTimeDefined, stopTime):
+        return self.hdll.fmi2_setupExperiment(self.fmu, comp, toleranceDefined, tolerance, startTime, stopTimeDefined, stopTime)
 
-    def fmi2_enterInitializationMode(self):
-        return self.hdll.fmi2_enterInitializationMode(self.fmu)
+    def fmi2_enterInitializationMode(self, comp):
+        return self.hdll.fmi2_enterInitializationMode(self.fmu, comp)
 
-    def fmi2_exitInitializationMode(self):
-        return self.hdll.fmi2_exitInitializationMode(self.fmu)
+    def fmi2_exitInitializationMode(self, comp):
+        return self.hdll.fmi2_exitInitializationMode(self.fmu, comp)
 
-    def fmi2_terminate(self):
-        return self.hdll.fmi2_terminate(self.fmu)
+    def fmi2_terminate(self, comp):
+        return self.hdll.fmi2_terminate(self.fmu, comp)
 
-    def fmi2_reset(self):
-        return self.hdll.fmi2_reset(self.fmu)
+    def fmi2_reset(self, comp):
+        return self.hdll.fmi2_reset(self.fmu, comp)
 
     def fmi2_getNumberOfUnits(self):
         return self.hdll.fmi2_getNumberOfUnits(self.fmu)
@@ -1645,160 +1642,160 @@ class fmi4c:
         self.hdll.fmi2_getDisplayUnitByIndex(unit, id, ct.byref(name), ct.byref(factor), ct.byref(offset))
         return (name.value.decode(), factor.value, offset.value)
 
-    def fmi2_getReal(self, valueReferences, nValueReferences):
+    def fmi2_getReal(self, comp, valueReferences, nValueReferences):
         uint_array_type = ct.c_uint * nValueReferences
         double_array_type = ct.c_double * nValueReferences
         valueReferencesArray = uint_array_type(*valueReferences)
         valuesArray = double_array_type()
-        success = self.hdll.fmi2_getReal(self.fmu, valueReferencesArray, nValueReferences, valuesArray)
+        success = self.hdll.fmi2_getReal(self.fmu, comp, valueReferencesArray, nValueReferences, valuesArray)
         return [success, list(valuesArray)]
 
-    def fmi2_getInteger(self, valueReferences, nValueReferences):
+    def fmi2_getInteger(self, comp, valueReferences, nValueReferences):
         uint_array_type = ct.c_uint * nValueReferences
         double_array_type = ct.c_int * nValueReferences
         valueReferencesArray = uint_array_type(*valueReferences)
         valuesArray = double_array_type(*[1]*nValueReferences)
-        success = self.hdll.fmi2_getInteger(self.fmu, valueReferencesArray, nValueReferences, valuesArray)
+        success = self.hdll.fmi2_getInteger(self.fmu, comp, valueReferencesArray, nValueReferences, valuesArray)
         return [success, list(valuesArray)]
 
-    def fmi2_getBoolean(self, valueReferences, nValueReferences):
+    def fmi2_getBoolean(self, comp, valueReferences, nValueReferences):
         uint_array_type = ct.c_uint * nValueReferences
         double_array_type = ct.c_bool * nValueReferences
         valueReferencesArray = uint_array_type(*valueReferences)
         valuesArray = double_array_type(*[1]*nValueReferences)
-        success = self.hdll.fmi2_getBoolean(self.fmu, valueReferencesArray, nValueReferences, valuesArray)
+        success = self.hdll.fmi2_getBoolean(self.fmu, comp, valueReferencesArray, nValueReferences, valuesArray)
         return [success, list(valuesArray)]
 
-    def fmi2_getString(self, valueReferences, nValueReferences):
+    def fmi2_getString(self, comp, valueReferences, nValueReferences):
         uint_array_type = ct.c_uint * nValueReferences
         double_array_type = ct.c_char_p * nValueReferences
         valueReferencesArray = uint_array_type(*valueReferences)
         valuesArray = double_array_type(*[1]*nValueReferences)
-        success = self.hdll.fmi2_getString(self.fmu, valueReferencesArray, nValueReferences, valuesArray)
+        success = self.hdll.fmi2_getString(self.fmu, comp, valueReferencesArray, nValueReferences, valuesArray)
         return [success, list(valuesArray)]
 
-    def fmi2_setReal(self, valueReferences,  nValueReferences, values):
+    def fmi2_setReal(self, comp, valueReferences,  nValueReferences, values):
         uint_array_type = ct.c_uint * nValueReferences
         double_array_type = ct.c_double * nValueReferences
         valueReferencesArray = uint_array_type(*valueReferences)
         valuesArray = double_array_type(*values)
-        return self.hdll.fmi2_setReal(self.fmu, valueReferencesArray, nValueReferences, valuesArray)
+        return self.hdll.fmi2_setReal(self.fmu, comp, valueReferencesArray, nValueReferences, valuesArray)
 
-    def fmi2_setInteger(self, valueReferences, nValueReferences, values):
+    def fmi2_setInteger(self, comp, valueReferences, nValueReferences, values):
         uint_array_type = ct.c_uint * nValueReferences
         double_array_type = ct.c_int * nValueReferences
         valueReferencesArray = uint_array_type(*valueReferences)
         valuesArray = double_array_type(*values)
-        return self.hdll.fmi2_setInteger(self.fmu, valueReferencesArray, nValueReferences, valuesArray)
+        return self.hdll.fmi2_setInteger(self.fmu, comp, valueReferencesArray, nValueReferences, valuesArray)
 
-    def fmi2_setBoolean(self, valueReferences, nValueReferences, values):
+    def fmi2_setBoolean(self, comp, valueReferences, nValueReferences, values):
         uint_array_type = ct.c_uint * nValueReferences
         double_array_type = ct.c_bool * nValueReferences
         valueReferencesArray = uint_array_type(*valueReferences)
         valuesArray = double_array_type(*values)
-        return self.hdll.fmi2_setBoolean(self.fmu, valueReferencesArray, nValueReferences, valuesArray)
+        return self.hdll.fmi2_setBoolean(self.fmu, comp, valueReferencesArray, nValueReferences, valuesArray)
 
-    def fmi2_setString(self, valueReferences, nValueReferences, values):
+    def fmi2_setString(self, comp, valueReferences, nValueReferences, values):
         uint_array_type = ct.c_uint * nValueReferences
         double_array_type = ct.c_char_p * nValueReferences
         valueReferencesArray = uint_array_type(*valueReferences)
         valuesArray = double_array_type(*values)
-        return self.hdll.fmi2_setString(self.fmu, valueReferencesArray, nValueReferences, valuesArray)
+        return self.hdll.fmi2_setString(self.fmu, comp, valueReferencesArray, nValueReferences, valuesArray)
 
-    def fmi2_getFMUstate(self, FMUstate):
-        return self.hdll.fmi2_getFMUstate(self.fmu, FMUstate)
+    def fmi2_getFMUstate(self, comp, FMUstate):
+        return self.hdll.fmi2_getFMUstate(self.fmu, comp, FMUstate)
 
-    def fmi2_setFMUstate(self, FMUstate):
-        return self.hdll.fmi2_setFMUstate(self.fmu, FMUstate)
+    def fmi2_setFMUstate(self, comp, FMUstate):
+        return self.hdll.fmi2_setFMUstate(self.fmu, comp, FMUstate)
 
-    def fmi2_freeFMUstate(self, FMUstate):
-        return self.hdll.fmi2_freeFMUstate(self.fmu, FMUstate)
+    def fmi2_freeFMUstate(self, comp, FMUstate):
+        return self.hdll.fmi2_freeFMUstate(self.fmu, comp, FMUstate)
 
-    def fmi2_serializedFMUstateSize(self, FMUstate,  size):
-        return self.hdll.fmi2_serializedFMUstateSize(self.fmu, FMUstate,  size)
+    def fmi2_serializedFMUstateSize(self, comp, FMUstate,  size):
+        return self.hdll.fmi2_serializedFMUstateSize(self.fmu, comp, FMUstate,  size)
 
-    def fmi2_serializeFMUstate(self, FMUstate, serializedState,  size):
-        return self.hdll.fmi2_serializeFMUstate(self.fmu, FMUstate, serializedState,  size)
+    def fmi2_serializeFMUstate(self, comp, FMUstate, serializedState,  size):
+        return self.hdll.fmi2_serializeFMUstate(self.fmu, comp, FMUstate, serializedState,  size)
 
-    def fmi2_deSerializeFMUstate(self, serializedState,  size, FMUstate):
-        return self.hdll.fmi2_deSerializeFMUstate(self.fmu, serializedState,  size, FMUstate)
+    def fmi2_deSerializeFMUstate(self, comp, serializedState,  size, FMUstate):
+        return self.hdll.fmi2_deSerializeFMUstate(self.fmu, comp, serializedState,  size, FMUstate)
 
-    def fmi2_getDirectionalDerivative(self, unknownReferences,  nUnknown, knownReferences,  nKnown, dvKnown, dvUnknown):
-        return self.hdll.fmi2_getDirectionalDerivative(self.fmu, unknownReferences,  nUnknown, knownReferences,  nKnown, dvKnown, dvUnknown)
+    def fmi2_getDirectionalDerivative(self, comp, unknownReferences,  nUnknown, knownReferences,  nKnown, dvKnown, dvUnknown):
+        return self.hdll.fmi2_getDirectionalDerivative(self.fmu, comp, unknownReferences,  nUnknown, knownReferences,  nKnown, dvKnown, dvUnknown)
 
-    def fmi2_enterEventMode(self):
-        return self.hdll.fmi2_enterEventMode(self.fmu)
+    def fmi2_enterEventMode(self, comp):
+        return self.hdll.fmi2_enterEventMode(self.fmu, comp)
 
-    def fmi2_newDiscreteStates(self, eventInfo):
-        return self.hdll.fmi2_newDiscreteStates(self.fmu, eventInfo)
+    def fmi2_newDiscreteStates(self, comp, eventInfo):
+        return self.hdll.fmi2_newDiscreteStates(self.fmu, comp, eventInfo)
 
-    def fmi2_enterContinuousTimeMode(self):
-        return self.hdll.fmi2_enterContinuousTimeMode(self.fmu)
+    def fmi2_enterContinuousTimeMode(self, comp):
+        return self.hdll.fmi2_enterContinuousTimeMode(self.fmu, comp)
 
-    def fmi2_completedIntegratorStep(self,  noSetFMUStatePriorToCurrentPoint):
+    def fmi2_completedIntegratorStep(self, comp, noSetFMUStatePriorToCurrentPoint):
         enterEventMode = ct.c_bool()
         terminateSimulation = ct.c_bool()
-        success = self.hdll.fmi2_completedIntegratorStep(self.fmu,  noSetFMUStatePriorToCurrentPoint,  ct.byref(enterEventMode),  ct.byref(terminateSimulation))
+        success = self.hdll.fmi2_completedIntegratorStep(self.fmu, comp,  noSetFMUStatePriorToCurrentPoint,  ct.byref(enterEventMode),  ct.byref(terminateSimulation))
         return (success, enterEventMode.value, terminateSimulation.value)
 
-    def fmi2_setTime(self, time):
-        return self.hdll.fmi2_setTime(self.fmu, time)
+    def fmi2_setTime(self, comp, time):
+        return self.hdll.fmi2_setTime(self.fmu, comp, time)
 
-    def fmi2_setContinuousStates(self, continuousStates, nContinuousStates):
+    def fmi2_setContinuousStates(self, comp, continuousStates, nContinuousStates):
         double_array_type = ct.c_double * nContinuousStates
         continuousStatesArray = double_array_type(*continuousStates)
-        return self.hdll.fmi2_setContinuousStates(self.fmu, continuousStatesArray, nContinuousStates)
+        return self.hdll.fmi2_setContinuousStates(self.fmu, comp, continuousStatesArray, nContinuousStates)
 
-    def fmi2_getDerivatives(self, nx):
+    def fmi2_getDerivatives(self, comp, nx):
         double_array_type = ct.c_double * nx
         derivativesArray = double_array_type()
-        success = self.hdll.fmi2_getDerivatives(self.fmu, derivativesArray, nx)
+        success = self.hdll.fmi2_getDerivatives(self.fmu, comp, derivativesArray, nx)
         return [success, list(derivativesArray)]
 
-    def fmi2_getEventIndicators(self, eventIndicators,  ni):
+    def fmi2_getEventIndicators(self, comp, eventIndicators,  ni):
         double_array_type = ct.c_double * nx
         eventIndicatorsArray = double_array_type()
-        success =  self.hdll.fmi2_getEventIndicators(self.fmu, eventIndicatorsArray,  ni)
+        success =  self.hdll.fmi2_getEventIndicators(self.fmu, comp, eventIndicatorsArray,  ni)
         return [success, list(eventIndicatorsArray)]
     
-    def fmi2_getContinuousStates(self, nStates):
+    def fmi2_getContinuousStates(self, comp, nStates):
         double_array_type = ct.c_double * nStates
         statesArray = double_array_type()
-        success = self.hdll.fmi2_getContinuousStates(self.fmu, statesArray, nStates)
+        success = self.hdll.fmi2_getContinuousStates(self.fmu, comp, statesArray, nStates)
         return [success, list(statesArray)]
 
-    def fmi2_getNominalsOfContinuousStates(self, nNominals):
+    def fmi2_getNominalsOfContinuousStates(self, comp, nNominals):
         double_array_type = ct.c_double * nNominals
         nominalsArray = double_array_type()
-        success = self.hdll.fmi2_getNominalsOfContinuousStates(self.fmu, nominalsArray, nNominals)
+        success = self.hdll.fmi2_getNominalsOfContinuousStates(self.fmu, comp, nominalsArray, nNominals)
         return [success, list(nominalsArray)]
         
-    def fmi2_setRealInputDerivatives(self, vr,  nvr,  order, value):
-        return self.hdll.fmi2_setRealInputDerivatives(self.fmu, vr,  nvr,  order, value)
+    def fmi2_setRealInputDerivatives(self, comp, vr,  nvr,  order, value):
+        return self.hdll.fmi2_setRealInputDerivatives(self.fmu, comp, vr,  nvr,  order, value)
 
-    def fmi2_getRealOutputDerivatives(self, vr,  nvr,  order, value):
-        return self.hdll.fmi2_getRealOutputDerivatives(self.fmu, vr,  nvr,  order, value)
+    def fmi2_getRealOutputDerivatives(self, comp, vr,  nvr,  order, value):
+        return self.hdll.fmi2_getRealOutputDerivatives(self.fmu, comp, vr,  nvr,  order, value)
 
-    def fmi2_doStep(self, currentCommunicationPoint, communicationStepSize, noSetFMUStatePriorToCurrentPoint):
-        return self.hdll.fmi2_doStep(self.fmu, currentCommunicationPoint, communicationStepSize, noSetFMUStatePriorToCurrentPoint)
+    def fmi2_doStep(self, comp, currentCommunicationPoint, communicationStepSize, noSetFMUStatePriorToCurrentPoint):
+        return self.hdll.fmi2_doStep(self.fmu, comp, currentCommunicationPoint, communicationStepSize, noSetFMUStatePriorToCurrentPoint)
 
-    def fmi2_cancelStep(self):
-        return self.hdll.fmi2_cancelStep(self.fmu)
+    def fmi2_cancelStep(self, comp):
+        return self.hdll.fmi2_cancelStep(self.fmu, comp)
 
-    def fmi2_getStatus(self, s, value):
-        return self.hdll.fmi2_getStatus(self.fmu, s, value)
+    def fmi2_getStatus(self, comp, s, value):
+        return self.hdll.fmi2_getStatus(self.fmu, comp, s, value)
 
-    def fmi2_getRealStatus(self, s, value):
-        return self.hdll.fmi2_getRealStatus(self.fmu, s, value)
+    def fmi2_getRealStatus(self, comp, s, value):
+        return self.hdll.fmi2_getRealStatus(self.fmu, comp, s, value)
 
-    def fmi2_getIntegerStatus(self, s, value):
-        return self.hdll.fmi2_getIntegerStatus(self.fmu, s, value)
+    def fmi2_getIntegerStatus(self, comp, s, value):
+        return self.hdll.fmi2_getIntegerStatus(self.fmu, comp, s, value)
 
-    def fmi2_getBooleanStatus(self, s,  value):
-        return self.hdll.fmi2_getBooleanStatus(self.fmu, s,  value)
+    def fmi2_getBooleanStatus(self, comp, s,  value):
+        return self.hdll.fmi2_getBooleanStatus(self.fmu, comp, s,  value)
 
-    def fmi2_getStringStatus(self, s, value):
-        return self.hdll.fmi2_getStringStatus(self.fmu, s, value)
+    def fmi2_getStringStatus(self, comp, s, value):
+        return self.hdll.fmi2_getStringStatus(self.fmu, comp, s, value)
 
     #FMI3 functions
 

--- a/fmi4c.py
+++ b/fmi4c.py
@@ -729,9 +729,9 @@ class fmi4c:
         self.hdll.fmi3se_getProvidesPerElementDependencies.restype = ct.c_bool 
         self.hdll.fmi3se_getProvidesPerElementDependencies.argtypes = ct.c_void_p,
 
-        self.hdll.fmi3_instantiateCoSimulation.restype = ct.c_bool 
+        self.hdll.fmi3_instantiateCoSimulation.restype = ct.c_void_p
         self.hdll.fmi3_instantiateCoSimulation.argtypes = ct.c_void_p, ct.c_bool, ct.c_bool, ct.c_bool, ct.c_bool, ct.POINTER(ct.c_uint), ct.c_size_t, ct.c_void_p, ct.c_void_p, ct.c_void_p,
-        self.hdll.fmi3_instantiateModelExchange.restype = ct.c_bool 
+        self.hdll.fmi3_instantiateModelExchange.restype = ct.c_void_p
         self.hdll.fmi3_instantiateModelExchange.argtypes = ct.c_void_p, ct.c_bool, ct.c_bool, ct.c_void_p, ct.c_void_p,
         self.hdll.fmi3_getVersion.restype = ct.c_char_p 
         self.hdll.fmi3_getVersion.argtypes = ct.c_void_p,
@@ -2352,248 +2352,248 @@ class fmi4c:
     def fmi3_getVersion(self):
         return self.hdll.fmi3_getVersion(self.fmu).decode()
 
-    def fmi3_setDebugLogging(self, loggingOn, nCategories, categories):
-        return self.hdll.fmi3_setDebugLogging(self.fmu, loggingOn, nCategories, categories)
+    def fmi3_setDebugLogging(self, instance, loggingOn, nCategories, categories):
+        return self.hdll.fmi3_setDebugLogging(instance, loggingOn, nCategories, categories)
 
-    def fmi3_enterInitializationMode(self,  toleranceDefined, tolerance, startTime, stopTimeDefined, stopTime):
-        return self.hdll.fmi3_enterInitializationMode(self.fmu, toleranceDefined, tolerance, startTime, stopTimeDefined, stopTime)
+    def fmi3_enterInitializationMode(self, instance, toleranceDefined, tolerance, startTime, stopTimeDefined, stopTime):
+        return self.hdll.fmi3_enterInitializationMode(instance,toleranceDefined, tolerance, startTime, stopTimeDefined, stopTime)
 
-    def fmi3_exitInitializationMode(self):
-        return self.hdll.fmi3_exitInitializationMode(self.fmu)
+    def fmi3_exitInitializationMode(self, instance):
+        return self.hdll.fmi3_exitInitializationMode(instance)
 
-    def fmi3_terminate(self):
-        return self.hdll.fmi3_terminate(self.fmu)
+    def fmi3_terminate(self, instance):
+        return self.hdll.fmi3_terminate(instance)
 
-    def fmi3_freeInstance(self):
-        return self.hdll.fmi3_freeInstance(self.fmu)
+    def fmi3_freeInstance(self, instance):
+        return self.hdll.fmi3_freeInstance(instance)
 
-    def fmi3_doStep(self,  currentCommunicationPoint, communicationStepSize, noSetFMUStatePriorToCurrentPoint):
+    def fmi3_doStep(self, instance,  currentCommunicationPoint, communicationStepSize, noSetFMUStatePriorToCurrentPoint):
         eventEncountered = ct.c_bool()
         terminateSimulation = ct.c_bool()
         earlyReturn = ct.c_bool()
         LastSuccessfulTime = ct.c_double()
-        success = self.hdll.fmi3_doStep(self.fmu, currentCommunicationPoint, communicationStepSize, noSetFMUStatePriorToCurrentPoint, ct.byref(eventEncountered), ct.byref(terminateSimulation), ct.byref(earlyReturn), ct.byref(LastSuccessfulTime))
+        success = self.hdll.fmi3_doStep(instance, currentCommunicationPoint, communicationStepSize, noSetFMUStatePriorToCurrentPoint, ct.byref(eventEncountered), ct.byref(terminateSimulation), ct.byref(earlyReturn), ct.byref(LastSuccessfulTime))
         return (success, eventEncountered.value, terminateSimulation.value, earlyReturn.value, LastSuccessfulTime.value)
 
-    def fmi3_enterEventMode(self):
-        return self.hdll.fmi3_enterEventMode(self.fmu)
+    def fmi3_enterEventMode(self, instance):
+        return self.hdll.fmi3_enterEventMode(instance)
 
-    def fmi3_reset(self):
-        return self.hdll.fmi3_reset(self.fmu)
+    def fmi3_reset(self, instance):
+        return self.hdll.fmi3_reset(instance)
 
-    def fmi3_getFloat64(self, valueReferences, nValueReferences, nValues):
+    def fmi3_getFloat64(self, instance, valueReferences, nValueReferences, nValues):
         uint_array_type = ct.c_uint * nValueReferences
         double_array_type = ct.c_double * nValueReferences
         valueReferencesArray = uint_array_type(*valueReferences)
         valuesArray = double_array_type()
-        success = self.hdll.fmi3_getFloat64(self.fmu, valueReferencesArray, nValueReferences, valuesArray, nValues)
+        success = self.hdll.fmi3_getFloat64(instance, valueReferencesArray, nValueReferences, valuesArray, nValues)
         return [success, list(valuesArray)]
 
-    def fmi3_getFloat32(self, valueReferences, nValueReferences, nValues):
+    def fmi3_getFloat32(self, instance, valueReferences, nValueReferences, nValues):
         uint_array_type = ct.c_uint * nValueReferences
         float_array_type = ct.c_float * nValueReferences
         valueReferencesArray = uint_array_type(*valueReferences)
         valuesArray = float_array_type()
-        success = self.hdll.fmi3_getFloat32(self.fmu, valueReferencesArray, nValueReferences, valuesArray, nValues)
+        success = self.hdll.fmi3_getFloat32(instance, valueReferencesArray, nValueReferences, valuesArray, nValues)
         return [success, list(valuesArray)]
 
-    def fmi3_getInt8(self, valueReferences, nValueReferences, nValues):
+    def fmi3_getInt8(self, instance, valueReferences, nValueReferences, nValues):
         uint_array_type = ct.c_uint * nValueReferences
         int8_array_type = ct.c_int8 * nValueReferences
         valueReferencesArray = uint_array_type(*valueReferences)
         valuesArray = int8_array_type()
-        success = self.hdll.fmi3_getInt8(self.fmu, valueReferencesArray, nValueReferences, valuesArray, nValues)
+        success = self.hdll.fmi3_getInt8(instance, valueReferencesArray, nValueReferences, valuesArray, nValues)
         return [success, list(valuesArray)]
 
-    def fmi3_getUInt8(self, valueReferences, nValueReferences, nValues):
+    def fmi3_getUInt8(self, instance, valueReferences, nValueReferences, nValues):
         uint_array_type = ct.c_uint * nValueReferences
         uint8_array_type = ct.c_uint8 * nValueReferences
         valueReferencesArray = uint_array_type(*valueReferences)
         valuesArray = uint8_array_type()
-        success = self.hdll.fmi3_getUInt8(self.fmu, valueReferencesArray, nValueReferences, valuesArray, nValues)
+        success = self.hdll.fmi3_getUInt8(instance, valueReferencesArray, nValueReferences, valuesArray, nValues)
         return [success, list(valuesArray)]
 
-    def fmi3_getInt16(self, valueReferences, nValueReferences, nValues):
+    def fmi3_getInt16(self, instance, valueReferences, nValueReferences, nValues):
         uint_array_type = ct.c_uint * nValueReferences
         int16_array_type = ct.c_int16 * nValueReferences
         valueReferencesArray = uint_array_type(*valueReferences)
         valuesArray = int16_array_type()
-        success = self.hdll.fmi3_getInt16(self.fmu, valueReferencesArray, nValueReferences, valuesArray, nValues)
+        success = self.hdll.fmi3_getInt16(instance, valueReferencesArray, nValueReferences, valuesArray, nValues)
         return [success, list(valuesArray)]
 
-    def fmi3_getUInt16(self, valueReferences, nValueReferences, nValues):
+    def fmi3_getUInt16(self, instance, valueReferences, nValueReferences, nValues):
         uint_array_type = ct.c_uint * nValueReferences
         uint16_array_type = ct.c_uint16 * nValueReferences
         valueReferencesArray = uint_array_type(*valueReferences)
         valuesArray = uint16_array_type()
-        success = self.hdll.fmi3_getUInt16(self.fmu, valueReferencesArray, nValueReferences, valuesArray, nValues)
+        success = self.hdll.fmi3_getUInt16(instance, valueReferencesArray, nValueReferences, valuesArray, nValues)
         return [success, list(valuesArray)]
 
-    def fmi3_getUInt32(self, valueReferences, nValueReferences, nValues):
+    def fmi3_getUInt32(self, instance, valueReferences, nValueReferences, nValues):
         uint_array_type = ct.c_uint * nValueReferences
         int32_array_type = ct.c_int32 * nValueReferences
         valueReferencesArray = uint_array_type(*valueReferences)
         valuesArray = int32_array_type()
-        success = self.hdll.fmi3_getUInt32(self.fmu, valueReferencesArray, nValueReferences, valuesArray, nValues)
+        success = self.hdll.fmi3_getUInt32(instance, valueReferencesArray, nValueReferences, valuesArray, nValues)
         return [success, list(valuesArray)]
 
-    def fmi3_getUInt32(self, valueReferences, nValueReferences, nValues):
+    def fmi3_getUInt32(self, instance, valueReferences, nValueReferences, nValues):
         uint_array_type = ct.c_uint * nValueReferences
         uint32_array_type = ct.c_uint32 * nValueReferences
         valueReferencesArray = uint_array_type(*valueReferences)
         valuesArray = uint32_array_type()
-        success = self.hdll.fmi3_getUInt32(self.fmu, valueReferencesArray, nValueReferences, valuesArray, nValues)
+        success = self.hdll.fmi3_getUInt32(instance, valueReferencesArray, nValueReferences, valuesArray, nValues)
         return [success, list(valuesArray)]
 
-    def fmi3_getInt64(self, valueReferences, nValueReferences, nValues):
+    def fmi3_getInt64(self, instance, valueReferences, nValueReferences, nValues):
         uint_array_type = ct.c_uint * nValueReferences
         int64_array_type = ct.c_int64 * nValueReferences
         valueReferencesArray = uint_array_type(*valueReferences)
         valuesArray = int64_array_type()
-        success = self.hdll.fmi3_getInt64(self.fmu, valueReferencesArray, nValueReferences, valuesArray, nValues)
+        success = self.hdll.fmi3_getInt64(instance, valueReferencesArray, nValueReferences, valuesArray, nValues)
         return [success, list(valuesArray)]
 
-    def fmi3_getUInt64(self, valueReferences, nValueReferences, nValues):
+    def fmi3_getUInt64(self, instance, valueReferences, nValueReferences, nValues):
         uint_array_type = ct.c_uint * nValueReferences
         uint64_array_type = ct.c_uint64 * nValueReferences
         valueReferencesArray = uint_array_type(*valueReferences)
         valuesArray = uint64_array_type()
-        success = self.hdll.fmi3_getUInt64(self.fmu, valueReferencesArray, nValueReferences, valuesArray, nValues)
+        success = self.hdll.fmi3_getUInt64(instance, valueReferencesArray, nValueReferences, valuesArray, nValues)
         return [success, list(valuesArray)]
 
-    def fmi3_getBoolean(self, valueReferences, nValueReferences, nValues):
+    def fmi3_getBoolean(self, instance, valueReferences, nValueReferences, nValues):
         uint_array_type = ct.c_uint * nValueReferences
         bool_array_type = ct.c_bool * nValueReferences
         valueReferencesArray = uint_array_type(*valueReferences)
         valuesArray = bool_array_type()
-        success = self.hdll.fmi3_getBoolean(self.fmu, valueReferencesArray, nValueReferences, valuesArray, nValues)
+        success = self.hdll.fmi3_getBoolean(instance, valueReferencesArray, nValueReferences, valuesArray, nValues)
         return [success, list(valuesArray)]
 
-    def fmi3_getString(self, valueReferences, nValueReferences, nValues):
+    def fmi3_getString(self, instance, valueReferences, nValueReferences, nValues):
         uint_array_type = ct.c_uint * nValueReferences
         string_array_type = ct.c_char_p * nValueReferences
         valueReferencesArray = uint_array_type(*valueReferences)
         valuesArray = string_array_type()
-        success = self.hdll.fmi3_getString(self.fmu, valueReferencesArray, nValueReferences, valuesArray, nValues)
+        success = self.hdll.fmi3_getString(instance, valueReferencesArray, nValueReferences, valuesArray, nValues)
         return [success, list(valuesArray)]
 
-    def fmi3_getBinary(self, valueReferences, nValueReferences, nValues):
+    def fmi3_getBinary(self, instance, valueReferences, nValueReferences, nValues):
         uint_array_type = ct.c_uint * nValueReferences
         size_t_array_type = ct.c_size_t * nValuesReferences
         binary_array_type = ct.POINTER(ct.c_uint8) * nValueReferences
         valueReferencesArray = uint_array_type(*valueReferences)
         valueSizesArray = size_t_array_type()
         valuesArray = binary_array_type()
-        success = self.hdll.fmi3_getBinary(self.fmu, valueReferencesArray, nValueReferences, valueSizesArray, valuesArray, nValues)
+        success = self.hdll.fmi3_getBinary(instance, valueReferencesArray, nValueReferences, valueSizesArray, valuesArray, nValues)
         return [success, list(valueSizesArray), list(valuesArray)]
 
-    def fmi3_getClock(self, valueReferences, nValueReferences, nValues):
+    def fmi3_getClock(self, instance, valueReferences, nValueReferences, nValues):
         uint_array_type = ct.c_uint * nValueReferences
         bool_array_type = ct.c_bool * nValueReferences
         valueReferencesArray = uint_array_type(*valueReferences)
         valuesArray = bool_array_type()
-        success = self.hdll.fmi3_getClock(self.fmu, valueReferencesArray, nValueReferences, valuesArray)
+        success = self.hdll.fmi3_getClock(instance, valueReferencesArray, nValueReferences, valuesArray)
         return [success, list(valuesArray)]
 
-    def fmi3_setFloat64(self, valueReferences, nValueReferences, values, nValues):
+    def fmi3_setFloat64(self, instance, valueReferences, nValueReferences, values, nValues):
         uint_array_type = ct.c_uint * nValueReferences
         double_array_type = ct.c_double * nValueReferences
         valueReferencesArray = uint_array_type(*valueReferences)
         valuesArray = double_array_type(*values)
-        return self.hdll.fmi3_setFloat64(self.fmu, valueReferencesArray, nValueReferences, valuesArray, nValues)
+        return self.hdll.fmi3_setFloat64(instance, valueReferencesArray, nValueReferences, valuesArray, nValues)
 
-    def fmi3_setFloat32(self, valueReferences, nValueReferences,values, nValues):
+    def fmi3_setFloat32(self, instance, valueReferences, nValueReferences,values, nValues):
         uint_array_type = ct.c_uint * nValueReferences
         float_array_type = ct.c_float * nValueReferences
         valueReferencesArray = uint_array_type(*valueReferences)
         valuesArray = float_array_type(*values)
-        return self.hdll.fmi3_setFloat32(self.fmu, valueReferencesArray, nValueReferences, valuesArray, nValues)
+        return self.hdll.fmi3_setFloat32(instance, valueReferencesArray, nValueReferences, valuesArray, nValues)
 
-    def fmi3_setInt8(self, valueReferences, nValueReferences,values, nValues):
+    def fmi3_setInt8(self, instance, valueReferences, nValueReferences,values, nValues):
         uint_array_type = ct.c_uint * nValueReferences
         int8_array_type = ct.c_int8 * nValueReferences
         valueReferencesArray = uint_array_type(*valueReferences)
         valuesArray = int8_array_type(*values)
-        return self.hdll.fmi3_setInt8(self.fmu, valueReferencesArray, nValueReferences, valuesArray, nValues)
+        return self.hdll.fmi3_setInt8(instance, valueReferencesArray, nValueReferences, valuesArray, nValues)
 
-    def fmi3_setUInt8(self, valueReferences, nValueReferences,values, nValues):
+    def fmi3_setUInt8(self, instance, valueReferences, nValueReferences,values, nValues):
         uint_array_type = ct.c_uint * nValueReferences
         uint8_array_type = ct.c_uint8 * nValueReferences
         valueReferencesArray = uint_array_type(*valueReferences)
         valuesArray = uint8_array_type(*values)
-        return self.hdll.fmi3_setUInt8(self.fmu, valueReferencesArray, nValueReferences, valuesArray, nValues)
+        return self.hdll.fmi3_setUInt8(instance, valueReferencesArray, nValueReferences, valuesArray, nValues)
 
-    def fmi3_setInt16(self, valueReferences, nValueReferences,values, nValues):
+    def fmi3_setInt16(self, instance, valueReferences, nValueReferences,values, nValues):
         uint_array_type = ct.c_uint * nValueReferences
         int16_array_type = ct.c_int16 * nValueReferences
         valueReferencesArray = uint_array_type(*valueReferences)
         valuesArray = int16_array_type(*values)
-        return self.hdll.fmi3_setInt16(self.fmu, valueReferencesArray, nValueReferences, valuesArray, nValues)
+        return self.hdll.fmi3_setInt16(instance, valueReferencesArray, nValueReferences, valuesArray, nValues)
 
-    def fmi3_setUInt16(self, valueReferences, nValueReferences,values, nValues):
+    def fmi3_setUInt16(self, instance, valueReferences, nValueReferences,values, nValues):
         uint_array_type = ct.c_uint * nValueReferences
         uint16_array_type = ct.c_uint16 * nValueReferences
         valueReferencesArray = uint_array_type(*valueReferences)
         valuesArray = uint16_array_type(*values)
-        return self.hdll.fmi3_setUInt16(self.fmu, valueReferencesArray, nValueReferences, valuesArray, nValues)
+        return self.hdll.fmi3_setUInt16(instance, valueReferencesArray, nValueReferences, valuesArray, nValues)
         
-    def fmi3_setInt32(self, valueReferences, nValueReferences,values, nValues):
+    def fmi3_setInt32(self, instance, valueReferences, nValueReferences,values, nValues):
         uint_array_type = ct.c_uint * nValueReferences
         int32_array_type = ct.c_int32 * nValueReferences
         valueReferencesArray = uint_array_type(*valueReferences)
         valuesArray = int32_array_type(*values)
-        return self.hdll.fmi3_setInt32(self.fmu, valueReferencesArray, nValueReferences, valuesArray, nValues)
+        return self.hdll.fmi3_setInt32(instance, valueReferencesArray, nValueReferences, valuesArray, nValues)
 
-    def fmi3_setUInt32(self, valueReferences, nValueReferences,values, nValues):
+    def fmi3_setUInt32(self, instance, valueReferences, nValueReferences,values, nValues):
         uint_array_type = ct.c_uint * nValueReferences
         uint32_array_type = ct.c_uint32 * nValueReferences
         valueReferencesArray = uint_array_type(*valueReferences)
         valuesArray = uint32_array_type(*values)
-        return self.hdll.fmi3_setUInt32(self.fmu, valueReferencesArray, nValueReferences, valuesArray, nValues)
+        return self.hdll.fmi3_setUInt32(instance, valueReferencesArray, nValueReferences, valuesArray, nValues)
 
-    def fmi3_setInt64(self, valueReferences, nValueReferences,values, nValues):
+    def fmi3_setInt64(self, instance, valueReferences, nValueReferences,values, nValues):
         uint_array_type = ct.c_uint * nValueReferences
         int64_array_type = ct.c_int64 * nValueReferences
         valueReferencesArray = uint_array_type(*valueReferences)
         valuesArray = int64_array_type(*values)
-        return self.hdll.fmi3_setInt64(self.fmu, valueReferencesArray, nValueReferences, valuesArray, nValues)
+        return self.hdll.fmi3_setInt64(instance, valueReferencesArray, nValueReferences, valuesArray, nValues)
 
-    def fmi3_setUInt64(self, valueReferences, nValueReferences,values, nValues):
+    def fmi3_setUInt64(self, instance, valueReferences, nValueReferences,values, nValues):
         uint_array_type = ct.c_uint * nValueReferences
         uint64_array_type = ct.c_uint64 * nValueReferences
         valueReferencesArray = uint_array_type(*valueReferences)
         valuesArray = uint64_array_type(*values)
-        return self.hdll.fmi3_setUInt64(self.fmu, valueReferencesArray, nValueReferences, valuesArray, nValues)
+        return self.hdll.fmi3_setUInt64(instance, valueReferencesArray, nValueReferences, valuesArray, nValues)
 
-    def fmi3_setBoolean(self, valueReferences, nValueReferences,values, nValues):
+    def fmi3_setBoolean(self, instance, valueReferences, nValueReferences,values, nValues):
         uint_array_type = ct.c_uint * nValueReferences
         bool_array_type = ct.c_bool * nValueReferences
         valueReferencesArray = uint_array_type(*valueReferences)
         valuesArray = bool_array_type(*values)
-        return self.hdll.fmi3_setBoolean(self.fmu, valueReferencesArray, nValueReferences, valuesArray, nValues)
+        return self.hdll.fmi3_setBoolean(instance, valueReferencesArray, nValueReferences, valuesArray, nValues)
         
-    def fmi3_setString(self, valueReferences, nValueReferences,values, nValues):
+    def fmi3_setString(self, instance, valueReferences, nValueReferences,values, nValues):
         uint_array_type = ct.c_uint * nValueReferences
         string_array_type = ct.c_char_p * nValueReferences
         valueReferencesArray = uint_array_type(*valueReferences)
         valuesArray = string_array_type(*values)
-        return self.hdll.fmi3_setString(self.fmu, valueReferencesArray, nValueReferences, valuesArray, nValues)
+        return self.hdll.fmi3_setString(instance, valueReferencesArray, nValueReferences, valuesArray, nValues)
 
-    def fmi3_setBinary(self, valueReferences, nValueReferences, valueSizes, values, Values):
+    def fmi3_setBinary(self, instance, valueReferences, nValueReferences, valueSizes, values, Values):
         uint_array_type = ct.c_uint * nValueReferences
         size_t_array_type = ct.c_size_t * nValueReferences
         binary_array_type = ct.POINTER(ct.c_uint8) * nValueReferences
         valueReferencesArray = uint_array_type(*valueReferences)
         valuesArray = binary_array_type(*values)
         valueSizesArray = size_t_array_type(*valueSizes)
-        return self.hdll.fmi3_setBinary(self.fmu, valueReferencesArray, nValueReferences, valueSizesArray, valuesArray, nValues)
+        return self.hdll.fmi3_setBinary(instance, valueReferencesArray, nValueReferences, valueSizesArray, valuesArray, nValues)
 
-    def fmi3_setClock(self, valueReferences, nValueReferences,values, nValues):
+    def fmi3_setClock(self, instance, valueReferences, nValueReferences,values, nValues):
         uint_array_type = ct.c_uint * nValueReferences
         bool_array_type = ct.c_bool * nValueReferences
         valueReferencesArray = uint_array_type(*valueReferences)
         valuesArray = boolarray_type(*values)
-        return self.hdll.fmi3_setClock(self.fmu, valueReferencesArray, nValueReferences, valuesArray, nValues)
+        return self.hdll.fmi3_setClock(instance, valueReferencesArray, nValueReferences, valuesArray, nValues)
         
         
     def fmi3_getNumberOfVariableDependencies(self, valueReference):
@@ -2614,33 +2614,33 @@ class fmi4c:
         return (success, elementIndicesOfDependent, independents, elementIndicesOfIndependents, dependencyKinds)
         
         
-    def fmi3_getFMUState(self):
+    def fmi3_getFMUState(self, instance):
         FMUState = ct.c_void_p()
-        success = self.hdll.fmi3_getFMUState(self.fmu, ct.byref(FMUState))
+        success = self.hdll.fmi3_getFMUState(instance, ct.byref(FMUState))
         return (success, FMUState)
 
-    def fmi3_setFMUState(self, FMUState):
-        return self.hdll.fmi3_setFMUState(self.fmu, FMUState)
+    def fmi3_setFMUState(self, instance, FMUState):
+        return self.hdll.fmi3_setFMUState(instance, FMUState)
 
-    def fmi3_freeFMUState(self, FMUState):
-        return self.hdll.fmi3_freeFMUState(self.fmu, FMUState)
+    def fmi3_freeFMUState(self, instance, FMUState):
+        return self.hdll.fmi3_freeFMUState(instance, FMUState)
 
-    def fmi3_serializedFMUStateSize(self, FMUState):
+    def fmi3_serializedFMUStateSize(self, instance, FMUState):
         size = ct.c_size_t()
-        success = self.hdll.fmi3_serializedFMUStateSize(self.fmu, FMUState,ct.byref(size))
+        success = self.hdll.fmi3_serializedFMUStateSize(instance, FMUState,ct.byref(size))
         return (success, size)
 
-    def fmi3_serializeFMUState(self, FMUState, size):
+    def fmi3_serializeFMUState(self, instance, FMUState, size):
         serializedState = ct.c_uint8()
-        success = self.hdll.fmi3_serializeFMUState(self.fmu, FMUState, ct.byref(serializedState), size)
+        success = self.hdll.fmi3_serializeFMUState(instance, FMUState, ct.byref(serializedState), size)
         return (success, serializedState)
 
-    def fmi3_deserializeFMUState(self, serializedState, size):
+    def fmi3_deserializeFMUState(self, instance, serializedState, size):
         FMUState = ct.c_void_p()
-        success = self.hdll.fmi3_deserializeFMUState(self.fmu, serializedState, size,ct.byref(FMUState))
+        success = self.hdll.fmi3_deserializeFMUState(instance, serializedState, size,ct.byref(FMUState))
         return (success, FMUState)
 
-    def fmi3_getDirectionalDerivative(self, unknowns, nUnknowns, knowns, nKnowns, seed, nSeed, nSensitivity):
+    def fmi3_getDirectionalDerivative(self, instance, unknowns, nUnknowns, knowns, nKnowns, seed, nSeed, nSensitivity):
         unknowns_array_type = ct.c_uint * nUnknowns
         unknowns_array = unknowns_array_type(*unknowns)
         knowns_array_type = ct.c_uint * nKnowns
@@ -2649,10 +2649,10 @@ class fmi4c:
         seed_array = seed_array_type(*seed)
         sensitivity_array_type = ct.c_double * nSensitivity
         sensitivity_array = sensitivity_array_type()
-        success = self.hdll.fmi3_getDirectionalDerivative(self.fmu, unknowns_array, nUnknowns, knowns_array, nKnowns, seed_array, nSeed, sensitivity_array, nSensitivity)
+        success = self.hdll.fmi3_getDirectionalDerivative(instance, unknowns_array, nUnknowns, knowns_array, nKnowns, seed_array, nSeed, sensitivity_array, nSensitivity)
         return (success, list(sensitivity_array))
 
-    def fmi3_getAdjointDerivative(self, unknowns, nUnknowns, knowns, nKnowns, seed, nSeed, nSensitivity):
+    def fmi3_getAdjointDerivative(self, instance, unknowns, nUnknowns, knowns, nKnowns, seed, nSeed, nSensitivity):
         unknowns_array_type = ct.c_uint * nUnknowns
         unknowns_array = unknowns_array_type(*unknowns)
         knowns_array_type = ct.c_uint * nKnowns
@@ -2661,26 +2661,26 @@ class fmi4c:
         seed_array = seed_array_type(*seed)
         sensitivity_array_type = ct.c_double * nSensitivity
         sensitivity_array = sensitivity_array_type()
-        success = self.hdll.fmi3_getAdjointDerivative(self.fmu, unknowns_array, nUnknowns, knowns_array, nKnowns, seed_array, nSeed, sensitivity_array, nSensitivity)
+        success = self.hdll.fmi3_getAdjointDerivative(instance, unknowns_array, nUnknowns, knowns_array, nKnowns, seed_array, nSeed, sensitivity_array, nSensitivity)
         return (success, list(sensitivity_array))
 
-    def fmi3_enterConfigurationMode(self):
-        return self.hdll.fmi3_enterConfigurationMode(self.fmu)
+    def fmi3_enterConfigurationMode(self, instance):
+        return self.hdll.fmi3_enterConfigurationMode(instance)
 
-    def fmi3_exitConfigurationMode(self):
-        return self.hdll.fmi3_exitConfigurationMode(self.fmu)
+    def fmi3_exitConfigurationMode(self, instance):
+        return self.hdll.fmi3_exitConfigurationMode(instance)
 
-    def fmi3_getIntervalDecimal(self, valueReferences, nValueReferences):
+    def fmi3_getIntervalDecimal(self, instance, valueReferences, nValueReferences):
         vr_array_type = ct.c_uint * nValueReferences
         vr_array = vr_array_type(*valueReferences)
         intervals_array_type = ct.c_double * nValueReferences
         intervals_array = intervals_array_type()
         qualifier_array_type = ct.c_int * nValueReferences
         qualifier_array = qualifier_array_type()
-        success = self.hdll.fmi3_getIntervalDecimal(self.fmu, vr_array, nValueReferences,intervals_array,qualifier_array)
+        success = self.hdll.fmi3_getIntervalDecimal(instance, vr_array, nValueReferences,intervals_array,qualifier_array)
         return (success, list(intervals_array), list(qualifier_array))
 
-    def fmi3_getIntervalFraction(self, valueReferences, nValueReferences):
+    def fmi3_getIntervalFraction(self, instance, valueReferences, nValueReferences):
         vr_array_type = ct.c_uint * nValueReferences
         vr_array = vr_array_type(*valueReferences)
         intervalCounters_array_type = ct.c_uint64 * nValueReferences
@@ -2689,118 +2689,118 @@ class fmi4c:
         resolutions_array = resolutions_array_type()
         qualifier_array_type = ct.c_int * nValueReferences
         qualifier_array = qualifier_array_type()
-        success = self.hdll.fmi3_getIntervalFraction(self.fmu, vr_array, nValueReferences, intervalCounters_array, resolutions_array, qualifier_array)
+        success = self.hdll.fmi3_getIntervalFraction(instance, vr_array, nValueReferences, intervalCounters_array, resolutions_array, qualifier_array)
         return (success, list(intervalCounters_array), list(resolutions_array), list(qualifier_array))
 
-    def fmi3_getShiftDecimal(self, valueReferences, nValueReferences):
+    def fmi3_getShiftDecimal(self, instance, valueReferences, nValueReferences):
         vr_array_type = ct.c_uint * nValueReferences
         vr_array = vr_array_type(*valueReferences)
         shifts_array_type = ct.c_double * nValueReferences
         shifts_array = shits_array_type()
-        success = self.hdll.fmi3_getShiftDecimal(self.fmu, vr_array, nValueReferences, shifts_array)
+        success = self.hdll.fmi3_getShiftDecimal(instance, vr_array, nValueReferences, shifts_array)
         return (success, list(shifts_array))
 
-    def fmi3_getShiftFraction(self, valueReferences, nValueReferences):
+    def fmi3_getShiftFraction(self, instance, valueReferences, nValueReferences):
         uint64_array_type = ct.c_uint64 * nValueReferences
         shiftCounters_array = uint64_array_type()
         resolutions_array = uint64_array_type()
         vr_array_type = ct.c_uint * nValueReferences
         vr_array = vr_array_type(*valueReferences)
-        success = self.hdll.fmi3_getShiftFraction(self.fmu, vr_array, nValueReferences, shiftCounters_array, resolutions_array)
+        success = self.hdll.fmi3_getShiftFraction(instance, vr_array, nValueReferences, shiftCounters_array, resolutions_array)
         return (success, list(shiftCounters_array), list(resolutions_array))
 
-    def fmi3_setIntervalDecimal(self, valueReferences, nValueReferences, intervals):
+    def fmi3_setIntervalDecimal(self, instance, valueReferences, nValueReferences, intervals):
         float64_array_type = ct.c_double * nValueReferences
         intervals_array = float64_array_type(*intervals)
         vr_array_type = ct.c_uint * nValueReferences
         vr_array = vr_array_type(*valueReferences)
-        return self.hdll.fmi3_setIntervalDecimal(self.fmu, vr_array, nValueReferences, intervals_array)
+        return self.hdll.fmi3_setIntervalDecimal(instance, vr_array, nValueReferences, intervals_array)
 
-    def fmi3_setIntervalFraction(self, valueReferences, nValueReferences, intervalCounters, resolutions):
+    def fmi3_setIntervalFraction(self, instance, valueReferences, nValueReferences, intervalCounters, resolutions):
         vr_array_type = ct.c_uint * nValueReferences
         vr_array = vr_array_type(*valueReferences)
         uint64_array_type = ct.c_uint64 * nValueReferences
         intervalCounters_array = uint64_array_type(*intervalCounters)
         resolutions_array = uint64_array_type(*resolutions)
-        return self.hdll.fmi3_setIntervalFraction(self.fmu, vr_array, nValueReferences, intervalCounters_array, resolutions_array)
+        return self.hdll.fmi3_setIntervalFraction(instance, vr_array, nValueReferences, intervalCounters_array, resolutions_array)
 
-    def fmi3_evaluateDiscreteStates(self):
-        return self.hdll.fmi3_evaluateDiscreteStates(self.fmu)
+    def fmi3_evaluateDiscreteStates(self, instance):
+        return self.hdll.fmi3_evaluateDiscreteStates(instance)
 
-    def fmi3_updateDiscreteStates(self):
+    def fmi3_updateDiscreteStates(self, instance):
         discreteStatesNeedUpdate = ct.c_bool()
         terminateSimulation = ct.c_bool()
         nominalsOfContinuousStatesChanged = ct.c_bool()
         valuesOfContinuousStatesChanged = ct.c_bool()
         nextEventTimeDefined = ct.c_bool()
         nextEventTime = ct.c_double()
-        success = self.hdll.fmi3_updateDiscreteStates(self.fmu, ct.byref(discreteStatesNeedUpdate), ct.byref(terminateSimulation), ct.byref(nominalsOfContinuousStatesChanged), ct.byref(valuesOfContinuousStatesChanged), ct.byref(nextEventTimeDefined), ct.byref(nextEventTime))
+        success = self.hdll.fmi3_updateDiscreteStates(instance, ct.byref(discreteStatesNeedUpdate), ct.byref(terminateSimulation), ct.byref(nominalsOfContinuousStatesChanged), ct.byref(valuesOfContinuousStatesChanged), ct.byref(nextEventTimeDefined), ct.byref(nextEventTime))
         return (success, discreteStatesNeedUpdate.value, terminateSimulation.value, nominalsOfContinuousStatesChanged.value, valuesOfContinuousStatesChanged.value, nextEventTimeDefined.value, nextEventTime.value)
 
-    def fmi3_enterContinuousTimeMode(self):
-        return self.hdll.fmi3_enterContinuousTimeMode(self.fmu)
+    def fmi3_enterContinuousTimeMode(self, instance):
+        return self.hdll.fmi3_enterContinuousTimeMode(instance)
 
-    def fmi3_completedIntegratorStep(self, noSetFMUStatePriorToCurrentPoint):
+    def fmi3_completedIntegratorStep(self, instance, noSetFMUStatePriorToCurrentPoint):
         enterEventMode = ct.c_bool()
         terminateSimulation = ct.c_bool()
-        success = self.hdll.fmi3_completedIntegratorStep(self.fmu, noSetFMUStatePriorToCurrentPoint, ct.byref(enterEventMode), ct.byref(terminateSimulation))
+        success = self.hdll.fmi3_completedIntegratorStep(instance, noSetFMUStatePriorToCurrentPoint, ct.byref(enterEventMode), ct.byref(terminateSimulation))
         return (success, enterEventMode.value, terminateSimulation.value)
 
-    def fmi3_setTime(self, time):
-        return self.hdll.fmi3_setTime(self.fmu, time)
+    def fmi3_setTime(self, instance, time):
+        return self.hdll.fmi3_setTime(instance, time)
 
-    def fmi3_setContinuousStates(self, continuousStates, nContinuousStates):
+    def fmi3_setContinuousStates(self, instance, continuousStates, nContinuousStates):
         float64_array_type = ct.c_double * nContinuousStates
         continuousStates_array = float64_array_type(*continuousStates)
-        return self.hdll.fmi3_setContinuousStates(self.fmu, continuousStates_array, nContinuousStates)
+        return self.hdll.fmi3_setContinuousStates(instance, continuousStates_array, nContinuousStates)
 
-    def fmi3_getContinuousStateDerivatives(self, nContinuousStates):
+    def fmi3_getContinuousStateDerivatives(self, instance, nContinuousStates):
         float64_array_type = ct.c_double * nContinuousStates
         derivatives_array = float64_array_type()
-        success = self.hdll.fmi3_getContinuousStateDerivatives(self.fmu, derivatives_array, nContinuousStates)
+        success = self.hdll.fmi3_getContinuousStateDerivatives(instance, derivatives_array, nContinuousStates)
         return (success, list(derivatives_array))
 
-    def fmi3_getEventIndicators(self, nEventIndicators):
+    def fmi3_getEventIndicators(self, instance, nEventIndicators):
         float64_array_type = ct.c_double * nEventIndicators
         eventIndicators_array = float64_array_type()
-        success = self.hdll.fmi3_getEventIndicators(self.fmu, eventIndicators_array, nEventIndicators)
+        success = self.hdll.fmi3_getEventIndicators(instance, eventIndicators_array, nEventIndicators)
         return (success, list(eventIndicators_array))
 
-    def fmi3_getContinuousStates(self, nContinuousStates):
+    def fmi3_getContinuousStates(self, instance, nContinuousStates):
         float64_array_type = ct.c_double * nContinuousStates
         continuousStates_array = float64_array_type()
-        success = self.hdll.fmi3_getContinuousStates(self.fmu, continuousStates_array, nContinuousStates)
+        success = self.hdll.fmi3_getContinuousStates(instance, continuousStates_array, nContinuousStates)
         return (success, list(continuousStates_array))
 
-    def fmi3_getNominalsOfContinuousStates(self, nContinuousStates):
+    def fmi3_getNominalsOfContinuousStates(self, instance, nContinuousStates):
         float64_array_type = ct.c_double * nContinuousStates
         nominals_array = float64_array_type()
-        success = self.hdll.fmi3_getNominalsOfContinuousStates(self.fmu, nominals_array, nContinuousStates)
+        success = self.hdll.fmi3_getNominalsOfContinuousStates(instance, nominals_array, nContinuousStates)
         return (success, list(nominals_array))
 
-    def fmi3_getNumberOfEventIndicators(self):
+    def fmi3_getNumberOfEventIndicators(self, instance):
         nEventIndicators = ct.c_size_t()
-        success = self.hdll.fmi3_getNumberOfEventIndicators(self.fmu, ct.byref(nEventIndicators))
+        success = self.hdll.fmi3_getNumberOfEventIndicators(instance, ct.byref(nEventIndicators))
         return (success, nEventIndicators.value)
 
-    def fmi3_getNumberOfContinuousStates(self):
+    def fmi3_getNumberOfContinuousStates(self, instance):
         nContinuousStates = ct.c_size_t()
-        success = self.hdll.fmi3_getNumberOfContinuousStates(self.fmu, ct.byref(nContinuousStates))
+        success = self.hdll.fmi3_getNumberOfContinuousStates(instance, ct.byref(nContinuousStates))
         return (success, nContinuousStates.value)
 
-    def fmi3_enterStepMode(self):
-        return self.hdll.fmi3_enterStepMode(self.fmu)
+    def fmi3_enterStepMode(self, instance):
+        return self.hdll.fmi3_enterStepMode(instance)
 
-    def fmi3_getOutputDerivatives(self, valueReferences, nValueReferences, orders, nValues):
+    def fmi3_getOutputDerivatives(self, instance, valueReferences, nValueReferences, orders, nValues):
         vr_array_type = ct.c_uint * nValueReferences
         vr_array = vr_array_type(*valueReferences)
         int32_array_type = ct.c_int32 * nValueReferences
         orders_array = int32_array_type(*orders)
         float64_array_type = ct.c_double * nValues
         values_array = float64_array_type()
-        success = self.hdll.fmi3_getOutputDerivatives(self.fmu, vr_array, nValueReferences, orders_array, values_array, nValues)
+        success = self.hdll.fmi3_getOutputDerivatives(instance, vr_array, nValueReferences, orders_array, values_array, nValues)
         return (success, list(values_array))
 
-    def fmi3_activateModelPartition(self, clockReference, activationTime):
-        return self.hdll.fmi3_activateModelPartition(self.fmu, clockReference, activationTime)
+    def fmi3_activateModelPartition(self, instance, clockReference, activationTime):
+        return self.hdll.fmi3_activateModelPartition(instance, clockReference, activationTime)
         

--- a/fmi4c.py
+++ b/fmi4c.py
@@ -137,7 +137,7 @@ class fmi4c:
         self.hdll.fmi1_setBoolean.argtypes = ct.c_void_p,ct.POINTER(ct.c_uint),ct.c_size_t,ct.POINTER(ct.c_bool),
         self.hdll.fmi1_setString.restype = ct.c_int
         self.hdll.fmi1_setString.argtypes = ct.c_void_p,ct.POINTER(ct.c_uint),ct.c_size_t,ct.POINTER(ct.c_char_p),
-        self.hdll.fmi1_instantiateSlave.restype = ct.c_bool
+        self.hdll.fmi1_instantiateSlave.restype = ct.c_void_p
         self.hdll.fmi1_instantiateSlave.argtypes = ct.c_void_p,ct.c_char_p,ct.c_double,ct.c_bool,ct.c_bool,ct.c_void_p,ct.c_void_p,ct.c_void_p,ct.c_void_p, ct.c_bool,
         self.hdll.fmi1_initializeSlave.restype = ct.c_int
         self.hdll.fmi1_initializeSlave.argtypes = ct.c_void_p,ct.c_double,ct.c_bool,ct.c_double,
@@ -167,7 +167,7 @@ class fmi4c:
         self.hdll.fmi1_getStringStatus.argtypes = ct.c_void_p,ct.c_int,ct.POINTER(ct.c_char_p),
         self.hdll.fmi1_getModelTypesPlatform.restype = ct.c_char_p
         self.hdll.fmi1_getModelTypesPlatform.argtypes = ct.c_void_p,
-        self.hdll.fmi1_instantiateModel.restype = ct.c_bool
+        self.hdll.fmi1_instantiateModel.restype = ct.c_void_p
         self.hdll.fmi1_instantiateModel.argtypes = ct.c_void_p,ct.c_void_p,ct.c_void_p,ct.c_bool,
         self.hdll.fmi1_freeModelInstance.restype = None
         self.hdll.fmi1_freeModelInstance.argtypes = ct.c_void_p,
@@ -1125,132 +1125,132 @@ class fmi4c:
     def fmi1_getVersion(self):
         return self.hdll.fmi1_getVersion(self.fmu).decode();
 
-    def fmi1_setDebugLogging(self, loggingOn):
-        return self.hdll.fmi1_setDebugLogging(self.fmu, loggingOn);
+    def fmi1_setDebugLogging(self, instance, loggingOn):
+        return self.hdll.fmi1_setDebugLogging(instance, loggingOn);
 
-    def fmi1_getReal(self, valueReferences, nValueReferences):
+    def fmi1_getReal(self, instance, valueReferences, nValueReferences):
         uint_array_type = ct.c_uint * nValueReferences
         double_array_type = ct.c_double * nValueReferences
         valueReferencesArray = uint_array_type(1,2)
         valuesArray = double_array_type()
-        success = self.hdll.fmi1_getReal(self.fmu, valueReferencesArray, nValueReferences, valuesArray)
+        success = self.hdll.fmi1_getReal(instance, valueReferencesArray, nValueReferences, valuesArray)
         return [success, list(valuesArray)]
 
-    def fmi1_getInteger(self, valueReferences, nValueReferences):
+    def fmi1_getInteger(self, instance, valueReferences, nValueReferences):
         uint_array_type = ct.c_uint * nValueReferences
         double_array_type = ct.c_int * nValueReferences
         valueReferencesArray = uint_array_type(*valueReferences)
         valuesArray = double_array_type(*[1]*nValueReferences)
-        success = self.hdll.fmi1_getInteger(self.fmu, valueReferencesArray, nValueReferences, valuesArray)
+        success = self.hdll.fmi1_getInteger(instance, valueReferencesArray, nValueReferences, valuesArray)
         return [success, list(valuesArray)]
 
-    def fmi1_getBoolean(self, valueReferences, nValueReferences):
+    def fmi1_getBoolean(self, instance, valueReferences, nValueReferences):
         uint_array_type = ct.c_uint * nValueReferences
         double_array_type = ct.c_bool * nValueReferences
         valueReferencesArray = uint_array_type(*valueReferences)
         valuesArray = double_array_type(*[1]*nValueReferences)
-        success = self.hdll.fmi1_getBoolean(self.fmu, valueReferencesArray, nValueReferences, valuesArray)
+        success = self.hdll.fmi1_getBoolean(instance, valueReferencesArray, nValueReferences, valuesArray)
         return [success, list(valuesArray)]
 
-    def fmi1_getString(self, valueReferences, nValueReferences):
+    def fmi1_getString(self, instance, valueReferences, nValueReferences):
         uint_array_type = ct.c_uint * nValueReferences
         double_array_type = ct.c_char_p * nValueReferences
         valueReferencesArray = uint_array_type(*valueReferences)
         valuesArray = double_array_type(*[1]*nValueReferences)
-        success = self.hdll.fmi1_getString(self.fmu, valueReferencesArray, nValueReferences, valuesArray)
+        success = self.hdll.fmi1_getString(instance, valueReferencesArray, nValueReferences, valuesArray)
         return [success, list(valuesArray)]
 
-    def fmi1_setReal(self, valueReferences, nValueReferences, values):
+    def fmi1_setReal(self, instance, valueReferences, nValueReferences, values):
         uint_array_type = ct.c_uint * nValueReferences
         double_array_type = ct.c_double * nValueReferences
         valueReferencesArray = uint_array_type(*valueReferences)
         valuesArray = double_array_type(*values)
-        return self.hdll.fmi1_setReal(self.fmu, valueReferencesArray, nValueReferences, valuesArray)
+        return self.hdll.fmi1_setReal(instance, valueReferencesArray, nValueReferences, valuesArray)
 
-    def fmi1_setInteger(self, valueReferences, nValueReferences, values):
+    def fmi1_setInteger(self, instance, valueReferences, nValueReferences, values):
         uint_array_type = ct.c_uint * nValueReferences
         double_array_type = ct.c_int * nValueReferences
         valueReferencesArray = uint_array_type(*valueReferences)
         valuesArray = double_array_type(*values)
-        return self.hdll.fmi1_setInteger(self.fmu, valueReferencesArray, nValueReferences, valuesArray)
+        return self.hdll.fmi1_setInteger(instance, valueReferencesArray, nValueReferences, valuesArray)
 
-    def fmi1_setBoolean(self, valueReferences, nValueReferences, values):
+    def fmi1_setBoolean(self, instance, valueReferences, nValueReferences, values):
         uint_array_type = ct.c_uint * nValueReferences
         double_array_type = ct.c_bool * nValueReferences
         valueReferencesArray = uint_array_type(*valueReferences)
         valuesArray = double_array_type(*values)
-        return self.hdll.fmi1_setBoolean(self.fmu, valueReferencesArray, nValueReferences, valuesArray)
+        return self.hdll.fmi1_setBoolean(instance, valueReferencesArray, nValueReferences, valuesArray)
 
-    def fmi1_setString(self, valueReferences, nValueReferences, values):
+    def fmi1_setString(self, instance, valueReferences, nValueReferences, values):
         uint_array_type = ct.c_uint * nValueReferences
         double_array_type = ct.c_char_p * nValueReferences
         valueReferencesArray = uint_array_type(*valueReferences)
         valuesArray = double_array_type(*values)
-        return self.hdll.fmi1_setString(self.fmu, valueReferencesArray, nValueReferences, valuesArray)
+        return self.hdll.fmi1_setString(instance, valueReferencesArray, nValueReferences, valuesArray)
 
     def fmi1_instantiateSlave(self, mimeType, timeOut, visible, interactive, loggingOn):
         return self.hdll.fmi1_instantiateSlave(self.fmu, mimeType, timeOut, visible, interactive, None, None, None, None, loggingOn)
 
-    def fmi1_initializeSlave(self, startTime, stopTimeDefined, stopTime):
-        return self.hdll.fmi1_initializeSlave(self.fmu, startTime, stopTimeDefined, stopTime)
+    def fmi1_initializeSlave(self, instance, startTime, stopTimeDefined, stopTime):
+        return self.hdll.fmi1_initializeSlave(instance, startTime, stopTimeDefined, stopTime)
 
-    def fmi1_resetSlave(self):
-        return self.hdll.fmi1_resetSlave(self.fmu)
+    def fmi1_resetSlave(self, instance):
+        return self.hdll.fmi1_resetSlave(instance)
 
-    def fmi1_terminateSlave(self):
-        return self.hdll.fmi1_terminateSlave(self.fmu)
+    def fmi1_terminateSlave(self, instance):
+        return self.hdll.fmi1_terminateSlave(instance)
 
-    def fmi1_freeSlaveInstance(self):
-        self.hdll.fmi1_freeSlaveInstance(self.fmu)
+    def fmi1_freeSlaveInstance(self, instance):
+        self.hdll.fmi1_freeSlaveInstance(instance)
 
-    def fmi1_setRealInputDerivatives(self, valueReferences, nValueReferences, orders, values):
+    def fmi1_setRealInputDerivatives(self, instance, valueReferences, nValueReferences, orders, values):
         uint_array_type = ct.c_uint * nValueReferences
         int_array_type = ct.c_int * nValueReferences
         double_array_type = ct.c_double * nValueReferences
         valueReferencesArray = uint_array_type(*valueReferences)
         ordersArray = int_array_type(*orders)
         valuesArray = double_array_type(*values)
-        return self.hdll.fmi1_setRealInputDerivatives(self.fmu, valueReferencesArray, nValueReferences, ordersArray, valuesArray)
+        return self.hdll.fmi1_setRealInputDerivatives(instance, valueReferencesArray, nValueReferences, ordersArray, valuesArray)
 
-    def fmi1_getRealOutputDerivatives(self, valueReferences, nValueReferences, orders):
+    def fmi1_getRealOutputDerivatives(self, instance, valueReferences, nValueReferences, orders):
         uint_array_type = ct.c_uint * nValueReferences
         int_array_type = ct.c_int * nValueReferences
         double_array_type = ct.c_double * nValueReferences
         valueReferencesArray = uint_array_type(*valueReferences)
         ordersArray = int_array_type(*orders)
         valuesArray = double_array_type(*[1]*nValueReferences)
-        success = self.hdll.fmi1_getRealOutputDerivatives(self.fmu, valueReferencesArray, nValueReferences, ordersArray, valuesArray)
+        success = self.hdll.fmi1_getRealOutputDerivatives(instance, valueReferencesArray, nValueReferences, ordersArray, valuesArray)
         return [success, list(valuesArray)]
 
-    def fmi1_cancelStep(self):
-        return self.hdll.fmi1_cancelStep(self.fmu)
+    def fmi1_cancelStep(self, instance):
+        return self.hdll.fmi1_cancelStep(instance)
 
-    def fmi1_doStep(self, currentCommunicationPoint, communicationStepSize, newStep):
-        return self.hdll.fmi1_doStep(self.fmu, currentCommunicationPoint, communicationStepSize, newStep)
+    def fmi1_doStep(self, instance, currentCommunicationPoint, communicationStepSize, newStep):
+        return self.hdll.fmi1_doStep(instance, currentCommunicationPoint, communicationStepSize, newStep)
 
-    def fmi1_getStatus(self, statusKind):
+    def fmi1_getStatus(self, instance, statusKind):
         value = ct.c_int()
-        success = self.hdll.fmi1_getStatus(self.fmu, statusKind, ct.byref(value))
+        success = self.hdll.fmi1_getStatus(instance, statusKind, ct.byref(value))
         return [success, value]
 
-    def fmi1_getRealStatus(self, statusKind):
+    def fmi1_getRealStatus(self, instance, statusKind):
         value = ct.c_double()
-        success = self.hdll.fmi1_getRealStatus(self.fmu, statusKind, ct.byref(value))
+        success = self.hdll.fmi1_getRealStatus(instance, statusKind, ct.byref(value))
         return [success, value]
 
-    def fmi1_getIntegerStatus(self, statusKind):
+    def fmi1_getIntegerStatus(self, instance, statusKind):
         value = ct.c_int()
-        success = self.hdll.fmi1_getIntegerStatus(self.fmu, statusKind, ct.byref(value))
+        success = self.hdll.fmi1_getIntegerStatus(instance, statusKind, ct.byref(value))
         return [success, value]
 
-    def fmi1_getBooleanStatus(self, statusKind):
+    def fmi1_getBooleanStatus(self, instance, statusKind):
         value = ct.c_bool()
-        success = self.hdll.fmi1_getBooleanStatus(self.fmu, statusKind, ct.byref(value))
+        success = self.hdll.fmi1_getBooleanStatus(instance, statusKind, ct.byref(value))
         return [success, value]
 
-    def fmi1_getStringStatus(self, statusKind):
+    def fmi1_getStringStatus(self, instance, statusKind):
         value = ct.c_char_p()
-        success = self.hdll.fmi1_getStringStatus(self.fmu, statusKind, ct.byref(value))
+        success = self.hdll.fmi1_getStringStatus(instance, statusKind, ct.byref(value))
         return [success, value.decode()]
 
     def fmi1_getModelTypesPlatform(self):
@@ -1259,59 +1259,59 @@ class fmi4c:
     def fmi1_instantiateModel(self, loggingOn):
         return self.hdll.fmi1_instantiateModel(self.fmu, None, None, None, loggingOn)
 
-    def fmi1_freeModelInstance(self):
-        return self.hdll.fmi1_freeModelInstance(self.fmu)
+    def fmi1_freeModelInstance(self, instance):
+        return self.hdll.fmi1_freeModelInstance(instance)
 
-    def fmi1_setTime(self, time):
-        return self.hdll.fmi1_setTime(self.fmu, time)
+    def fmi1_setTime(self, instance, time):
+        return self.hdll.fmi1_setTime(instance, time)
 
-    def fmi1_setContinuousStates(self, continuousStates, nContinuousStates):
+    def fmi1_setContinuousStates(self, instance, continuousStates, nContinuousStates):
         double_array_type = ct.c_double * nContinuousStates
         continuousStatesArray = double_array_type(*continuousStates)
-        return self.hdll.fmi1_setContinuousStates(self.fmu, continuousStatesArray, nContinuousStates)
+        return self.hdll.fmi1_setContinuousStates(instance, continuousStatesArray, nContinuousStates)
 
-    def fmi1_completedIntegratorStep(self, callEventUpdate):
-        return self.hdll.fmi1_completedIntegratorStep(self.fmu, callEventUpdate)
+    def fmi1_completedIntegratorStep(self, instance, callEventUpdate):
+        return self.hdll.fmi1_completedIntegratorStep(instance, callEventUpdate)
 
-    def fmi1_initialize(self, toleranceControlled, relativeTolerance, eventInfo):
-        return self.hdll.fmi1_initialize(self.fmu, toleranceControlled, relativeTolerance, eventInfo)
+    def fmi1_initialize(self, instance, toleranceControlled, relativeTolerance, eventInfo):
+        return self.hdll.fmi1_initialize(instance, toleranceControlled, relativeTolerance, eventInfo)
 
-    def fmi1_getDerivatives(self, nDerivatives):
+    def fmi1_getDerivatives(self, instance, nDerivatives):
         double_array_type = ct.c_double * nDerivatives
         derivativesArray = double_array_type()
-        success = self.hdll.fmi1_getDerivatives(self.fmu, derivativesArray, nDerivatives)
+        success = self.hdll.fmi1_getDerivatives(instance, derivativesArray, nDerivatives)
         return [success, list(derivativesArray)]
 
-    def fmi1_getEventIndicators(self, indicators, nIndicators):
+    def fmi1_getEventIndicators(self, instance, indicators, nIndicators):
         double_array_type = ct.c_double * nIndicators
         indicatorsArray = double_array_type(*indicators)
-        success = self.hdll.fmi1_getEventIndicators(self.fmu, indicatorsArray, nIndicators)
+        success = self.hdll.fmi1_getEventIndicators(instance, indicatorsArray, nIndicators)
         return [success, list(indicatorsArray)]
 
-    def fmi1_eventUpdate(self, intermediateResults, eventInfo):
-        return self.hdll.fmi1_eventUpdate(self.fmu, intermediateResults, eventInfo)
+    def fmi1_eventUpdate(self, instance, intermediateResults, eventInfo):
+        return self.hdll.fmi1_eventUpdate(instance, intermediateResults, eventInfo)
 
-    def fmi1_getContinuousStates(self, nStates):
+    def fmi1_getContinuousStates(self, instance, nStates):
         double_array_type = ct.c_double * nStates
         statesArray = double_array_type()
-        success = self.hdll.fmi1_getContinuousStates(self.fmu, statesArray, nStates)
+        success = self.hdll.fmi1_getContinuousStates(instance, statesArray, nStates)
         return [success, list(statesArray)]
 
-    def fmi1_getNominalContinuousStates(self, nNominals):
+    def fmi1_getNominalContinuousStates(self, instance, nNominals):
         double_array_type = ct.c_double * nNominals
         nominalsArray = double_array_type()
-        success = self.hdll.fmi1_getNominalContinuousStates(self.fmu, nominalsArray, nNominals)
+        success = self.hdll.fmi1_getNominalContinuousStates(instance, nominalsArray, nNominals)
         return [success, list(nominalsArray)]
 
 
-    def fmi1_getStateValueReferences(self, nValueReferences):
+    def fmi1_getStateValueReferences(self, instance, nValueReferences):
         uint_array_type = ct.c_uint * nValueReferences
         valueReferencesArray = uint_array_type(*[1]*nValueReferences)
-        success = self.hdll.fmi1_getStateValueReferences(self.fmu, valueReferencesArray, nValueReferences)
+        success = self.hdll.fmi1_getStateValueReferences(instance, valueReferencesArray, nValueReferences)
         return [success, list(valueReferencesArray)]
 
-    def fmi1_terminate(self):
-        return self.hdll.fmi1_terminate(self.fmu)
+    def fmi1_terminate(self, instance):
+        return self.hdll.fmi1_terminate(instance)
 
     def fmi2_defaultStartTimeDefined(self):
         return self.hdll.fmi2_defaultStartTimeDefined(self.fmu)

--- a/include/fmi4c.h
+++ b/include/fmi4c.h
@@ -189,7 +189,7 @@ FMI4C_DLLAPI fmi2DataType fmi2_getVariableDataType(fmi2VariableHandle* var);
 
 FMI4C_DLLAPI const char* fmi2_getTypesPlatform(fmiHandle* fmu);
 FMI4C_DLLAPI const char* fmi2_getVersion(fmiHandle* fmu);
-FMI4C_DLLAPI fmi2Status fmi2_setDebugLogging(fmiHandle *fmu, fmi2Boolean loggingOn, size_t nCategories, const fmi2String categories[]);
+FMI4C_DLLAPI fmi2Status fmi2_setDebugLogging(fmiHandle *fmu, fmi2Component comp, fmi2Boolean loggingOn, size_t nCategories, const fmi2String categories[]);
 FMI4C_DLLAPI const char* fmi2_getGuid(fmiHandle *fmu);
 
 FMI4C_DLLAPI const char* fmi2cs_getModelIdentifier(fmiHandle* fmu);
@@ -231,14 +231,14 @@ FMI4C_DLLAPI bool fmi2_getModelStructureDependencyKindsDefined(fmi2ModelStructur
 FMI4C_DLLAPI void fmi2_getModelStructureDependencies(fmi2ModelStructureHandle *handle, int *dependencies, size_t numberOfDependencies);
 FMI4C_DLLAPI void fmi2_getModelStructureDependencyKinds(fmi2ModelStructureHandle *handle, int *dependencyKinds, size_t numberOfDependencies);
 
-FMI4C_DLLAPI bool fmi2_instantiate(fmiHandle *fmu, fmi2Type type, fmi2CallbackLogger logger, fmi2CallbackAllocateMemory allocateMemory, fmi2CallbackFreeMemory freeMemory, fmi2StepFinished stepFinished, fmi2ComponentEnvironment componentEnvironment, fmi2Boolean visible, fmi2Boolean loggingOn);
-FMI4C_DLLAPI void fmi2_freeInstance(fmiHandle* fmu);
+FMI4C_DLLAPI fmi2Component fmi2_instantiate(fmiHandle *fmu, fmi2Type type, fmi2CallbackLogger logger, fmi2CallbackAllocateMemory allocateMemory, fmi2CallbackFreeMemory freeMemory, fmi2StepFinished stepFinished, fmi2ComponentEnvironment componentEnvironment, fmi2Boolean visible, fmi2Boolean loggingOn);
+FMI4C_DLLAPI void fmi2_freeInstance(fmiHandle *fmu, fmi2Component comp);
 
-FMI4C_DLLAPI fmi2Status fmi2_setupExperiment(fmiHandle *fmu, fmi2Boolean toleranceDefined, fmi2Real tolerance, fmi2Real startTime, fmi2Boolean stopTimeDefined, fmi2Real stopTime);
-FMI4C_DLLAPI fmi2Status fmi2_enterInitializationMode(fmiHandle* fmu);
-FMI4C_DLLAPI fmi2Status fmi2_exitInitializationMode(fmiHandle* fmu);
-FMI4C_DLLAPI fmi2Status fmi2_terminate(fmiHandle* fmu);
-FMI4C_DLLAPI fmi2Status fmi2_reset(fmiHandle* fmu);
+FMI4C_DLLAPI fmi2Status fmi2_setupExperiment(fmiHandle *fmu, fmi2Component comp, fmi2Boolean toleranceDefined, fmi2Real tolerance, fmi2Real startTime, fmi2Boolean stopTimeDefined, fmi2Real stopTime);
+FMI4C_DLLAPI fmi2Status fmi2_enterInitializationMode(fmiHandle* fmu, fmi2Component comp);
+FMI4C_DLLAPI fmi2Status fmi2_exitInitializationMode(fmiHandle* fmu, fmi2Component comp);
+FMI4C_DLLAPI fmi2Status fmi2_terminate(fmiHandle* fmu, fmi2Component comp);
+FMI4C_DLLAPI fmi2Status fmi2_reset(fmiHandle* fmu, fmi2Component comp);
 
 FMI4C_DLLAPI int fmi2_getNumberOfUnits(fmiHandle *fmu);
 FMI4C_DLLAPI fmi2UnitHandle *fmi2_getUnitByIndex(fmiHandle *fmu, int i);
@@ -248,35 +248,35 @@ FMI4C_DLLAPI void fmi2_getBaseUnit(fmi2UnitHandle *unit, double *factor, double 
 FMI4C_DLLAPI int fmi2_getNumberOfDisplayUnits(fmi2UnitHandle *unit);
 FMI4C_DLLAPI void fmi2_getDisplayUnitByIndex(fmi2UnitHandle *unit, int id, const char **name, double *factor, double *offset);
 
-FMI4C_DLLAPI fmi2Status fmi2_getReal(fmiHandle* fmu, const fmi2ValueReference valueReferences[], size_t nValueReferences, fmi2Real values[]);
-FMI4C_DLLAPI fmi2Status fmi2_getInteger(fmiHandle* fmu, const fmi2ValueReference valueReferences[], size_t nValueReferences, fmi2Integer values[]);
-FMI4C_DLLAPI fmi2Status fmi2_getBoolean(fmiHandle* fmu, const fmi2ValueReference valueReferences[], size_t nValueReferences, fmi2Boolean values[]);
-FMI4C_DLLAPI fmi2Status fmi2_getString(fmiHandle* fmu, const fmi2ValueReference valueReferences[], size_t nValueReferences, fmi2String values[]);
+FMI4C_DLLAPI fmi2Status fmi2_getReal(fmiHandle* fmu, fmi2Component comp, const fmi2ValueReference valueReferences[], size_t nValueReferences, fmi2Real values[]);
+FMI4C_DLLAPI fmi2Status fmi2_getInteger(fmiHandle* fmu, fmi2Component comp, const fmi2ValueReference valueReferences[], size_t nValueReferences, fmi2Integer values[]);
+FMI4C_DLLAPI fmi2Status fmi2_getBoolean(fmiHandle* fmu, fmi2Component comp, const fmi2ValueReference valueReferences[], size_t nValueReferences, fmi2Boolean values[]);
+FMI4C_DLLAPI fmi2Status fmi2_getString(fmiHandle* fmu, fmi2Component comp, const fmi2ValueReference valueReferences[], size_t nValueReferences, fmi2String values[]);
 
-FMI4C_DLLAPI fmi2Status fmi2_setReal(fmiHandle* fmu, const fmi2ValueReference valueReferences[], size_t nValueReferences, const fmi2Real values[]);
-FMI4C_DLLAPI fmi2Status fmi2_setInteger(fmiHandle* fmu, const fmi2ValueReference valueReferences[], size_t nValueReferences, const fmi2Integer values[]);
-FMI4C_DLLAPI fmi2Status fmi2_setBoolean(fmiHandle* fmu, const fmi2ValueReference valueReferences[], size_t nValueReferences, const fmi2Boolean values[]);
-FMI4C_DLLAPI fmi2Status fmi2_setString(fmiHandle* fmu, const fmi2ValueReference valueReferences[], size_t nValueReferences, const fmi2String values[]);
+FMI4C_DLLAPI fmi2Status fmi2_setReal(fmiHandle* fmu, fmi2Component comp, const fmi2ValueReference valueReferences[], size_t nValueReferences, const fmi2Real values[]);
+FMI4C_DLLAPI fmi2Status fmi2_setInteger(fmiHandle* fmu, fmi2Component comp, const fmi2ValueReference valueReferences[], size_t nValueReferences, const fmi2Integer values[]);
+FMI4C_DLLAPI fmi2Status fmi2_setBoolean(fmiHandle* fmu, fmi2Component comp, const fmi2ValueReference valueReferences[], size_t nValueReferences, const fmi2Boolean values[]);
+FMI4C_DLLAPI fmi2Status fmi2_setString(fmiHandle* fmu, fmi2Component comp, const fmi2ValueReference valueReferences[], size_t nValueReferences, const fmi2String values[]);
 
-FMI4C_DLLAPI fmi2Status fmi2_getFMUstate(fmiHandle* fmu,
+FMI4C_DLLAPI fmi2Status fmi2_getFMUstate(fmiHandle* fmu, fmi2Component comp,
                                          fmi2FMUstate* FMUstate);
-FMI4C_DLLAPI fmi2Status fmi2_setFMUstate(fmiHandle* fmu,
+FMI4C_DLLAPI fmi2Status fmi2_setFMUstate(fmiHandle* fmu, fmi2Component comp,
                                          fmi2FMUstate FMUstate);
-FMI4C_DLLAPI fmi2Status fmi2_freeFMUstate(fmiHandle* fmu,
+FMI4C_DLLAPI fmi2Status fmi2_freeFMUstate(fmiHandle* fmu, fmi2Component comp,
                                           fmi2FMUstate* FMUstate);
-FMI4C_DLLAPI fmi2Status fmi2_serializedFMUstateSize(fmiHandle* fmu,
+FMI4C_DLLAPI fmi2Status fmi2_serializedFMUstateSize(fmiHandle* fmu, fmi2Component comp,
                                                     fmi2FMUstate FMUstate,
                                                     size_t* size);
-FMI4C_DLLAPI fmi2Status fmi2_serializeFMUstate(fmiHandle* fmu,
+FMI4C_DLLAPI fmi2Status fmi2_serializeFMUstate(fmiHandle* fmu, fmi2Component comp,
                                                fmi2FMUstate FMUstate,
                                                fmi2Byte serializedState[],
                                                size_t size);
-FMI4C_DLLAPI fmi2Status fmi2_deSerializeFMUstate(fmiHandle* fmu,
+FMI4C_DLLAPI fmi2Status fmi2_deSerializeFMUstate(fmiHandle* fmu, fmi2Component comp,
                                                  const fmi2Byte serializedState[],
                                                  size_t size,
                                                  fmi2FMUstate* FMUstate);
 
-FMI4C_DLLAPI fmi2Status fmi2_getDirectionalDerivative(fmiHandle* fmu,
+FMI4C_DLLAPI fmi2Status fmi2_getDirectionalDerivative(fmiHandle* fmu, fmi2Component comp,
                                                       const fmi2ValueReference unknownReferences[],
                                                       size_t nUnknown,
                                                       const fmi2ValueReference knownReferences[],
@@ -284,45 +284,45 @@ FMI4C_DLLAPI fmi2Status fmi2_getDirectionalDerivative(fmiHandle* fmu,
                                                       const fmi2Real dvKnown[],
                                                       fmi2Real dvUnknown[]);
 
-FMI4C_DLLAPI fmi2Status fmi2_enterEventMode(fmiHandle* fmu);
-FMI4C_DLLAPI fmi2Status fmi2_newDiscreteStates(fmiHandle* fmu, fmi2EventInfo* eventInfo);
-FMI4C_DLLAPI fmi2Status fmi2_enterContinuousTimeMode(fmiHandle* fmu);
-FMI4C_DLLAPI fmi2Status fmi2_completedIntegratorStep(fmiHandle* fmu,
+FMI4C_DLLAPI fmi2Status fmi2_enterEventMode(fmiHandle* fmu, fmi2Component comp);
+FMI4C_DLLAPI fmi2Status fmi2_newDiscreteStates(fmiHandle* fmu, fmi2Component comp, fmi2EventInfo* eventInfo);
+FMI4C_DLLAPI fmi2Status fmi2_enterContinuousTimeMode(fmiHandle* fmu, fmi2Component comp);
+FMI4C_DLLAPI fmi2Status fmi2_completedIntegratorStep(fmiHandle* fmu, fmi2Component comp,
                                                      fmi2Boolean noSetFMUStatePriorToCurrentPoint,
                                                      fmi2Boolean* enterEventMode,
                                                      fmi2Boolean* terminateSimulation);
 
-FMI4C_DLLAPI fmi2Status fmi2_setTime(fmiHandle* fmu,
+FMI4C_DLLAPI fmi2Status fmi2_setTime(fmiHandle* fmu, fmi2Component comp,
                                      fmi2Real time);
-FMI4C_DLLAPI fmi2Status fmi2_setContinuousStates(fmiHandle* fmu,
+FMI4C_DLLAPI fmi2Status fmi2_setContinuousStates(fmiHandle* fmu, fmi2Component comp,
                                                  const fmi2Real x[],
                                                  size_t nx);
 
-FMI4C_DLLAPI fmi2Status fmi2_getDerivatives(fmiHandle* fmu,
+FMI4C_DLLAPI fmi2Status fmi2_getDerivatives(fmiHandle* fmu, fmi2Component comp,
                                             fmi2Real derivatives[],
                                             size_t nx);
-FMI4C_DLLAPI fmi2Status fmi2_getEventIndicators(fmiHandle* fmu,
+FMI4C_DLLAPI fmi2Status fmi2_getEventIndicators(fmiHandle* fmu, fmi2Component comp,
                                                 fmi2Real eventIndicators[],
                                                 size_t ni);
-FMI4C_DLLAPI fmi2Status fmi2_getContinuousStates(fmiHandle* fmu,
+FMI4C_DLLAPI fmi2Status fmi2_getContinuousStates(fmiHandle* fmu, fmi2Component comp,
                                                  fmi2Real x[],
                                                  size_t nx);
-FMI4C_DLLAPI fmi2Status fmi2_getNominalsOfContinuousStates(fmiHandle* fmu,
+FMI4C_DLLAPI fmi2Status fmi2_getNominalsOfContinuousStates(fmiHandle* fmu, fmi2Component comp,
                                                            fmi2Real x_nominal[],
                                                            size_t nx);
 
-FMI4C_DLLAPI fmi2Status fmi2_setRealInputDerivatives(fmiHandle* fmu,
+FMI4C_DLLAPI fmi2Status fmi2_setRealInputDerivatives(fmiHandle* fmu, fmi2Component comp,
                                                      const fmi2ValueReference vr[],
                                                      size_t nvr,
                                                      const fmi2Integer order[],
                                                      const fmi2Real value[]);
-FMI4C_DLLAPI fmi2Status fmi2_getRealOutputDerivatives (fmiHandle* fmu,
+FMI4C_DLLAPI fmi2Status fmi2_getRealOutputDerivatives (fmiHandle* fmu, fmi2Component comp,
                                                       const fmi2ValueReference vr[],
                                                       size_t nvr,
                                                       const fmi2Integer order[],
                                                       fmi2Real value[]);
 
-FMI4C_DLLAPI fmi2Status fmi2_doStep(fmiHandle *fmu, fmi2Real currentCommunicationPoint, fmi2Real communicationStepSize, fmi2Boolean noSetFMUStatePriorToCurrentPoint);
+FMI4C_DLLAPI fmi2Status fmi2_doStep(fmiHandle *fmu, fmi2Component comp, fmi2Real currentCommunicationPoint, fmi2Real communicationStepSize, fmi2Boolean noSetFMUStatePriorToCurrentPoint);
 FMI4C_DLLAPI fmi2Status fmi2_cancelStep(fmiHandle* fmu);
 
 FMI4C_DLLAPI fmi2Status fmi2_getStatus(fmiHandle* fmu, const fmi2StatusKind s, fmi2Status* value);

--- a/include/fmi4c.h
+++ b/include/fmi4c.h
@@ -556,56 +556,56 @@ FMI4C_DLLAPI bool fmi3se_getProvidesDirectionalDerivative(fmuHandle* fmu);
 FMI4C_DLLAPI bool fmi3se_getProvidesAdjointDerivatives(fmuHandle* fmu);
 FMI4C_DLLAPI bool fmi3se_getProvidesPerElementDependencies(fmuHandle* fmu);
 
-FMI4C_DLLAPI bool fmi3_instantiateCoSimulation(fmuHandle *fmu,
-                                              fmi3Boolean                    visible,
-                                              fmi3Boolean                    loggingOn,
-                                              fmi3Boolean                    eventModeUsed,
-                                              fmi3Boolean                    earlyReturnAllowed,
-                                              const fmi3ValueReference       requiredIntermediateVariables[],
-                                              size_t                         nRequiredIntermediateVariables,
-                                              fmi3InstanceEnvironment        instanceEnvironment,
-                                              fmi3LogMessageCallback         logMessage,
-                                              fmi3IntermediateUpdateCallback intermediateUpdate);
+FMI4C_DLLAPI fmi3InstanceHandle *fmi3_instantiateCoSimulation(fmuHandle *fmu,
+                                                              fmi3Boolean                    visible,
+                                                              fmi3Boolean                    loggingOn,
+                                                              fmi3Boolean                    eventModeUsed,
+                                                              fmi3Boolean                    earlyReturnAllowed,
+                                                              const fmi3ValueReference       requiredIntermediateVariables[],
+                                                              size_t                         nRequiredIntermediateVariables,
+                                                              fmi3InstanceEnvironment        instanceEnvironment,
+                                                              fmi3LogMessageCallback         logMessage,
+                                                              fmi3IntermediateUpdateCallback intermediateUpdate);
 
-FMI4C_DLLAPI bool fmi3_instantiateModelExchange(fmuHandle *fmu,
-                                               fmi3Boolean                visible,
-                                               fmi3Boolean                loggingOn,
-                                               fmi3InstanceEnvironment    instanceEnvironment,
-                                               fmi3LogMessageCallback     logMessage);
+FMI4C_DLLAPI fmi3InstanceHandle *fmi3_instantiateModelExchange(fmuHandle *fmu,
+                                                               fmi3Boolean                visible,
+                                                               fmi3Boolean                loggingOn,
+                                                               fmi3InstanceEnvironment    instanceEnvironment,
+                                                               fmi3LogMessageCallback     logMessage);
 
 FMI4C_DLLAPI const char* fmi3_getVersion(fmuHandle *fmu);
 
-FMI4C_DLLAPI fmi3Status fmi3_setDebugLogging(fmuHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3_setDebugLogging(fmi3InstanceHandle *instance,
                                             fmi3Boolean loggingOn,
                                             size_t nCategories,
                                             const fmi3String categories[]);
 
-FMI4C_DLLAPI fmi3Status fmi3_getFloat64(fmuHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3_getFloat64(fmi3InstanceHandle *instance,
                                        const fmi3ValueReference valueReferences[],
                                        size_t nValueReferences,
                                        fmi3Float64 values[],
                                        size_t nValues);
 
-FMI4C_DLLAPI fmi3Status fmi3_setFloat64(fmuHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3_setFloat64(fmi3InstanceHandle *instance,
                                        const fmi3ValueReference valueReferences[],
                                        size_t nValueReferences,
                                        const fmi3Float64 values[],
                                        size_t nValues);
 
-FMI4C_DLLAPI fmi3Status fmi3_enterInitializationMode(fmuHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3_enterInitializationMode(fmi3InstanceHandle *instance,
                                                     fmi3Boolean toleranceDefined,
                                                     fmi3Float64 tolerance,
                                                     fmi3Float64 startTime,
                                                     fmi3Boolean stopTimeDefined,
                                                     fmi3Float64 stopTime);
 
-FMI4C_DLLAPI fmi3Status fmi3_exitInitializationMode(fmuHandle *fmu);
+FMI4C_DLLAPI fmi3Status fmi3_exitInitializationMode(fmi3InstanceHandle *instance);
 
-FMI4C_DLLAPI fmi3Status fmi3_terminate(fmuHandle *fmu);
+FMI4C_DLLAPI fmi3Status fmi3_terminate(fmi3InstanceHandle *instance);
 
-FMI4C_DLLAPI void fmi3_freeInstance(fmuHandle *fmu);
+FMI4C_DLLAPI void fmi3_freeInstance(fmi3InstanceHandle *instance);
 
-FMI4C_DLLAPI fmi3Status fmi3_doStep(fmuHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3_doStep(fmi3InstanceHandle *instance,
                                    fmi3Float64 currentCommunicationPoint,
                                    fmi3Float64 communicationStepSize,
                                    fmi3Boolean noSetFMUStatePriorToCurrentPoint,
@@ -614,171 +614,171 @@ FMI4C_DLLAPI fmi3Status fmi3_doStep(fmuHandle *fmu,
                                    fmi3Boolean *earlyReturn,
                                    fmi3Float64 *lastSuccessfulTime);
 
-FMI4C_DLLAPI fmi3Status fmi3_enterEventMode(fmuHandle *fmu);
+FMI4C_DLLAPI fmi3Status fmi3_enterEventMode(fmi3InstanceHandle *instance);
 
-FMI4C_DLLAPI fmi3Status fmi3_reset(fmuHandle *fmu);
+FMI4C_DLLAPI fmi3Status fmi3_reset(fmi3InstanceHandle *instance);
 
-FMI4C_DLLAPI fmi3Status fmi3_getFloat32(fmuHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3_getFloat32(fmi3InstanceHandle *instance,
                                        const fmi3ValueReference valueReferences[],
                                        size_t nValueReferences,
                                        fmi3Float32 values[],
                                        size_t nValues);
 
-FMI4C_DLLAPI fmi3Status fmi3_getInt8(fmuHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3_getInt8(fmi3InstanceHandle *instance,
                                     const fmi3ValueReference valueReferences[],
                                     size_t nValueReferences,
                                     fmi3Int8 values[],
                                     size_t nValues);
 
-FMI4C_DLLAPI fmi3Status fmi3_getUInt8(fmuHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3_getUInt8(fmi3InstanceHandle *instance,
                                      const fmi3ValueReference valueReferences[],
                                      size_t nValueReferences,
                                      fmi3UInt8 values[],
                                      size_t nValues);
 
-FMI4C_DLLAPI fmi3Status fmi3_getInt16(fmuHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3_getInt16(fmi3InstanceHandle *instance,
                                      const fmi3ValueReference valueReferences[],
                                      size_t nValueReferences,
                                      fmi3Int16 values[],
                                      size_t nValues);
 
-FMI4C_DLLAPI fmi3Status fmi3_getUInt16(fmuHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3_getUInt16(fmi3InstanceHandle *instance,
                                       const fmi3ValueReference valueReferences[],
                                       size_t nValueReferences,
                                       fmi3UInt16 values[],
                                       size_t nValues);
 
-FMI4C_DLLAPI fmi3Status fmi3_getInt32(fmuHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3_getInt32(fmi3InstanceHandle *instance,
                                      const fmi3ValueReference valueReferences[],
                                      size_t nValueReferences,
                                      fmi3Int32 values[],
                                      size_t nValues);
 
-FMI4C_DLLAPI fmi3Status fmi3_getUInt32(fmuHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3_getUInt32(fmi3InstanceHandle *instance,
                                       const fmi3ValueReference valueReferences[],
                                       size_t nValueReferences,
                                       fmi3UInt32 values[],
                                       size_t nValues);
 
-FMI4C_DLLAPI fmi3Status fmi3_getInt64(fmuHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3_getInt64(fmi3InstanceHandle *instance,
                                      const fmi3ValueReference valueReferences[],
                                      size_t nValueReferences,
                                      fmi3Int64 values[],
                                      size_t nValues);
 
-FMI4C_DLLAPI fmi3Status fmi3_getUInt64(fmuHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3_getUInt64(fmi3InstanceHandle *instance,
                                       const fmi3ValueReference valueReferences[],
                                       size_t nValueReferences,
                                       fmi3UInt64 values[],
                                       size_t nValues);
 
-FMI4C_DLLAPI fmi3Status fmi3_getBoolean(fmuHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3_getBoolean(fmi3InstanceHandle *instance,
                                        const fmi3ValueReference valueReferences[],
                                        size_t nValueReferences,
                                        fmi3Boolean values[],
                                        size_t nValues);
 
-FMI4C_DLLAPI fmi3Status fmi3_getString(fmuHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3_getString(fmi3InstanceHandle *instance,
                                       const fmi3ValueReference valueReferences[],
                                       size_t nValueReferences,
                                       fmi3String values[],
                                       size_t nValues);
 
-FMI4C_DLLAPI fmi3Status fmi3_getBinary(fmuHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3_getBinary(fmi3InstanceHandle *instance,
                                       const fmi3ValueReference valueReferences[],
                                       size_t nValueReferences,
                                       size_t valueSizes[],
                                       fmi3Binary values[],
                                       size_t nValues);
 
-FMI4C_DLLAPI fmi3Status fmi3_getClock(fmuHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3_getClock(fmi3InstanceHandle *instance,
                                      const fmi3ValueReference valueReferences[],
                                      size_t nValueReferences,
                                      fmi3Clock values[]);
 
-FMI4C_DLLAPI fmi3Status fmi3_setFloat32(fmuHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3_setFloat32(fmi3InstanceHandle *instance,
                                        const fmi3ValueReference valueReferences[],
                                        size_t nValueReferences,
                                        const fmi3Float32 values[],
                                        size_t nValues);
 
-FMI4C_DLLAPI fmi3Status fmi3_setInt8(fmuHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3_setInt8(fmi3InstanceHandle *instance,
                                     const fmi3ValueReference valueReferences[],
                                     size_t nValueReferences,
                                     const fmi3Int8 values[],
                                     size_t nValues);
 
-FMI4C_DLLAPI fmi3Status fmi3_setUInt8(fmuHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3_setUInt8(fmi3InstanceHandle *instance,
                                      const fmi3ValueReference valueReferences[],
                                      size_t nValueReferences,
                                      const fmi3UInt8 values[],
                                      size_t nValues);
 
-FMI4C_DLLAPI fmi3Status fmi3_setInt16(fmuHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3_setInt16(fmi3InstanceHandle *instance,
                                      const fmi3ValueReference valueReferences[],
                                      size_t nValueReferences,
                                      const fmi3Int16 values[],
                                      size_t nValues);
 
-FMI4C_DLLAPI fmi3Status fmi3_setUInt16(fmuHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3_setUInt16(fmi3InstanceHandle *instance,
                                       const fmi3ValueReference valueReferences[],
                                       size_t nValueReferences,
                                       const fmi3UInt16 values[],
                                       size_t nValues);
 
-FMI4C_DLLAPI fmi3Status fmi3_setInt32(fmuHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3_setInt32(fmi3InstanceHandle *instance,
                                      const fmi3ValueReference valueReferences[],
                                      size_t nValueReferences,
                                      const fmi3Int32 values[],
                                      size_t nValues);
 
-FMI4C_DLLAPI fmi3Status fmi3_setUInt32(fmuHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3_setUInt32(fmi3InstanceHandle *instance,
                                       const fmi3ValueReference valueReferences[],
                                       size_t nValueReferences,
                                       const fmi3UInt32 values[],
                                       size_t nValues);
 
-FMI4C_DLLAPI fmi3Status fmi3_setInt64(fmuHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3_setInt64(fmi3InstanceHandle *instance,
                                      const fmi3ValueReference valueReferences[],
                                      size_t nValueReferences,
                                      const fmi3Int64 values[],
                                      size_t nValues);
 
-FMI4C_DLLAPI fmi3Status fmi3_setUInt64(fmuHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3_setUInt64(fmi3InstanceHandle *instance,
                                       const fmi3ValueReference valueReferences[],
                                       size_t nValueReferences,
                                       const fmi3UInt64 values[],
                                       size_t nValues);
 
-FMI4C_DLLAPI fmi3Status fmi3_setBoolean(fmuHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3_setBoolean(fmi3InstanceHandle *instance,
                                        const fmi3ValueReference valueReferences[],
                                        size_t nValueReferences,
                                        const fmi3Boolean values[],
                                        size_t nValues);
 
-FMI4C_DLLAPI fmi3Status fmi3_setString(fmuHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3_setString(fmi3InstanceHandle *instance,
                                       const fmi3ValueReference valueReferences[],
                                       size_t nValueReferences,
                                       const fmi3String values[],
                                       size_t nValues);
 
-FMI4C_DLLAPI fmi3Status fmi3_setBinary(fmuHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3_setBinary(fmi3InstanceHandle *instance,
                                       const fmi3ValueReference valueReferences[],
                                       size_t nValueReferences,
                                       const size_t valueSizes[],
                                       const fmi3Binary values[],
                                       size_t nValues);
 
-FMI4C_DLLAPI fmi3Status fmi3_setClock(fmuHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3_setClock(fmi3InstanceHandle *instance,
                                      const fmi3ValueReference valueReferences[],
                                      size_t nValueReferences,
                                      const fmi3Clock values[]);
 
-FMI4C_DLLAPI fmi3Status fmi3_getNumberOfVariableDependencies(fmuHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3_getNumberOfVariableDependencies(fmi3InstanceHandle *instance,
                                                             fmi3ValueReference valueReference,
                                                             size_t* nDependencies);
 
-FMI4C_DLLAPI fmi3Status fmi3_getVariableDependencies(fmuHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3_getVariableDependencies(fmi3InstanceHandle *instance,
                                                     fmi3ValueReference dependent,
                                                     size_t elementIndicesOfDependent[],
                                                     fmi3ValueReference independents[],
@@ -786,27 +786,27 @@ FMI4C_DLLAPI fmi3Status fmi3_getVariableDependencies(fmuHandle *fmu,
                                                     fmi3DependencyKind dependencyKinds[],
                                                     size_t nDependencies);
 
-FMI4C_DLLAPI fmi3Status fmi3_getFMUState(fmuHandle *fmu, fmi3FMUState* FMUState);
+FMI4C_DLLAPI fmi3Status fmi3_getFMUState(fmi3InstanceHandle *instance, fmi3FMUState* FMUState);
 
-FMI4C_DLLAPI fmi3Status fmi3_setFMUState(fmuHandle *fmu, fmi3FMUState  FMUState);
+FMI4C_DLLAPI fmi3Status fmi3_setFMUState(fmi3InstanceHandle *instance, fmi3FMUState  FMUState);
 
-FMI4C_DLLAPI fmi3Status fmi3_freeFMUState(fmuHandle *fmu, fmi3FMUState* FMUState);
+FMI4C_DLLAPI fmi3Status fmi3_freeFMUState(fmi3InstanceHandle *instance, fmi3FMUState* FMUState);
 
-FMI4C_DLLAPI fmi3Status fmi3_serializedFMUStateSize(fmuHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3_serializedFMUStateSize(fmi3InstanceHandle *instance,
                                                    fmi3FMUState  FMUState,
                                                    size_t* size);
 
-FMI4C_DLLAPI fmi3Status fmi3_serializeFMUState(fmuHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3_serializeFMUState(fmi3InstanceHandle *instance,
                                               fmi3FMUState  FMUState,
                                               fmi3Byte serializedState[],
                                               size_t size);
 
-FMI4C_DLLAPI fmi3Status fmi3_deserializeFMUState(fmuHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3_deserializeFMUState(fmi3InstanceHandle *instance,
                                                 const fmi3Byte serializedState[],
                                                 size_t size,
                                                 fmi3FMUState* FMUState);
 
-FMI4C_DLLAPI fmi3Status fmi3_getDirectionalDerivative(fmuHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3_getDirectionalDerivative(fmi3InstanceHandle *instance,
                                                      const fmi3ValueReference unknowns[],
                                                      size_t nUnknowns,
                                                      const fmi3ValueReference knowns[],
@@ -816,7 +816,7 @@ FMI4C_DLLAPI fmi3Status fmi3_getDirectionalDerivative(fmuHandle *fmu,
                                                      fmi3Float64 sensitivity[],
                                                      size_t nSensitivity);
 
-FMI4C_DLLAPI fmi3Status fmi3_getAdjointDerivative(fmuHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3_getAdjointDerivative(fmi3InstanceHandle *instance,
                                                  const fmi3ValueReference unknowns[],
                                                  size_t nUnknowns,
                                                  const fmi3ValueReference knowns[],
@@ -826,48 +826,48 @@ FMI4C_DLLAPI fmi3Status fmi3_getAdjointDerivative(fmuHandle *fmu,
                                                  fmi3Float64 sensitivity[],
                                                  size_t nSensitivity);
 
-FMI4C_DLLAPI fmi3Status fmi3_enterConfigurationMode(fmuHandle *fmu);
+FMI4C_DLLAPI fmi3Status fmi3_enterConfigurationMode(fmi3InstanceHandle *instance);
 
-FMI4C_DLLAPI fmi3Status fmi3_exitConfigurationMode(fmuHandle *fmu);
+FMI4C_DLLAPI fmi3Status fmi3_exitConfigurationMode(fmi3InstanceHandle *instance);
 
-FMI4C_DLLAPI fmi3Status fmi3_getIntervalDecimal(fmuHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3_getIntervalDecimal(fmi3InstanceHandle *instance,
                                                const fmi3ValueReference valueReferences[],
                                                size_t nValueReferences,
                                                fmi3Float64 intervals[],
                                                fmi3IntervalQualifier qualifiers[]);
 
-FMI4C_DLLAPI fmi3Status fmi3_getIntervalFraction(fmuHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3_getIntervalFraction(fmi3InstanceHandle *instance,
                                                 const fmi3ValueReference valueReferences[],
                                                 size_t nValueReferences,
                                                 fmi3UInt64 intervalCounters[],
                                                 fmi3UInt64 resolutions[],
                                                 fmi3IntervalQualifier qualifiers[]);
 
-FMI4C_DLLAPI fmi3Status fmi3_getShiftDecimal(fmuHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3_getShiftDecimal(fmi3InstanceHandle *instance,
                                             const fmi3ValueReference valueReferences[],
                                             size_t nValueReferences,
                                             fmi3Float64 shifts[]);
 
-FMI4C_DLLAPI fmi3Status fmi3_getShiftFraction(fmuHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3_getShiftFraction(fmi3InstanceHandle *instance,
                                              const fmi3ValueReference valueReferences[],
                                              size_t nValueReferences,
                                              fmi3UInt64 shiftCounters[],
                                              fmi3UInt64 resolutions[]);
 
-FMI4C_DLLAPI fmi3Status fmi3_setIntervalDecimal(fmuHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3_setIntervalDecimal(fmi3InstanceHandle *instance,
                                                const fmi3ValueReference valueReferences[],
                                                size_t nValueReferences,
                                                const fmi3Float64 intervals[]);
 
-FMI4C_DLLAPI fmi3Status fmi3_setIntervalFraction(fmuHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3_setIntervalFraction(fmi3InstanceHandle *instance,
                                                 const fmi3ValueReference valueReferences[],
                                                 size_t nValueReferences,
                                                 const fmi3UInt64 intervalCounters[],
                                                 const fmi3UInt64 resolutions[]);
 
-FMI4C_DLLAPI fmi3Status fmi3_evaluateDiscreteStates(fmuHandle *fmu);
+FMI4C_DLLAPI fmi3Status fmi3_evaluateDiscreteStates(fmi3InstanceHandle *instance);
 
-FMI4C_DLLAPI fmi3Status fmi3_updateDiscreteStates(fmuHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3_updateDiscreteStates(fmi3InstanceHandle *instance,
                                                  fmi3Boolean* discreteStatesNeedUpdate,
                                                  fmi3Boolean* terminateSimulation,
                                                  fmi3Boolean* nominalsOfContinuousStatesChanged,
@@ -875,51 +875,51 @@ FMI4C_DLLAPI fmi3Status fmi3_updateDiscreteStates(fmuHandle *fmu,
                                                  fmi3Boolean* nextEventTimeDefined,
                                                  fmi3Float64* nextEventTime);
 
-FMI4C_DLLAPI fmi3Status fmi3_enterContinuousTimeMode(fmuHandle *fmu);
+FMI4C_DLLAPI fmi3Status fmi3_enterContinuousTimeMode(fmi3InstanceHandle *instance);
 
-FMI4C_DLLAPI fmi3Status fmi3_completedIntegratorStep(fmuHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3_completedIntegratorStep(fmi3InstanceHandle *instance,
                                                     fmi3Boolean  noSetFMUStatePriorToCurrentPoint,
                                                     fmi3Boolean* enterEventMode,
                                                     fmi3Boolean* terminateSimulation);
 
-FMI4C_DLLAPI fmi3Status fmi3_setTime(fmuHandle *fmu, fmi3Float64 time);
+FMI4C_DLLAPI fmi3Status fmi3_setTime(fmi3InstanceHandle *instance, fmi3Float64 time);
 
-FMI4C_DLLAPI fmi3Status fmi3_setContinuousStates(fmuHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3_setContinuousStates(fmi3InstanceHandle *instance,
                                                 const fmi3Float64 continuousStates[],
                                                 size_t nContinuousStates);
 
-FMI4C_DLLAPI fmi3Status fmi3_getContinuousStateDerivatives(fmuHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3_getContinuousStateDerivatives(fmi3InstanceHandle *instance,
                                                           fmi3Float64 derivatives[],
                                                           size_t nContinuousStates);
 
-FMI4C_DLLAPI fmi3Status fmi3_getEventIndicators(fmuHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3_getEventIndicators(fmi3InstanceHandle *instance,
                                                fmi3Float64 eventIndicators[],
                                                size_t nEventIndicators);
 
-FMI4C_DLLAPI fmi3Status fmi3_getContinuousStates(fmuHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3_getContinuousStates(fmi3InstanceHandle *instance,
                                                 fmi3Float64 continuousStates[],
                                                 size_t nContinuousStates);
 
-FMI4C_DLLAPI fmi3Status fmi3_getNominalsOfContinuousStates(fmuHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3_getNominalsOfContinuousStates(fmi3InstanceHandle *instance,
                                                           fmi3Float64 nominals[],
                                                           size_t nContinuousStates);
 
-FMI4C_DLLAPI fmi3Status fmi3_getNumberOfEventIndicators(fmuHandle *fmu,
-                                                       size_t* nEventIndicators);
+FMI4C_DLLAPI fmi3Status fmi3_getNumberOfEventIndicators(fmi3InstanceHandle *instance,
+                                                        size_t* nEventIndicators);
 
-FMI4C_DLLAPI fmi3Status fmi3_getNumberOfContinuousStates(fmuHandle *fmu,
-                                                        size_t* nContinuousStates);
+FMI4C_DLLAPI fmi3Status fmi3_getNumberOfContinuousStates(fmi3InstanceHandle *instance,
+                                                         size_t* nContinuousStates);
 
-FMI4C_DLLAPI fmi3Status fmi3_enterStepMode(fmuHandle *fmu);
+FMI4C_DLLAPI fmi3Status fmi3_enterStepMode(fmi3InstanceHandle *instance);
 
-FMI4C_DLLAPI fmi3Status fmi3_getOutputDerivatives(fmuHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3_getOutputDerivatives(fmi3InstanceHandle *instance,
                                                  const fmi3ValueReference valueReferences[],
                                                  size_t nValueReferences,
                                                  const fmi3Int32 orders[],
                                                  fmi3Float64 values[],
                                                  size_t nValues);
 
-FMI4C_DLLAPI fmi3Status fmi3_activateModelPartition(fmuHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3_activateModelPartition(fmi3InstanceHandle *instance,
                                                    fmi3ValueReference clockReference,
                                                    fmi3Float64 activationTime);
 

--- a/include/fmi4c.h
+++ b/include/fmi4c.h
@@ -41,33 +41,33 @@ extern "C" {
 // FMU access functions
 
 FMI4C_DLLAPI void fmi4c_setMessageFunction(void (*func)(const char*));
-FMI4C_DLLAPI fmiVersion_t fmi4c_getFmiVersion(fmiHandle *fmu);
-FMI4C_DLLAPI fmiHandle *fmi4c_loadUnzippedFmu(const char *instanceName, const char *unzipLocation);
-FMI4C_DLLAPI fmiHandle* fmi4c_loadFmu(const char *fmufile, const char* instanceName);
-FMI4C_DLLAPI void fmi4c_freeFmu(fmiHandle* fmu);
+FMI4C_DLLAPI fmiVersion_t fmi4c_getFmiVersion(fmuHandle *fmu);
+FMI4C_DLLAPI fmuHandle *fmi4c_loadUnzippedFmu(const char *instanceName, const char *unzipLocation);
+FMI4C_DLLAPI fmuHandle* fmi4c_loadFmu(const char *fmufile, const char* instanceName);
+FMI4C_DLLAPI void fmi4c_freeFmu(fmuHandle* fmu);
 
 // FMI 1 wrapper functions
-FMI4C_DLLAPI fmi1Type fmi1_getType(fmiHandle *fmu);
-FMI4C_DLLAPI const char* fmi1_getModelName(fmiHandle *fmu);
-FMI4C_DLLAPI const char* fmi1_getModelIdentifier(fmiHandle *fmu);
-FMI4C_DLLAPI const char* fmi1_getGuid(fmiHandle *fmu);
-FMI4C_DLLAPI const char* fmi1_getDescription(fmiHandle *fmu);
-FMI4C_DLLAPI const char* fmi1_getAuthor(fmiHandle *fmu);
-FMI4C_DLLAPI const char* fmi1_getGenerationTool(fmiHandle *fmu);
-FMI4C_DLLAPI const char* fmi1_getGenerationDateAndTime(fmiHandle *fmu);
-FMI4C_DLLAPI int fmi1_getNumberOfContinuousStates(fmiHandle *fmu);
-FMI4C_DLLAPI int fmi1_getNumberOfEventIndicators(fmiHandle *fmu);
-FMI4C_DLLAPI bool fmi1_defaultStartTimeDefined(fmiHandle *fmu);
-FMI4C_DLLAPI bool fmi1_defaultStopTimeDefined(fmiHandle *fmu);
-FMI4C_DLLAPI bool fmi1_defaultToleranceDefined(fmiHandle *fmu) ;
-FMI4C_DLLAPI double fmi1_getDefaultStartTime(fmiHandle *fmu);
-FMI4C_DLLAPI double fmi1_getDefaultStopTime(fmiHandle *fmu);
-FMI4C_DLLAPI double fmi1_getDefaultTolerance(fmiHandle *fmu);
+FMI4C_DLLAPI fmi1Type fmi1_getType(fmuHandle *fmu);
+FMI4C_DLLAPI const char* fmi1_getModelName(fmuHandle *fmu);
+FMI4C_DLLAPI const char* fmi1_getModelIdentifier(fmuHandle *fmu);
+FMI4C_DLLAPI const char* fmi1_getGuid(fmuHandle *fmu);
+FMI4C_DLLAPI const char* fmi1_getDescription(fmuHandle *fmu);
+FMI4C_DLLAPI const char* fmi1_getAuthor(fmuHandle *fmu);
+FMI4C_DLLAPI const char* fmi1_getGenerationTool(fmuHandle *fmu);
+FMI4C_DLLAPI const char* fmi1_getGenerationDateAndTime(fmuHandle *fmu);
+FMI4C_DLLAPI int fmi1_getNumberOfContinuousStates(fmuHandle *fmu);
+FMI4C_DLLAPI int fmi1_getNumberOfEventIndicators(fmuHandle *fmu);
+FMI4C_DLLAPI bool fmi1_defaultStartTimeDefined(fmuHandle *fmu);
+FMI4C_DLLAPI bool fmi1_defaultStopTimeDefined(fmuHandle *fmu);
+FMI4C_DLLAPI bool fmi1_defaultToleranceDefined(fmuHandle *fmu) ;
+FMI4C_DLLAPI double fmi1_getDefaultStartTime(fmuHandle *fmu);
+FMI4C_DLLAPI double fmi1_getDefaultStopTime(fmuHandle *fmu);
+FMI4C_DLLAPI double fmi1_getDefaultTolerance(fmuHandle *fmu);
 
-FMI4C_DLLAPI int fmi1_getNumberOfVariables(fmiHandle *fmu);
-FMI4C_DLLAPI fmi1VariableHandle* fmi1_getVariableByIndex(fmiHandle *fmu, int i);
-FMI4C_DLLAPI fmi1VariableHandle* fmi1_getVariableByValueReference(fmiHandle *fmu, fmi1ValueReference vr);
-FMI4C_DLLAPI fmi1VariableHandle* fmi1_getVariableByName(fmiHandle *fmu, fmi1String name);
+FMI4C_DLLAPI int fmi1_getNumberOfVariables(fmuHandle *fmu);
+FMI4C_DLLAPI fmi1VariableHandle* fmi1_getVariableByIndex(fmuHandle *fmu, int i);
+FMI4C_DLLAPI fmi1VariableHandle* fmi1_getVariableByValueReference(fmuHandle *fmu, fmi1ValueReference vr);
+FMI4C_DLLAPI fmi1VariableHandle* fmi1_getVariableByName(fmuHandle *fmu, fmi1String name);
 FMI4C_DLLAPI const char* fmi1_getVariableName(fmi1VariableHandle* var);
 FMI4C_DLLAPI const char* fmi1_getVariableDescription(fmi1VariableHandle* var);
 FMI4C_DLLAPI const char* fmi1_getVariableQuantity(fmi1VariableHandle* var);
@@ -89,83 +89,83 @@ FMI4C_DLLAPI fmi1Alias fmi1_getAlias(fmi1VariableHandle* var);
 FMI4C_DLLAPI bool fmi1_getVariableIsFixed(fmi1VariableHandle* var);
 FMI4C_DLLAPI fmi1DataType fmi1_getVariableDataType(fmi1VariableHandle* var);
 
-FMI4C_DLLAPI const char* fmi1_getTypesPlatform(fmiHandle* fmu);
-FMI4C_DLLAPI const char* fmi1_getVersion(fmiHandle* fmu);
-FMI4C_DLLAPI fmi1Status fmi1_setDebugLogging(fmiHandle* fmu, fmi1Boolean loggingOn);
+FMI4C_DLLAPI const char* fmi1_getTypesPlatform(fmuHandle* fmu);
+FMI4C_DLLAPI const char* fmi1_getVersion(fmuHandle* fmu);
+FMI4C_DLLAPI fmi1Status fmi1_setDebugLogging(fmuHandle* fmu, fmi1Boolean loggingOn);
 
-FMI4C_DLLAPI int fmi1_getNumberOfBaseUnits(fmiHandle *fmu);
-FMI4C_DLLAPI fmi1BaseUnitHandle *fmi1_getBaseUnitByIndex(fmiHandle *fmu, int i);
+FMI4C_DLLAPI int fmi1_getNumberOfBaseUnits(fmuHandle *fmu);
+FMI4C_DLLAPI fmi1BaseUnitHandle *fmi1_getBaseUnitByIndex(fmuHandle *fmu, int i);
 FMI4C_DLLAPI const char* fmi1_getBaseUnitUnit(fmi1BaseUnitHandle *baseUnit);
 FMI4C_DLLAPI int fmi1_getNumberOfDisplayUnits(fmi1BaseUnitHandle *baseUnit);
 FMI4C_DLLAPI void fmi1_getDisplayUnitByIndex(fmi1BaseUnitHandle *baseUnit, int id, const char **displayUnit, double *gain, double *offset);
 
-FMI4C_DLLAPI fmi1Status fmi1_getReal(fmiHandle* fmu, const fmi1ValueReference valueReferences[], size_t nValueReferences, fmi1Real values[]);
-FMI4C_DLLAPI fmi1Status fmi1_getInteger(fmiHandle* fmu, const fmi1ValueReference valueReferences[], size_t nValueReferences, fmi1Integer values[]);
-FMI4C_DLLAPI fmi1Status fmi1_getBoolean(fmiHandle* fmu, const fmi1ValueReference valueReferences[], size_t nValueReferences, fmi1Boolean values[]);
-FMI4C_DLLAPI fmi1Status fmi1_getString(fmiHandle* fmu, const fmi1ValueReference valueReferences[], size_t nValueReferences, fmi1String values[]);
+FMI4C_DLLAPI fmi1Status fmi1_getReal(fmuHandle* fmu, const fmi1ValueReference valueReferences[], size_t nValueReferences, fmi1Real values[]);
+FMI4C_DLLAPI fmi1Status fmi1_getInteger(fmuHandle* fmu, const fmi1ValueReference valueReferences[], size_t nValueReferences, fmi1Integer values[]);
+FMI4C_DLLAPI fmi1Status fmi1_getBoolean(fmuHandle* fmu, const fmi1ValueReference valueReferences[], size_t nValueReferences, fmi1Boolean values[]);
+FMI4C_DLLAPI fmi1Status fmi1_getString(fmuHandle* fmu, const fmi1ValueReference valueReferences[], size_t nValueReferences, fmi1String values[]);
 
-FMI4C_DLLAPI fmi1Status fmi1_setReal(fmiHandle* fmu, const fmi1ValueReference valueReferences[], size_t nValueReferences, const fmi1Real values[]);
-FMI4C_DLLAPI fmi1Status fmi1_setInteger(fmiHandle* fmu, const fmi1ValueReference valueReferences[], size_t nValueReferences, const fmi1Integer values[]);
-FMI4C_DLLAPI fmi1Status fmi1_setBoolean(fmiHandle* fmu, const fmi1ValueReference valueReferences[], size_t nValueReferences, const fmi1Boolean values[]);
-FMI4C_DLLAPI fmi1Status fmi1_setString(fmiHandle* fmu, const fmi1ValueReference valueReferences[], size_t nValueReferences, const fmi1String values[]);
+FMI4C_DLLAPI fmi1Status fmi1_setReal(fmuHandle* fmu, const fmi1ValueReference valueReferences[], size_t nValueReferences, const fmi1Real values[]);
+FMI4C_DLLAPI fmi1Status fmi1_setInteger(fmuHandle* fmu, const fmi1ValueReference valueReferences[], size_t nValueReferences, const fmi1Integer values[]);
+FMI4C_DLLAPI fmi1Status fmi1_setBoolean(fmuHandle* fmu, const fmi1ValueReference valueReferences[], size_t nValueReferences, const fmi1Boolean values[]);
+FMI4C_DLLAPI fmi1Status fmi1_setString(fmuHandle* fmu, const fmi1ValueReference valueReferences[], size_t nValueReferences, const fmi1String values[]);
 
-FMI4C_DLLAPI bool fmi1_instantiateSlave(fmiHandle *fmu, fmi1String mimeType, fmi1Real timeOut, fmi1Boolean visible, fmi1Boolean interactive, fmi1CallbackLogger_t logger, fmi1CallbackAllocateMemory_t allocateMemory, fmi1CallbackFreeMemory_t freeMemory, fmi1StepFinished_t stepFinished, fmi1Boolean loggingOn);
-FMI4C_DLLAPI fmi1Status fmi1_initializeSlave(fmiHandle* fmu, fmi1Real startTime, fmi1Boolean stopTimeDefined, fmi1Real stopTime);
-FMI4C_DLLAPI fmi1Status fmi1_terminateSlave(fmiHandle* fmu);
-FMI4C_DLLAPI fmi1Status fmi1_resetSlave(fmiHandle* fmu);
-FMI4C_DLLAPI void fmi1_freeSlaveInstance(fmiHandle* fmu);
+FMI4C_DLLAPI bool fmi1_instantiateSlave(fmuHandle *fmu, fmi1String mimeType, fmi1Real timeOut, fmi1Boolean visible, fmi1Boolean interactive, fmi1CallbackLogger_t logger, fmi1CallbackAllocateMemory_t allocateMemory, fmi1CallbackFreeMemory_t freeMemory, fmi1StepFinished_t stepFinished, fmi1Boolean loggingOn);
+FMI4C_DLLAPI fmi1Status fmi1_initializeSlave(fmuHandle* fmu, fmi1Real startTime, fmi1Boolean stopTimeDefined, fmi1Real stopTime);
+FMI4C_DLLAPI fmi1Status fmi1_terminateSlave(fmuHandle* fmu);
+FMI4C_DLLAPI fmi1Status fmi1_resetSlave(fmuHandle* fmu);
+FMI4C_DLLAPI void fmi1_freeSlaveInstance(fmuHandle* fmu);
 
-FMI4C_DLLAPI fmi1Status fmi1_setRealInputDerivatives(fmiHandle *fmu, const fmi1ValueReference valueReferences[], size_t nValueReferences, const fmi1Integer orders[], const fmi1Real values[]);
-FMI4C_DLLAPI fmi1Status fmi1_getRealOutputDerivatives(fmiHandle *fmu, const fmi1ValueReference valueReferences[], size_t nValueReferences, const fmi1Integer orders[], fmi1Real values[]);
-FMI4C_DLLAPI fmi1Status fmi1_cancelStep(fmiHandle* fmu);
-FMI4C_DLLAPI fmi1Status fmi1_doStep(fmiHandle *fmu, fmi1Real currentCommunicationPoint, fmi1Real communicationStepSize, fmi1Boolean newStep);
-FMI4C_DLLAPI fmi1Status fmi1_getStatus(fmiHandle* fmu, const fmi1StatusKind statusKind, fmi1Status* value);
-FMI4C_DLLAPI fmi1Status fmi1_getRealStatus(fmiHandle* fmu, const fmi1StatusKind statusKind, fmi1Real* value);
-FMI4C_DLLAPI fmi1Status fmi1_getIntegerStatus(fmiHandle* fmu, const fmi1StatusKind statusKind, fmi1Integer* value);
-FMI4C_DLLAPI fmi1Status fmi1_getBooleanStatus(fmiHandle* fmu, const fmi1StatusKind statusKind, fmi1Boolean* value);
-FMI4C_DLLAPI fmi1Status fmi1_getStringStatus(fmiHandle* fmu, const fmi1StatusKind statusKind, fmi1String* value);
+FMI4C_DLLAPI fmi1Status fmi1_setRealInputDerivatives(fmuHandle *fmu, const fmi1ValueReference valueReferences[], size_t nValueReferences, const fmi1Integer orders[], const fmi1Real values[]);
+FMI4C_DLLAPI fmi1Status fmi1_getRealOutputDerivatives(fmuHandle *fmu, const fmi1ValueReference valueReferences[], size_t nValueReferences, const fmi1Integer orders[], fmi1Real values[]);
+FMI4C_DLLAPI fmi1Status fmi1_cancelStep(fmuHandle* fmu);
+FMI4C_DLLAPI fmi1Status fmi1_doStep(fmuHandle *fmu, fmi1Real currentCommunicationPoint, fmi1Real communicationStepSize, fmi1Boolean newStep);
+FMI4C_DLLAPI fmi1Status fmi1_getStatus(fmuHandle* fmu, const fmi1StatusKind statusKind, fmi1Status* value);
+FMI4C_DLLAPI fmi1Status fmi1_getRealStatus(fmuHandle* fmu, const fmi1StatusKind statusKind, fmi1Real* value);
+FMI4C_DLLAPI fmi1Status fmi1_getIntegerStatus(fmuHandle* fmu, const fmi1StatusKind statusKind, fmi1Integer* value);
+FMI4C_DLLAPI fmi1Status fmi1_getBooleanStatus(fmuHandle* fmu, const fmi1StatusKind statusKind, fmi1Boolean* value);
+FMI4C_DLLAPI fmi1Status fmi1_getStringStatus(fmuHandle* fmu, const fmi1StatusKind statusKind, fmi1String* value);
 
-FMI4C_DLLAPI const char *fmi1_getModelTypesPlatform(fmiHandle* fmu);
-FMI4C_DLLAPI bool fmi1_instantiateModel(fmiHandle *fmu, fmi1CallbackLogger_t logger, fmi1CallbackAllocateMemory_t allocateMemory, fmi1CallbackFreeMemory_t freeMemory, fmi1Boolean loggingOn);
-FMI4C_DLLAPI void fmi1_freeModelInstance(fmiHandle* fmu);
-FMI4C_DLLAPI fmi1Status fmi1_setTime(fmiHandle* fmu, fmi1Real time);
-FMI4C_DLLAPI fmi1Status fmi1_setContinuousStates(fmiHandle *fmu, const fmi1Real values[], size_t nStates);
-FMI4C_DLLAPI fmi1Status fmi1_completedIntegratorStep(fmiHandle* fmu, fmi1Boolean* callEventUpdate);
-FMI4C_DLLAPI fmi1Status fmi1_initialize(fmiHandle *fmu, fmi1Boolean toleranceControlled, fmi1Real relativeTolerance, fmi1EventInfo *eventInfo);
-FMI4C_DLLAPI fmi1Status fmi1_getDerivatives(fmiHandle *fmu, fmi1Real derivatives[], size_t nDerivatives);
-FMI4C_DLLAPI fmi1Status fmi1_getEventIndicators(fmiHandle *fmu, fmi1Real indicators[], size_t nIndicators);
-FMI4C_DLLAPI fmi1Status fmi1_eventUpdate(fmiHandle *fmu, fmi1Boolean intermediateResults, fmi1EventInfo *eventInfo);
-FMI4C_DLLAPI fmi1Status fmi1_getContinuousStates(fmiHandle *fmu, fmi1Real states[], size_t nStates);
-FMI4C_DLLAPI fmi1Status fmi1_getNominalContinuousStates(fmiHandle* fmu, fmi1Real nominals[], size_t nNominals);
-FMI4C_DLLAPI fmi1Status fmi1_getStateValueReferences(fmiHandle* fmu, fmi1ValueReference valueReferences[], size_t nValueReferences);
-FMI4C_DLLAPI fmi1Status fmi1_terminate(fmiHandle* fmu);
+FMI4C_DLLAPI const char *fmi1_getModelTypesPlatform(fmuHandle* fmu);
+FMI4C_DLLAPI bool fmi1_instantiateModel(fmuHandle *fmu, fmi1CallbackLogger_t logger, fmi1CallbackAllocateMemory_t allocateMemory, fmi1CallbackFreeMemory_t freeMemory, fmi1Boolean loggingOn);
+FMI4C_DLLAPI void fmi1_freeModelInstance(fmuHandle* fmu);
+FMI4C_DLLAPI fmi1Status fmi1_setTime(fmuHandle* fmu, fmi1Real time);
+FMI4C_DLLAPI fmi1Status fmi1_setContinuousStates(fmuHandle *fmu, const fmi1Real values[], size_t nStates);
+FMI4C_DLLAPI fmi1Status fmi1_completedIntegratorStep(fmuHandle* fmu, fmi1Boolean* callEventUpdate);
+FMI4C_DLLAPI fmi1Status fmi1_initialize(fmuHandle *fmu, fmi1Boolean toleranceControlled, fmi1Real relativeTolerance, fmi1EventInfo *eventInfo);
+FMI4C_DLLAPI fmi1Status fmi1_getDerivatives(fmuHandle *fmu, fmi1Real derivatives[], size_t nDerivatives);
+FMI4C_DLLAPI fmi1Status fmi1_getEventIndicators(fmuHandle *fmu, fmi1Real indicators[], size_t nIndicators);
+FMI4C_DLLAPI fmi1Status fmi1_eventUpdate(fmuHandle *fmu, fmi1Boolean intermediateResults, fmi1EventInfo *eventInfo);
+FMI4C_DLLAPI fmi1Status fmi1_getContinuousStates(fmuHandle *fmu, fmi1Real states[], size_t nStates);
+FMI4C_DLLAPI fmi1Status fmi1_getNominalContinuousStates(fmuHandle* fmu, fmi1Real nominals[], size_t nNominals);
+FMI4C_DLLAPI fmi1Status fmi1_getStateValueReferences(fmuHandle* fmu, fmi1ValueReference valueReferences[], size_t nValueReferences);
+FMI4C_DLLAPI fmi1Status fmi1_terminate(fmuHandle* fmu);
 
 // FMI 2 wrapper functions
 
-FMI4C_DLLAPI bool fmi2_defaultStartTimeDefined(fmiHandle *fmu);
-FMI4C_DLLAPI bool fmi2_defaultStopTimeDefined(fmiHandle *fmu);
-FMI4C_DLLAPI bool fmi2_defaultToleranceDefined(fmiHandle *fmu) ;
-FMI4C_DLLAPI bool fmi2_defaultStepSizeDefined(fmiHandle *fmu);
-FMI4C_DLLAPI double fmi2_getDefaultStartTime(fmiHandle *fmu);
-FMI4C_DLLAPI double fmi2_getDefaultStopTime(fmiHandle *fmu);
-FMI4C_DLLAPI double fmi2_getDefaultTolerance(fmiHandle *fmu);
-FMI4C_DLLAPI double fmi2_getDefaultStepSize(fmiHandle *fmu);
+FMI4C_DLLAPI bool fmi2_defaultStartTimeDefined(fmuHandle *fmu);
+FMI4C_DLLAPI bool fmi2_defaultStopTimeDefined(fmuHandle *fmu);
+FMI4C_DLLAPI bool fmi2_defaultToleranceDefined(fmuHandle *fmu) ;
+FMI4C_DLLAPI bool fmi2_defaultStepSizeDefined(fmuHandle *fmu);
+FMI4C_DLLAPI double fmi2_getDefaultStartTime(fmuHandle *fmu);
+FMI4C_DLLAPI double fmi2_getDefaultStopTime(fmuHandle *fmu);
+FMI4C_DLLAPI double fmi2_getDefaultTolerance(fmuHandle *fmu);
+FMI4C_DLLAPI double fmi2_getDefaultStepSize(fmuHandle *fmu);
 
-FMI4C_DLLAPI int fmi2_getNumberOfVariables(fmiHandle *fmu);
-FMI4C_DLLAPI fmi2VariableHandle* fmi2_getVariableByIndex(fmiHandle *fmu, int i);
-FMI4C_DLLAPI fmi2VariableHandle* fmi2_getVariableByValueReference(fmiHandle *fmu, fmi2ValueReference vr);
-FMI4C_DLLAPI fmi2VariableHandle* fmi2_getVariableByName(fmiHandle *fmu, fmi2String name);
+FMI4C_DLLAPI int fmi2_getNumberOfVariables(fmuHandle *fmu);
+FMI4C_DLLAPI fmi2VariableHandle* fmi2_getVariableByIndex(fmuHandle *fmu, int i);
+FMI4C_DLLAPI fmi2VariableHandle* fmi2_getVariableByValueReference(fmuHandle *fmu, fmi2ValueReference vr);
+FMI4C_DLLAPI fmi2VariableHandle* fmi2_getVariableByName(fmuHandle *fmu, fmi2String name);
 FMI4C_DLLAPI const char* fmi2_getVariableName(fmi2VariableHandle* var);
 FMI4C_DLLAPI const char* fmi2_getVariableDescription(fmi2VariableHandle* var);
-FMI4C_DLLAPI const char* fmi2_getFmiVersion(fmiHandle* fmu);
-FMI4C_DLLAPI const char* fmi2_getAuthor(fmiHandle *fmu);
-FMI4C_DLLAPI const char* fmi2_getModelName(fmiHandle *fmu);
-FMI4C_DLLAPI const char* fmi2_getModelDescription(fmiHandle *fmu);
-FMI4C_DLLAPI const char* fmi2_getCopyright(fmiHandle *fmu);
-FMI4C_DLLAPI const char* fmi2_getLicense(fmiHandle *fmu);
-FMI4C_DLLAPI const char* fmi2_getGenerationTool(fmiHandle *fmu);
-FMI4C_DLLAPI const char* fmi2_getGenerationDateAndTime(fmiHandle *fmu);
-FMI4C_DLLAPI const char* fmi2_getVariableNamingConvention(fmiHandle *fmu);
+FMI4C_DLLAPI const char* fmi2_getFmiVersion(fmuHandle *fmu);
+FMI4C_DLLAPI const char* fmi2_getAuthor(fmuHandle *fmu);
+FMI4C_DLLAPI const char* fmi2_getModelName(fmuHandle *fmu);
+FMI4C_DLLAPI const char* fmi2_getModelDescription(fmuHandle *fmu);
+FMI4C_DLLAPI const char* fmi2_getCopyright(fmuHandle *fmu);
+FMI4C_DLLAPI const char* fmi2_getLicense(fmuHandle *fmu);
+FMI4C_DLLAPI const char* fmi2_getGenerationTool(fmuHandle *fmu);
+FMI4C_DLLAPI const char* fmi2_getGenerationDateAndTime(fmuHandle *fmu);
+FMI4C_DLLAPI const char* fmi2_getVariableNamingConvention(fmuHandle *fmu);
 FMI4C_DLLAPI int fmi2_getVariableDerivativeIndex(fmi2VariableHandle* var);
 FMI4C_DLLAPI const char* fmi2_getVariableQuantity(fmi2VariableHandle* var);
 FMI4C_DLLAPI const char* fmi2_getVariableUnit(fmi2VariableHandle* var);
@@ -187,96 +187,96 @@ FMI4C_DLLAPI fmi2Initial fmi2_getVariableInitial(fmi2VariableHandle* var);
 FMI4C_DLLAPI bool fmi2_getVariableCanHandleMultipleSetPerTimeInstant(fmi2VariableHandle* var);
 FMI4C_DLLAPI fmi2DataType fmi2_getVariableDataType(fmi2VariableHandle* var);
 
-FMI4C_DLLAPI const char* fmi2_getTypesPlatform(fmiHandle* fmu);
-FMI4C_DLLAPI const char* fmi2_getVersion(fmiHandle* fmu);
-FMI4C_DLLAPI fmi2Status fmi2_setDebugLogging(fmiHandle *fmu, fmi2Component comp, fmi2Boolean loggingOn, size_t nCategories, const fmi2String categories[]);
-FMI4C_DLLAPI const char* fmi2_getGuid(fmiHandle *fmu);
+FMI4C_DLLAPI const char* fmi2_getTypesPlatform(fmuHandle *fmu);
+FMI4C_DLLAPI const char* fmi2_getVersion(fmuHandle *fmu);
+FMI4C_DLLAPI fmi2Status fmi2_setDebugLogging(fmi2InstanceHandle *instance, fmi2Boolean loggingOn, size_t nCategories, const fmi2String categories[]);
+FMI4C_DLLAPI const char* fmi2_getGuid(fmuHandle *fmu);
 
-FMI4C_DLLAPI const char* fmi2cs_getModelIdentifier(fmiHandle* fmu);
-FMI4C_DLLAPI bool fmi2cs_getCanHandleVariableCommunicationStepSize(fmiHandle* fmu);
-FMI4C_DLLAPI bool fmi2cs_getCanInterpolateInputs(fmiHandle* fmu);
-FMI4C_DLLAPI int fmi2cs_getMaxOutputDerivativeOrder(fmiHandle* fmu);
-FMI4C_DLLAPI bool fmi2cs_getCanRunAsynchronuously(fmiHandle* fmu);
-FMI4C_DLLAPI bool fmi2cs_getNeedsExecutionTool(fmiHandle* fmu);
-FMI4C_DLLAPI bool fmi2cs_getCanBeInstantiatedOnlyOncePerProcess(fmiHandle* fmu);
-FMI4C_DLLAPI bool fmi2cs_getCanNotUseMemoryManagementFunctions(fmiHandle* fmu);
-FMI4C_DLLAPI bool fmi2cs_getCanGetAndSetFMUState(fmiHandle* fmu);
-FMI4C_DLLAPI bool fmi2cs_getCanSerializeFMUState(fmiHandle* fmu);
-FMI4C_DLLAPI bool fmi2cs_getProvidesDirectionalDerivative(fmiHandle* fmu);
+FMI4C_DLLAPI const char* fmi2cs_getModelIdentifier(fmuHandle *fmu);
+FMI4C_DLLAPI bool fmi2cs_getCanHandleVariableCommunicationStepSize(fmuHandle *fmu);
+FMI4C_DLLAPI bool fmi2cs_getCanInterpolateInputs(fmuHandle *fmu);
+FMI4C_DLLAPI int fmi2cs_getMaxOutputDerivativeOrder(fmuHandle *fmu);
+FMI4C_DLLAPI bool fmi2cs_getCanRunAsynchronuously(fmuHandle *fmu);
+FMI4C_DLLAPI bool fmi2cs_getNeedsExecutionTool(fmuHandle *fmu);
+FMI4C_DLLAPI bool fmi2cs_getCanBeInstantiatedOnlyOncePerProcess(fmuHandle *fmu);
+FMI4C_DLLAPI bool fmi2cs_getCanNotUseMemoryManagementFunctions(fmuHandle *fmu);
+FMI4C_DLLAPI bool fmi2cs_getCanGetAndSetFMUState(fmuHandle *fmu);
+FMI4C_DLLAPI bool fmi2cs_getCanSerializeFMUState(fmuHandle *fmu);
+FMI4C_DLLAPI bool fmi2cs_getProvidesDirectionalDerivative(fmuHandle *fmu);
 
-FMI4C_DLLAPI const char* fmi2me_getModelIdentifier(fmiHandle* fmu);
-FMI4C_DLLAPI bool fmi2me_getCompletedIntegratorStepNotNeeded(fmiHandle* fmu);
-FMI4C_DLLAPI bool fmi2me_getNeedsExecutionTool(fmiHandle* fmu);
-FMI4C_DLLAPI bool fmi2me_getCanBeInstantiatedOnlyOncePerProcess(fmiHandle* fmu);
-FMI4C_DLLAPI bool fmi2me_getCanNotUseMemoryManagementFunctions(fmiHandle* fmu);
-FMI4C_DLLAPI bool fmi2me_getCanGetAndSetFMUState(fmiHandle* fmu);
-FMI4C_DLLAPI bool fmi2me_getCanSerializeFMUState(fmiHandle* fmu);
-FMI4C_DLLAPI bool fmi2me_getProvidesDirectionalDerivative(fmiHandle* fmu);
+FMI4C_DLLAPI const char* fmi2me_getModelIdentifier(fmuHandle *fmu);
+FMI4C_DLLAPI bool fmi2me_getCompletedIntegratorStepNotNeeded(fmuHandle *fmu);
+FMI4C_DLLAPI bool fmi2me_getNeedsExecutionTool(fmuHandle *fmu);
+FMI4C_DLLAPI bool fmi2me_getCanBeInstantiatedOnlyOncePerProcess(fmuHandle *fmu);
+FMI4C_DLLAPI bool fmi2me_getCanNotUseMemoryManagementFunctions(fmuHandle *fmu);
+FMI4C_DLLAPI bool fmi2me_getCanGetAndSetFMUState(fmuHandle *fmu);
+FMI4C_DLLAPI bool fmi2me_getCanSerializeFMUState(fmuHandle *fmu);
+FMI4C_DLLAPI bool fmi2me_getProvidesDirectionalDerivative(fmuHandle *fmu);
 
-FMI4C_DLLAPI int fmi2_getNumberOfContinuousStates(fmiHandle *fmu);
-FMI4C_DLLAPI void fmi2_getContinuousStateValueReferences(fmiHandle *fmu, fmi2ValueReference valueReferences[], size_t nValueReferences);
-FMI4C_DLLAPI int fmi2_getNumberOfEventIndicators(fmiHandle *fmu);
-FMI4C_DLLAPI bool fmi2_getSupportsCoSimulation(fmiHandle *fmu);
-FMI4C_DLLAPI bool fmi2_getSupportsModelExchange(fmiHandle *fmu);
+FMI4C_DLLAPI int fmi2_getNumberOfContinuousStates(fmuHandle *fmu);
+FMI4C_DLLAPI void fmi2_getContinuousStateValueReferences(fmuHandle *fmu, fmi2ValueReference valueReferences[], size_t nValueReferences);
+FMI4C_DLLAPI int fmi2_getNumberOfEventIndicators(fmuHandle *fmu);
+FMI4C_DLLAPI bool fmi2_getSupportsCoSimulation(fmuHandle *fmu);
+FMI4C_DLLAPI bool fmi2_getSupportsModelExchange(fmuHandle *fmu);
 
-FMI4C_DLLAPI int fmi2_getNumberOfModelStructureOutputs(fmiHandle *fmu);
-FMI4C_DLLAPI int fmi2_getNumberOfModelStructureDerivatives(fmiHandle *fmu);
-FMI4C_DLLAPI int fmi2_getNumberOfModelStructureInitialUnknowns(fmiHandle *fmu);
-FMI4C_DLLAPI fmi2ModelStructureHandle *fmi2_getModelStructureOutput(fmiHandle *fmu, size_t i);
-FMI4C_DLLAPI fmi2ModelStructureHandle *fmi2_getModelStructureDerivative(fmiHandle *fmu, size_t i);
-FMI4C_DLLAPI fmi2ModelStructureHandle *fmi2_getModelStructureInitialUnknown(fmiHandle *fmu, size_t i);
+FMI4C_DLLAPI int fmi2_getNumberOfModelStructureOutputs(fmuHandle *fmu);
+FMI4C_DLLAPI int fmi2_getNumberOfModelStructureDerivatives(fmuHandle *fmu);
+FMI4C_DLLAPI int fmi2_getNumberOfModelStructureInitialUnknowns(fmuHandle *fmu);
+FMI4C_DLLAPI fmi2ModelStructureHandle *fmi2_getModelStructureOutput(fmuHandle *fmu, size_t i);
+FMI4C_DLLAPI fmi2ModelStructureHandle *fmi2_getModelStructureDerivative(fmuHandle *fmu, size_t i);
+FMI4C_DLLAPI fmi2ModelStructureHandle *fmi2_getModelStructureInitialUnknown(fmuHandle *fmu, size_t i);
 FMI4C_DLLAPI int fmi2_getModelStructureIndex(fmi2ModelStructureHandle *handle);
 FMI4C_DLLAPI int fmi2_getModelStructureNumberOfDependencies(fmi2ModelStructureHandle *handle);
 FMI4C_DLLAPI bool fmi2_getModelStructureDependencyKindsDefined(fmi2ModelStructureHandle *handle);
 FMI4C_DLLAPI void fmi2_getModelStructureDependencies(fmi2ModelStructureHandle *handle, int *dependencies, size_t numberOfDependencies);
 FMI4C_DLLAPI void fmi2_getModelStructureDependencyKinds(fmi2ModelStructureHandle *handle, int *dependencyKinds, size_t numberOfDependencies);
 
-FMI4C_DLLAPI fmi2Component fmi2_instantiate(fmiHandle *fmu, fmi2Type type, fmi2CallbackLogger logger, fmi2CallbackAllocateMemory allocateMemory, fmi2CallbackFreeMemory freeMemory, fmi2StepFinished stepFinished, fmi2ComponentEnvironment componentEnvironment, fmi2Boolean visible, fmi2Boolean loggingOn);
-FMI4C_DLLAPI void fmi2_freeInstance(fmiHandle *fmu, fmi2Component comp);
+FMI4C_DLLAPI fmi2InstanceHandle *fmi2_instantiate(fmuHandle *fmu, fmi2Type type, fmi2CallbackLogger logger, fmi2CallbackAllocateMemory allocateMemory, fmi2CallbackFreeMemory freeMemory, fmi2StepFinished stepFinished, fmi2ComponentEnvironment componentEnvironment, fmi2Boolean visible, fmi2Boolean loggingOn);
+FMI4C_DLLAPI void fmi2_freeInstance(fmi2InstanceHandle *instance);
 
-FMI4C_DLLAPI fmi2Status fmi2_setupExperiment(fmiHandle *fmu, fmi2Component comp, fmi2Boolean toleranceDefined, fmi2Real tolerance, fmi2Real startTime, fmi2Boolean stopTimeDefined, fmi2Real stopTime);
-FMI4C_DLLAPI fmi2Status fmi2_enterInitializationMode(fmiHandle* fmu, fmi2Component comp);
-FMI4C_DLLAPI fmi2Status fmi2_exitInitializationMode(fmiHandle* fmu, fmi2Component comp);
-FMI4C_DLLAPI fmi2Status fmi2_terminate(fmiHandle* fmu, fmi2Component comp);
-FMI4C_DLLAPI fmi2Status fmi2_reset(fmiHandle* fmu, fmi2Component comp);
+FMI4C_DLLAPI fmi2Status fmi2_setupExperiment(fmi2InstanceHandle *instance,  fmi2Boolean toleranceDefined, fmi2Real tolerance, fmi2Real startTime, fmi2Boolean stopTimeDefined, fmi2Real stopTime);
+FMI4C_DLLAPI fmi2Status fmi2_enterInitializationMode(fmi2InstanceHandle *instance);
+FMI4C_DLLAPI fmi2Status fmi2_exitInitializationMode(fmi2InstanceHandle *instance);
+FMI4C_DLLAPI fmi2Status fmi2_terminate(fmi2InstanceHandle *instance);
+FMI4C_DLLAPI fmi2Status fmi2_reset(fmi2InstanceHandle *instance);
 
-FMI4C_DLLAPI int fmi2_getNumberOfUnits(fmiHandle *fmu);
-FMI4C_DLLAPI fmi2UnitHandle *fmi2_getUnitByIndex(fmiHandle *fmu, int i);
+FMI4C_DLLAPI int fmi2_getNumberOfUnits(fmuHandle *fmu);
+FMI4C_DLLAPI fmi2UnitHandle *fmi2_getUnitByIndex(fmuHandle *fmu, int i);
 FMI4C_DLLAPI const char* fmi2_getUnitName(fmi2UnitHandle *unit);
 FMI4C_DLLAPI bool fmi2_hasBaseUnit(fmi2UnitHandle *unit);
 FMI4C_DLLAPI void fmi2_getBaseUnit(fmi2UnitHandle *unit, double *factor, double *offset, int *kg, int *m, int *s, int *A, int *K, int *mol, int *cd, int *rad);
 FMI4C_DLLAPI int fmi2_getNumberOfDisplayUnits(fmi2UnitHandle *unit);
 FMI4C_DLLAPI void fmi2_getDisplayUnitByIndex(fmi2UnitHandle *unit, int id, const char **name, double *factor, double *offset);
 
-FMI4C_DLLAPI fmi2Status fmi2_getReal(fmiHandle* fmu, fmi2Component comp, const fmi2ValueReference valueReferences[], size_t nValueReferences, fmi2Real values[]);
-FMI4C_DLLAPI fmi2Status fmi2_getInteger(fmiHandle* fmu, fmi2Component comp, const fmi2ValueReference valueReferences[], size_t nValueReferences, fmi2Integer values[]);
-FMI4C_DLLAPI fmi2Status fmi2_getBoolean(fmiHandle* fmu, fmi2Component comp, const fmi2ValueReference valueReferences[], size_t nValueReferences, fmi2Boolean values[]);
-FMI4C_DLLAPI fmi2Status fmi2_getString(fmiHandle* fmu, fmi2Component comp, const fmi2ValueReference valueReferences[], size_t nValueReferences, fmi2String values[]);
+FMI4C_DLLAPI fmi2Status fmi2_getReal(fmi2InstanceHandle *instance,  const fmi2ValueReference valueReferences[], size_t nValueReferences, fmi2Real values[]);
+FMI4C_DLLAPI fmi2Status fmi2_getInteger(fmi2InstanceHandle *instance,  const fmi2ValueReference valueReferences[], size_t nValueReferences, fmi2Integer values[]);
+FMI4C_DLLAPI fmi2Status fmi2_getBoolean(fmi2InstanceHandle *instance,  const fmi2ValueReference valueReferences[], size_t nValueReferences, fmi2Boolean values[]);
+FMI4C_DLLAPI fmi2Status fmi2_getString(fmi2InstanceHandle *instance,  const fmi2ValueReference valueReferences[], size_t nValueReferences, fmi2String values[]);
 
-FMI4C_DLLAPI fmi2Status fmi2_setReal(fmiHandle* fmu, fmi2Component comp, const fmi2ValueReference valueReferences[], size_t nValueReferences, const fmi2Real values[]);
-FMI4C_DLLAPI fmi2Status fmi2_setInteger(fmiHandle* fmu, fmi2Component comp, const fmi2ValueReference valueReferences[], size_t nValueReferences, const fmi2Integer values[]);
-FMI4C_DLLAPI fmi2Status fmi2_setBoolean(fmiHandle* fmu, fmi2Component comp, const fmi2ValueReference valueReferences[], size_t nValueReferences, const fmi2Boolean values[]);
-FMI4C_DLLAPI fmi2Status fmi2_setString(fmiHandle* fmu, fmi2Component comp, const fmi2ValueReference valueReferences[], size_t nValueReferences, const fmi2String values[]);
+FMI4C_DLLAPI fmi2Status fmi2_setReal(fmi2InstanceHandle *instance,  const fmi2ValueReference valueReferences[], size_t nValueReferences, const fmi2Real values[]);
+FMI4C_DLLAPI fmi2Status fmi2_setInteger(fmi2InstanceHandle *instance,  const fmi2ValueReference valueReferences[], size_t nValueReferences, const fmi2Integer values[]);
+FMI4C_DLLAPI fmi2Status fmi2_setBoolean(fmi2InstanceHandle *instance,  const fmi2ValueReference valueReferences[], size_t nValueReferences, const fmi2Boolean values[]);
+FMI4C_DLLAPI fmi2Status fmi2_setString(fmi2InstanceHandle *instance,  const fmi2ValueReference valueReferences[], size_t nValueReferences, const fmi2String values[]);
 
-FMI4C_DLLAPI fmi2Status fmi2_getFMUstate(fmiHandle* fmu, fmi2Component comp,
+FMI4C_DLLAPI fmi2Status fmi2_getFMUstate(fmi2InstanceHandle *instance,
                                          fmi2FMUstate* FMUstate);
-FMI4C_DLLAPI fmi2Status fmi2_setFMUstate(fmiHandle* fmu, fmi2Component comp,
+FMI4C_DLLAPI fmi2Status fmi2_setFMUstate(fmi2InstanceHandle *instance,
                                          fmi2FMUstate FMUstate);
-FMI4C_DLLAPI fmi2Status fmi2_freeFMUstate(fmiHandle* fmu, fmi2Component comp,
+FMI4C_DLLAPI fmi2Status fmi2_freeFMUstate(fmi2InstanceHandle *instance,
                                           fmi2FMUstate* FMUstate);
-FMI4C_DLLAPI fmi2Status fmi2_serializedFMUstateSize(fmiHandle* fmu, fmi2Component comp,
+FMI4C_DLLAPI fmi2Status fmi2_serializedFMUstateSize(fmi2InstanceHandle *instance,
                                                     fmi2FMUstate FMUstate,
                                                     size_t* size);
-FMI4C_DLLAPI fmi2Status fmi2_serializeFMUstate(fmiHandle* fmu, fmi2Component comp,
+FMI4C_DLLAPI fmi2Status fmi2_serializeFMUstate(fmi2InstanceHandle *instance,
                                                fmi2FMUstate FMUstate,
                                                fmi2Byte serializedState[],
                                                size_t size);
-FMI4C_DLLAPI fmi2Status fmi2_deSerializeFMUstate(fmiHandle* fmu, fmi2Component comp,
+FMI4C_DLLAPI fmi2Status fmi2_deSerializeFMUstate(fmi2InstanceHandle *instance,
                                                  const fmi2Byte serializedState[],
                                                  size_t size,
                                                  fmi2FMUstate* FMUstate);
 
-FMI4C_DLLAPI fmi2Status fmi2_getDirectionalDerivative(fmiHandle* fmu, fmi2Component comp,
+FMI4C_DLLAPI fmi2Status fmi2_getDirectionalDerivative(fmi2InstanceHandle *instance,
                                                       const fmi2ValueReference unknownReferences[],
                                                       size_t nUnknown,
                                                       const fmi2ValueReference knownReferences[],
@@ -284,58 +284,58 @@ FMI4C_DLLAPI fmi2Status fmi2_getDirectionalDerivative(fmiHandle* fmu, fmi2Compon
                                                       const fmi2Real dvKnown[],
                                                       fmi2Real dvUnknown[]);
 
-FMI4C_DLLAPI fmi2Status fmi2_enterEventMode(fmiHandle* fmu, fmi2Component comp);
-FMI4C_DLLAPI fmi2Status fmi2_newDiscreteStates(fmiHandle* fmu, fmi2Component comp, fmi2EventInfo* eventInfo);
-FMI4C_DLLAPI fmi2Status fmi2_enterContinuousTimeMode(fmiHandle* fmu, fmi2Component comp);
-FMI4C_DLLAPI fmi2Status fmi2_completedIntegratorStep(fmiHandle* fmu, fmi2Component comp,
+FMI4C_DLLAPI fmi2Status fmi2_enterEventMode(fmi2InstanceHandle *instance);
+FMI4C_DLLAPI fmi2Status fmi2_newDiscreteStates(fmi2InstanceHandle *instance,  fmi2EventInfo* eventInfo);
+FMI4C_DLLAPI fmi2Status fmi2_enterContinuousTimeMode(fmi2InstanceHandle *instance);
+FMI4C_DLLAPI fmi2Status fmi2_completedIntegratorStep(fmi2InstanceHandle *instance,
                                                      fmi2Boolean noSetFMUStatePriorToCurrentPoint,
                                                      fmi2Boolean* enterEventMode,
                                                      fmi2Boolean* terminateSimulation);
 
-FMI4C_DLLAPI fmi2Status fmi2_setTime(fmiHandle* fmu, fmi2Component comp,
+FMI4C_DLLAPI fmi2Status fmi2_setTime(fmi2InstanceHandle *instance,
                                      fmi2Real time);
-FMI4C_DLLAPI fmi2Status fmi2_setContinuousStates(fmiHandle* fmu, fmi2Component comp,
+FMI4C_DLLAPI fmi2Status fmi2_setContinuousStates(fmi2InstanceHandle *instance,
                                                  const fmi2Real x[],
                                                  size_t nx);
 
-FMI4C_DLLAPI fmi2Status fmi2_getDerivatives(fmiHandle* fmu, fmi2Component comp,
+FMI4C_DLLAPI fmi2Status fmi2_getDerivatives(fmi2InstanceHandle *instance,
                                             fmi2Real derivatives[],
                                             size_t nx);
-FMI4C_DLLAPI fmi2Status fmi2_getEventIndicators(fmiHandle* fmu, fmi2Component comp,
+FMI4C_DLLAPI fmi2Status fmi2_getEventIndicators(fmi2InstanceHandle *instance,
                                                 fmi2Real eventIndicators[],
                                                 size_t ni);
-FMI4C_DLLAPI fmi2Status fmi2_getContinuousStates(fmiHandle* fmu, fmi2Component comp,
+FMI4C_DLLAPI fmi2Status fmi2_getContinuousStates(fmi2InstanceHandle *instance,
                                                  fmi2Real x[],
                                                  size_t nx);
-FMI4C_DLLAPI fmi2Status fmi2_getNominalsOfContinuousStates(fmiHandle* fmu, fmi2Component comp,
+FMI4C_DLLAPI fmi2Status fmi2_getNominalsOfContinuousStates(fmi2InstanceHandle *instance,
                                                            fmi2Real x_nominal[],
                                                            size_t nx);
 
-FMI4C_DLLAPI fmi2Status fmi2_setRealInputDerivatives(fmiHandle* fmu, fmi2Component comp,
+FMI4C_DLLAPI fmi2Status fmi2_setRealInputDerivatives(fmi2InstanceHandle *instance,
                                                      const fmi2ValueReference vr[],
                                                      size_t nvr,
                                                      const fmi2Integer order[],
                                                      const fmi2Real value[]);
-FMI4C_DLLAPI fmi2Status fmi2_getRealOutputDerivatives (fmiHandle* fmu, fmi2Component comp,
+FMI4C_DLLAPI fmi2Status fmi2_getRealOutputDerivatives (fmi2InstanceHandle *instance,
                                                       const fmi2ValueReference vr[],
                                                       size_t nvr,
                                                       const fmi2Integer order[],
                                                       fmi2Real value[]);
 
-FMI4C_DLLAPI fmi2Status fmi2_doStep(fmiHandle *fmu, fmi2Component comp, fmi2Real currentCommunicationPoint, fmi2Real communicationStepSize, fmi2Boolean noSetFMUStatePriorToCurrentPoint);
-FMI4C_DLLAPI fmi2Status fmi2_cancelStep(fmiHandle* fmu);
+FMI4C_DLLAPI fmi2Status fmi2_doStep(fmi2InstanceHandle *instance, fmi2Real currentCommunicationPoint, fmi2Real communicationStepSize, fmi2Boolean noSetFMUStatePriorToCurrentPoint);
+FMI4C_DLLAPI fmi2Status fmi2_cancelStep(fmi2InstanceHandle *instance);
 
-FMI4C_DLLAPI fmi2Status fmi2_getStatus(fmiHandle* fmu, const fmi2StatusKind s, fmi2Status* value);
-FMI4C_DLLAPI fmi2Status fmi2_getRealStatus(fmiHandle* fmu, const fmi2StatusKind s, fmi2Real* value);
-FMI4C_DLLAPI fmi2Status fmi2_getIntegerStatus(fmiHandle* fmu, const fmi2StatusKind s, fmi2Integer* value);
-FMI4C_DLLAPI fmi2Status fmi2_getBooleanStatus(fmiHandle* fmu, const fmi2StatusKind s, fmi2Boolean* value);
-FMI4C_DLLAPI fmi2Status fmi2_getStringStatus(fmiHandle* fmu, const fmi2StatusKind s, fmi2String* value);
+FMI4C_DLLAPI fmi2Status fmi2_getStatus(fmi2InstanceHandle *instance, const fmi2StatusKind s, fmi2Status* value);
+FMI4C_DLLAPI fmi2Status fmi2_getRealStatus(fmi2InstanceHandle *instance, const fmi2StatusKind s, fmi2Real* value);
+FMI4C_DLLAPI fmi2Status fmi2_getIntegerStatus(fmi2InstanceHandle *instance, const fmi2StatusKind s, fmi2Integer* value);
+FMI4C_DLLAPI fmi2Status fmi2_getBooleanStatus(fmi2InstanceHandle *instance, const fmi2StatusKind s, fmi2Boolean* value);
+FMI4C_DLLAPI fmi2Status fmi2_getStringStatus(fmi2InstanceHandle *instance, const fmi2StatusKind s, fmi2String* value);
 
 
-FMI4C_DLLAPI int fmi3_getNumberOfVariables(fmiHandle *fmu);
-FMI4C_DLLAPI fmi3VariableHandle* fmi3_getVariableByName(fmiHandle *fmu, fmi3String name);
-FMI4C_DLLAPI fmi3VariableHandle* fmi3_getVariableByIndex(fmiHandle *fmu, int i);
-FMI4C_DLLAPI fmi3VariableHandle* fmi3_getVariableByValueReference(fmiHandle *fmu, fmi3ValueReference vr);
+FMI4C_DLLAPI int fmi3_getNumberOfVariables(fmuHandle *fmu);
+FMI4C_DLLAPI fmi3VariableHandle* fmi3_getVariableByName(fmuHandle *fmu, fmi3String name);
+FMI4C_DLLAPI fmi3VariableHandle* fmi3_getVariableByIndex(fmuHandle *fmu, int i);
+FMI4C_DLLAPI fmi3VariableHandle* fmi3_getVariableByValueReference(fmuHandle *fmu, fmi3ValueReference vr);
 FMI4C_DLLAPI const char* fmi3_getVariableName(fmi3VariableHandle* var);
 FMI4C_DLLAPI fmi3Causality fmi3_getVariableCausality(fmi3VariableHandle* var);
 FMI4C_DLLAPI fmi3Variability fmi3_getVariableVariability(fmi3VariableHandle* var);
@@ -363,37 +363,37 @@ FMI4C_DLLAPI fmi3String fmi3_getVariableStartString(fmi3VariableHandle *var);
 FMI4C_DLLAPI fmi3Binary fmi3_getVariableStartBinary(fmi3VariableHandle *var);
 FMI4C_DLLAPI fmi3ValueReference fmi3_getVariableValueReference(fmi3VariableHandle* var);
 
-FMI4C_DLLAPI const char* fmi3_modelName(fmiHandle *fmu);
-FMI4C_DLLAPI const char* fmi3_instantiationToken(fmiHandle *fmu);
-FMI4C_DLLAPI const char* fmi3_description(fmiHandle *fmu);
-FMI4C_DLLAPI const char* fmi3_author(fmiHandle *fmu);
-FMI4C_DLLAPI const char* fmi3_version(fmiHandle *fmu);
-FMI4C_DLLAPI const char* fmi3_copyright(fmiHandle *fmu);
-FMI4C_DLLAPI const char* fmi3_license(fmiHandle *fmu);
-FMI4C_DLLAPI const char* fmi3_generationTool(fmiHandle *fmu);
-FMI4C_DLLAPI const char* fmi3_generationDateAndTime(fmiHandle *fmu);
-FMI4C_DLLAPI const char* fmi3_variableNamingConvention(fmiHandle *fmu);
-FMI4C_DLLAPI bool fmi3_supportsModelExchange(fmiHandle *fmu);
-FMI4C_DLLAPI bool fmi3_supportsScheduledExecution(fmiHandle *fmu);
-FMI4C_DLLAPI bool fmi3_supportsCoSimulation(fmiHandle *fmu);
-FMI4C_DLLAPI bool fmi3_defaultStartTimeDefined(fmiHandle *fmu);
-FMI4C_DLLAPI bool fmi3_defaultStopTimeDefined(fmiHandle *fmu);
-FMI4C_DLLAPI bool fmi3_defaultToleranceDefined(fmiHandle *fmu) ;
-FMI4C_DLLAPI bool fmi3_defaultStepSizeDefined(fmiHandle *fmu);
-FMI4C_DLLAPI double fmi3_getDefaultStartTime(fmiHandle *fmu);
-FMI4C_DLLAPI double fmi3_getDefaultStopTime(fmiHandle *fmu);
-FMI4C_DLLAPI double fmi3_getDefaultTolerance(fmiHandle *fmu);
-FMI4C_DLLAPI double fmi3_getDefaultStepSize(fmiHandle *fmu);
+FMI4C_DLLAPI const char* fmi3_modelName(fmuHandle *fmu);
+FMI4C_DLLAPI const char* fmi3_instantiationToken(fmuHandle *fmu);
+FMI4C_DLLAPI const char* fmi3_description(fmuHandle *fmu);
+FMI4C_DLLAPI const char* fmi3_author(fmuHandle *fmu);
+FMI4C_DLLAPI const char* fmi3_version(fmuHandle *fmu);
+FMI4C_DLLAPI const char* fmi3_copyright(fmuHandle *fmu);
+FMI4C_DLLAPI const char* fmi3_license(fmuHandle *fmu);
+FMI4C_DLLAPI const char* fmi3_generationTool(fmuHandle *fmu);
+FMI4C_DLLAPI const char* fmi3_generationDateAndTime(fmuHandle *fmu);
+FMI4C_DLLAPI const char* fmi3_variableNamingConvention(fmuHandle *fmu);
+FMI4C_DLLAPI bool fmi3_supportsModelExchange(fmuHandle *fmu);
+FMI4C_DLLAPI bool fmi3_supportsScheduledExecution(fmuHandle *fmu);
+FMI4C_DLLAPI bool fmi3_supportsCoSimulation(fmuHandle *fmu);
+FMI4C_DLLAPI bool fmi3_defaultStartTimeDefined(fmuHandle *fmu);
+FMI4C_DLLAPI bool fmi3_defaultStopTimeDefined(fmuHandle *fmu);
+FMI4C_DLLAPI bool fmi3_defaultToleranceDefined(fmuHandle *fmu) ;
+FMI4C_DLLAPI bool fmi3_defaultStepSizeDefined(fmuHandle *fmu);
+FMI4C_DLLAPI double fmi3_getDefaultStartTime(fmuHandle *fmu);
+FMI4C_DLLAPI double fmi3_getDefaultStopTime(fmuHandle *fmu);
+FMI4C_DLLAPI double fmi3_getDefaultTolerance(fmuHandle *fmu);
+FMI4C_DLLAPI double fmi3_getDefaultStepSize(fmuHandle *fmu);
 
-FMI4C_DLLAPI int fmi3_getNumberOfUnits(fmiHandle *fmu);
-FMI4C_DLLAPI fmi3UnitHandle *fmi3_getUnitByIndex(fmiHandle *fmu, int i);
+FMI4C_DLLAPI int fmi3_getNumberOfUnits(fmuHandle *fmu);
+FMI4C_DLLAPI fmi3UnitHandle *fmi3_getUnitByIndex(fmuHandle *fmu, int i);
 FMI4C_DLLAPI const char* fmi3_getUnitName(fmi3UnitHandle *unit);
 FMI4C_DLLAPI bool fmi3_hasBaseUnit(fmi3UnitHandle *unit);
 FMI4C_DLLAPI void fmi3_getBaseUnit(fmi3UnitHandle *unit, double *factor, double *offset, int *kg, int *m, int *s, int *A, int *K, int *mol, int *cd, int *rad);
 FMI4C_DLLAPI int fmi3_getNumberOfDisplayUnits(fmi3UnitHandle *unit);
 FMI4C_DLLAPI void fmi3_getDisplayUnitByIndex(fmi3UnitHandle *unit, int id, const char **name, double *factor, double *offset, bool *inverse);
 
-FMI4C_DLLAPI void fmi3_getFloat64Type(fmiHandle* fmu,
+FMI4C_DLLAPI void fmi3_getFloat64Type(fmuHandle* fmu,
                                       const char* name,
                                       const char** description,
                                       const char** quantity,
@@ -404,7 +404,7 @@ FMI4C_DLLAPI void fmi3_getFloat64Type(fmiHandle* fmu,
                                       double* min,
                                       double* max,
                                       double* nominal);
-FMI4C_DLLAPI void fmi3_getFloat32Type(fmiHandle* fmu,
+FMI4C_DLLAPI void fmi3_getFloat32Type(fmuHandle* fmu,
                                       const char* name,
                                       const char** description,
                                       const char** quantity,
@@ -415,79 +415,79 @@ FMI4C_DLLAPI void fmi3_getFloat32Type(fmiHandle* fmu,
                                       float *min,
                                       float *max,
                                       float *nominal);
-FMI4C_DLLAPI void fmi3_getInt64Type(fmiHandle *fmu,
+FMI4C_DLLAPI void fmi3_getInt64Type(fmuHandle *fmu,
                                     const char *name,
                                     const char** description,
                                     const char** quantity,
                                     int64_t* min,
                                     int64_t* max);
-FMI4C_DLLAPI void fmi3_getInt32Type(fmiHandle *fmu,
+FMI4C_DLLAPI void fmi3_getInt32Type(fmuHandle *fmu,
                                     const char *name,
                                     const char** description,
                                     const char** quantity,
                                     int32_t* min,
                                     int32_t* max);
-FMI4C_DLLAPI void fmi3_getInt16Type(fmiHandle *fmu,
+FMI4C_DLLAPI void fmi3_getInt16Type(fmuHandle *fmu,
                                     const char *name,
                                     const char** description,
                                     const char** quantity,
                                     int16_t* min,
                                     int16_t* max);
-FMI4C_DLLAPI void fmi3_getInt8Type(fmiHandle *fmu,
+FMI4C_DLLAPI void fmi3_getInt8Type(fmuHandle *fmu,
                                    const char *name,
                                    const char** description,
                                    const char** quantity,
                                    int8_t* min,
                                    int8_t* max);
-FMI4C_DLLAPI void fmi3_getUInt64Type(fmiHandle *fmu,
+FMI4C_DLLAPI void fmi3_getUInt64Type(fmuHandle *fmu,
                                      const char *name,
                                      const char** description,
                                      const char** quantity,
                                      uint64_t* min,
                                      uint64_t* max);
-FMI4C_DLLAPI void fmi3_getUInt32Type(fmiHandle *fmu,
+FMI4C_DLLAPI void fmi3_getUInt32Type(fmuHandle *fmu,
                                      const char *name,
                                      const char** description,
                                      const char** quantity,
                                      uint32_t* min,
                                      uint32_t* max);
-FMI4C_DLLAPI void fmi3_getUInt16Type(fmiHandle *fmu,
+FMI4C_DLLAPI void fmi3_getUInt16Type(fmuHandle *fmu,
                                      const char *name,
                                      const char** description,
                                      const char** quantity,
                                      uint16_t* min,
                                      uint16_t* max);
-FMI4C_DLLAPI void fmi3_getUInt8Type(fmiHandle *fmu,
+FMI4C_DLLAPI void fmi3_getUInt8Type(fmuHandle *fmu,
                                     const char *name,
                                     const char** description,
                                     const char** quantity,
                                     uint8_t* min,
                                     uint8_t* max);
-FMI4C_DLLAPI void fmi3_getBooleanType(fmiHandle *fmu,
+FMI4C_DLLAPI void fmi3_getBooleanType(fmuHandle *fmu,
                                       const char *name,
                                       const char **description);
-FMI4C_DLLAPI void fmi3_getStringType(fmiHandle *fmu,
+FMI4C_DLLAPI void fmi3_getStringType(fmuHandle *fmu,
                                      const char *name,
                                      const char **description);
-FMI4C_DLLAPI void fmi3_getBinaryType(fmiHandle *fmu,
+FMI4C_DLLAPI void fmi3_getBinaryType(fmuHandle *fmu,
                                      const char *name,
                                      const char **description,
                                      const char **mimeType,
                                      uint32_t *maxSize);
-FMI4C_DLLAPI void fmi3_getEnumerationType(fmiHandle *fmu,
+FMI4C_DLLAPI void fmi3_getEnumerationType(fmuHandle *fmu,
                                           const char *name,
                                           const char **description,
                                           const char **quantity,
                                           int64_t *min,
                                           int64_t *max,
                                           int *numberOfItems);
-FMI4C_DLLAPI void fmi3_getEnumerationItem(fmiHandle *fmu,
+FMI4C_DLLAPI void fmi3_getEnumerationItem(fmuHandle *fmu,
                                           const char *typeName,
                                           int itemId,
                                           const char **itemName,
                                           int64_t *value,
                                           const char **description);
-FMI4C_DLLAPI void fmi3_getClockType(fmiHandle *fmu,
+FMI4C_DLLAPI void fmi3_getClockType(fmuHandle *fmu,
                                     const char *name,
                                     const char **description,
                                     bool *canBeDeactivated,
@@ -500,63 +500,63 @@ FMI4C_DLLAPI void fmi3_getClockType(fmiHandle *fmu,
                                     uint64_t *intervalCounter,
                                     uint64_t *shiftCounter);
 
-FMI4C_DLLAPI int fmi3_getNumberOfLogCategories(fmiHandle *fmu);
-FMI4C_DLLAPI void fmi3_getLogCategory(fmiHandle *fmu, int id, const char **name, const char **description);
+FMI4C_DLLAPI int fmi3_getNumberOfLogCategories(fmuHandle *fmu);
+FMI4C_DLLAPI void fmi3_getLogCategory(fmuHandle *fmu, int id, const char **name, const char **description);
 
-FMI4C_DLLAPI int fmi3_getNumberOfModelStructureOutputs(fmiHandle *fmu);
-FMI4C_DLLAPI int fmi3_getNumberOfModelStructureContinuousStateDerivatives(fmiHandle *fmu);
-FMI4C_DLLAPI int fmi3_getNumberOfModelStructureClockedStates(fmiHandle *fmu);
-FMI4C_DLLAPI int fmi3_getNumberOfModelStructureInitialUnknowns(fmiHandle *fmu);
-FMI4C_DLLAPI int fmi3_getNumberOfModelStructureEventIndicators(fmiHandle *fmu);
-FMI4C_DLLAPI fmi3ModelStructureHandle *fmi3_getModelStructureOutput(fmiHandle *fmu, size_t i);
-FMI4C_DLLAPI fmi3ModelStructureHandle *fmi3_getModelStructureContinuousStateDerivative(fmiHandle *fmu, size_t i);
-FMI4C_DLLAPI fmi3ModelStructureHandle *fmi3_getModelStructureClockedState(fmiHandle *fmu, size_t i);
-FMI4C_DLLAPI fmi3ModelStructureHandle *fmi3_getModelStructureInitialUnknown(fmiHandle *fmu, size_t i);
-FMI4C_DLLAPI fmi3ModelStructureHandle *fmi3_getModelStructureEventIndicator(fmiHandle *fmu, size_t i);
+FMI4C_DLLAPI int fmi3_getNumberOfModelStructureOutputs(fmuHandle *fmu);
+FMI4C_DLLAPI int fmi3_getNumberOfModelStructureContinuousStateDerivatives(fmuHandle *fmu);
+FMI4C_DLLAPI int fmi3_getNumberOfModelStructureClockedStates(fmuHandle *fmu);
+FMI4C_DLLAPI int fmi3_getNumberOfModelStructureInitialUnknowns(fmuHandle *fmu);
+FMI4C_DLLAPI int fmi3_getNumberOfModelStructureEventIndicators(fmuHandle *fmu);
+FMI4C_DLLAPI fmi3ModelStructureHandle *fmi3_getModelStructureOutput(fmuHandle *fmu, size_t i);
+FMI4C_DLLAPI fmi3ModelStructureHandle *fmi3_getModelStructureContinuousStateDerivative(fmuHandle *fmu, size_t i);
+FMI4C_DLLAPI fmi3ModelStructureHandle *fmi3_getModelStructureClockedState(fmuHandle *fmu, size_t i);
+FMI4C_DLLAPI fmi3ModelStructureHandle *fmi3_getModelStructureInitialUnknown(fmuHandle *fmu, size_t i);
+FMI4C_DLLAPI fmi3ModelStructureHandle *fmi3_getModelStructureEventIndicator(fmuHandle *fmu, size_t i);
 FMI4C_DLLAPI fmi3ValueReference fmi3_getModelStructureValueReference(fmi3ModelStructureHandle *handle);
 FMI4C_DLLAPI int fmi3_getModelStructureNumberOfDependencies(fmi3ModelStructureHandle *handle);
 FMI4C_DLLAPI bool fmi3_getModelStructureDependencyKindsDefined(fmi3ModelStructureHandle *handle);
 FMI4C_DLLAPI void fmi3_getModelStructureDependencies(fmi3ModelStructureHandle *handle, int *dependencies, size_t numberOfDependencies);
 FMI4C_DLLAPI void fmi3_getModelStructureDependencyKinds(fmi3ModelStructureHandle *handle, int *dependencyKinds, size_t numberOfDependencies);
 
-FMI4C_DLLAPI const char* fmi3cs_getModelIdentifier(fmiHandle* fmu);
-FMI4C_DLLAPI bool fmi3cs_getNeedsExecutionTool(fmiHandle* fmu);
-FMI4C_DLLAPI bool fmi3cs_getCanBeInstantiatedOnlyOncePerProcess(fmiHandle* fmu);
-FMI4C_DLLAPI bool fmi3cs_getCanGetAndSetFMUState(fmiHandle* fmu);
-FMI4C_DLLAPI bool fmi3cs_getCanSerializeFMUState(fmiHandle* fmu);
-FMI4C_DLLAPI bool fmi3cs_getProvidesDirectionalDerivative(fmiHandle* fmu);
-FMI4C_DLLAPI bool fmi3cs_getProvidesAdjointDerivatives(fmiHandle* fmu);
-FMI4C_DLLAPI bool fmi3cs_getProvidesPerElementDependencies(fmiHandle* fmu);
-FMI4C_DLLAPI bool fmi3cs_getProvidesIntermediateUpdate(fmiHandle* fmu);
-FMI4C_DLLAPI bool fmi3cs_getProvidesEvaluateDiscreteStates(fmiHandle* fmu);
-FMI4C_DLLAPI bool fmi3cs_getHasEventMode(fmiHandle* fmu);
-FMI4C_DLLAPI bool fmi3cs_getRecommendedIntermediateInputSmoothness(fmiHandle* fmu);
-FMI4C_DLLAPI int fmi3cs_getMaxOutputDerivativeOrder(fmiHandle* fmu);
-FMI4C_DLLAPI bool fmi3cs_getCanHandleVariableCommunicationStepSize(fmiHandle* fmu);
-FMI4C_DLLAPI bool fmi3cs_getCanReturnEarlyAfterIntermediateUpdate(fmiHandle* fmu);
-FMI4C_DLLAPI double fmi3cs_getFixedInternalStepSize(fmiHandle* fmu);
+FMI4C_DLLAPI const char* fmi3cs_getModelIdentifier(fmuHandle* fmu);
+FMI4C_DLLAPI bool fmi3cs_getNeedsExecutionTool(fmuHandle* fmu);
+FMI4C_DLLAPI bool fmi3cs_getCanBeInstantiatedOnlyOncePerProcess(fmuHandle* fmu);
+FMI4C_DLLAPI bool fmi3cs_getCanGetAndSetFMUState(fmuHandle* fmu);
+FMI4C_DLLAPI bool fmi3cs_getCanSerializeFMUState(fmuHandle* fmu);
+FMI4C_DLLAPI bool fmi3cs_getProvidesDirectionalDerivative(fmuHandle* fmu);
+FMI4C_DLLAPI bool fmi3cs_getProvidesAdjointDerivatives(fmuHandle* fmu);
+FMI4C_DLLAPI bool fmi3cs_getProvidesPerElementDependencies(fmuHandle* fmu);
+FMI4C_DLLAPI bool fmi3cs_getProvidesIntermediateUpdate(fmuHandle* fmu);
+FMI4C_DLLAPI bool fmi3cs_getProvidesEvaluateDiscreteStates(fmuHandle* fmu);
+FMI4C_DLLAPI bool fmi3cs_getHasEventMode(fmuHandle* fmu);
+FMI4C_DLLAPI bool fmi3cs_getRecommendedIntermediateInputSmoothness(fmuHandle* fmu);
+FMI4C_DLLAPI int fmi3cs_getMaxOutputDerivativeOrder(fmuHandle* fmu);
+FMI4C_DLLAPI bool fmi3cs_getCanHandleVariableCommunicationStepSize(fmuHandle* fmu);
+FMI4C_DLLAPI bool fmi3cs_getCanReturnEarlyAfterIntermediateUpdate(fmuHandle* fmu);
+FMI4C_DLLAPI double fmi3cs_getFixedInternalStepSize(fmuHandle* fmu);
 
-FMI4C_DLLAPI const char* fmi3me_getModelIdentifier(fmiHandle* fmu);
-FMI4C_DLLAPI bool fmi3me_getNeedsExecutionTool(fmiHandle* fmu);
-FMI4C_DLLAPI bool fmi3me_getCanBeInstantiatedOnlyOncePerProcess(fmiHandle* fmu);
-FMI4C_DLLAPI bool fmi3me_getCanGetAndSetFMUState(fmiHandle* fmu);
-FMI4C_DLLAPI bool fmi3me_getCanSerializeFMUState(fmiHandle* fmu);
-FMI4C_DLLAPI bool fmi3me_getProvidesDirectionalDerivative(fmiHandle* fmu);
-FMI4C_DLLAPI bool fmi3me_getProvidesAdjointDerivatives(fmiHandle* fmu);
-FMI4C_DLLAPI bool fmi3me_getProvidesPerElementDependencies(fmiHandle* fmu);
-FMI4C_DLLAPI bool fmi3me_getProvidesEvaluateDiscreteStates(fmiHandle* fmu);
-FMI4C_DLLAPI bool fmi3me_getNeedsCompletedIntegratorStep(fmiHandle* fmu);
+FMI4C_DLLAPI const char* fmi3me_getModelIdentifier(fmuHandle* fmu);
+FMI4C_DLLAPI bool fmi3me_getNeedsExecutionTool(fmuHandle* fmu);
+FMI4C_DLLAPI bool fmi3me_getCanBeInstantiatedOnlyOncePerProcess(fmuHandle* fmu);
+FMI4C_DLLAPI bool fmi3me_getCanGetAndSetFMUState(fmuHandle* fmu);
+FMI4C_DLLAPI bool fmi3me_getCanSerializeFMUState(fmuHandle* fmu);
+FMI4C_DLLAPI bool fmi3me_getProvidesDirectionalDerivative(fmuHandle* fmu);
+FMI4C_DLLAPI bool fmi3me_getProvidesAdjointDerivatives(fmuHandle* fmu);
+FMI4C_DLLAPI bool fmi3me_getProvidesPerElementDependencies(fmuHandle* fmu);
+FMI4C_DLLAPI bool fmi3me_getProvidesEvaluateDiscreteStates(fmuHandle* fmu);
+FMI4C_DLLAPI bool fmi3me_getNeedsCompletedIntegratorStep(fmuHandle* fmu);
 
-FMI4C_DLLAPI const char* fmi3se_getModelIdentifier(fmiHandle* fmu);
-FMI4C_DLLAPI bool fmi3se_getNeedsExecutionTool(fmiHandle* fmu);
-FMI4C_DLLAPI bool fmi3se_getCanBeInstantiatedOnlyOncePerProcess(fmiHandle* fmu);
-FMI4C_DLLAPI bool fmi3se_getCanGetAndSetFMUState(fmiHandle* fmu);
-FMI4C_DLLAPI bool fmi3se_getCanSerializeFMUState(fmiHandle* fmu);
-FMI4C_DLLAPI bool fmi3se_getProvidesDirectionalDerivative(fmiHandle* fmu);
-FMI4C_DLLAPI bool fmi3se_getProvidesAdjointDerivatives(fmiHandle* fmu);
-FMI4C_DLLAPI bool fmi3se_getProvidesPerElementDependencies(fmiHandle* fmu);
+FMI4C_DLLAPI const char* fmi3se_getModelIdentifier(fmuHandle* fmu);
+FMI4C_DLLAPI bool fmi3se_getNeedsExecutionTool(fmuHandle* fmu);
+FMI4C_DLLAPI bool fmi3se_getCanBeInstantiatedOnlyOncePerProcess(fmuHandle* fmu);
+FMI4C_DLLAPI bool fmi3se_getCanGetAndSetFMUState(fmuHandle* fmu);
+FMI4C_DLLAPI bool fmi3se_getCanSerializeFMUState(fmuHandle* fmu);
+FMI4C_DLLAPI bool fmi3se_getProvidesDirectionalDerivative(fmuHandle* fmu);
+FMI4C_DLLAPI bool fmi3se_getProvidesAdjointDerivatives(fmuHandle* fmu);
+FMI4C_DLLAPI bool fmi3se_getProvidesPerElementDependencies(fmuHandle* fmu);
 
-FMI4C_DLLAPI bool fmi3_instantiateCoSimulation(fmiHandle *fmu,
+FMI4C_DLLAPI bool fmi3_instantiateCoSimulation(fmuHandle *fmu,
                                               fmi3Boolean                    visible,
                                               fmi3Boolean                    loggingOn,
                                               fmi3Boolean                    eventModeUsed,
@@ -567,45 +567,45 @@ FMI4C_DLLAPI bool fmi3_instantiateCoSimulation(fmiHandle *fmu,
                                               fmi3LogMessageCallback         logMessage,
                                               fmi3IntermediateUpdateCallback intermediateUpdate);
 
-FMI4C_DLLAPI bool fmi3_instantiateModelExchange(fmiHandle *fmu,
+FMI4C_DLLAPI bool fmi3_instantiateModelExchange(fmuHandle *fmu,
                                                fmi3Boolean                visible,
                                                fmi3Boolean                loggingOn,
                                                fmi3InstanceEnvironment    instanceEnvironment,
                                                fmi3LogMessageCallback     logMessage);
 
-FMI4C_DLLAPI const char* fmi3_getVersion(fmiHandle *fmu);
+FMI4C_DLLAPI const char* fmi3_getVersion(fmuHandle *fmu);
 
-FMI4C_DLLAPI fmi3Status fmi3_setDebugLogging(fmiHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3_setDebugLogging(fmuHandle *fmu,
                                             fmi3Boolean loggingOn,
                                             size_t nCategories,
                                             const fmi3String categories[]);
 
-FMI4C_DLLAPI fmi3Status fmi3_getFloat64(fmiHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3_getFloat64(fmuHandle *fmu,
                                        const fmi3ValueReference valueReferences[],
                                        size_t nValueReferences,
                                        fmi3Float64 values[],
                                        size_t nValues);
 
-FMI4C_DLLAPI fmi3Status fmi3_setFloat64(fmiHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3_setFloat64(fmuHandle *fmu,
                                        const fmi3ValueReference valueReferences[],
                                        size_t nValueReferences,
                                        const fmi3Float64 values[],
                                        size_t nValues);
 
-FMI4C_DLLAPI fmi3Status fmi3_enterInitializationMode(fmiHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3_enterInitializationMode(fmuHandle *fmu,
                                                     fmi3Boolean toleranceDefined,
                                                     fmi3Float64 tolerance,
                                                     fmi3Float64 startTime,
                                                     fmi3Boolean stopTimeDefined,
                                                     fmi3Float64 stopTime);
 
-FMI4C_DLLAPI fmi3Status fmi3_exitInitializationMode(fmiHandle *fmu);
+FMI4C_DLLAPI fmi3Status fmi3_exitInitializationMode(fmuHandle *fmu);
 
-FMI4C_DLLAPI fmi3Status fmi3_terminate(fmiHandle *fmu);
+FMI4C_DLLAPI fmi3Status fmi3_terminate(fmuHandle *fmu);
 
-FMI4C_DLLAPI void fmi3_freeInstance(fmiHandle *fmu);
+FMI4C_DLLAPI void fmi3_freeInstance(fmuHandle *fmu);
 
-FMI4C_DLLAPI fmi3Status fmi3_doStep(fmiHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3_doStep(fmuHandle *fmu,
                                    fmi3Float64 currentCommunicationPoint,
                                    fmi3Float64 communicationStepSize,
                                    fmi3Boolean noSetFMUStatePriorToCurrentPoint,
@@ -614,171 +614,171 @@ FMI4C_DLLAPI fmi3Status fmi3_doStep(fmiHandle *fmu,
                                    fmi3Boolean *earlyReturn,
                                    fmi3Float64 *lastSuccessfulTime);
 
-FMI4C_DLLAPI fmi3Status fmi3_enterEventMode(fmiHandle *fmu);
+FMI4C_DLLAPI fmi3Status fmi3_enterEventMode(fmuHandle *fmu);
 
-FMI4C_DLLAPI fmi3Status fmi3_reset(fmiHandle *fmu);
+FMI4C_DLLAPI fmi3Status fmi3_reset(fmuHandle *fmu);
 
-FMI4C_DLLAPI fmi3Status fmi3_getFloat32(fmiHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3_getFloat32(fmuHandle *fmu,
                                        const fmi3ValueReference valueReferences[],
                                        size_t nValueReferences,
                                        fmi3Float32 values[],
                                        size_t nValues);
 
-FMI4C_DLLAPI fmi3Status fmi3_getInt8(fmiHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3_getInt8(fmuHandle *fmu,
                                     const fmi3ValueReference valueReferences[],
                                     size_t nValueReferences,
                                     fmi3Int8 values[],
                                     size_t nValues);
 
-FMI4C_DLLAPI fmi3Status fmi3_getUInt8(fmiHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3_getUInt8(fmuHandle *fmu,
                                      const fmi3ValueReference valueReferences[],
                                      size_t nValueReferences,
                                      fmi3UInt8 values[],
                                      size_t nValues);
 
-FMI4C_DLLAPI fmi3Status fmi3_getInt16(fmiHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3_getInt16(fmuHandle *fmu,
                                      const fmi3ValueReference valueReferences[],
                                      size_t nValueReferences,
                                      fmi3Int16 values[],
                                      size_t nValues);
 
-FMI4C_DLLAPI fmi3Status fmi3_getUInt16(fmiHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3_getUInt16(fmuHandle *fmu,
                                       const fmi3ValueReference valueReferences[],
                                       size_t nValueReferences,
                                       fmi3UInt16 values[],
                                       size_t nValues);
 
-FMI4C_DLLAPI fmi3Status fmi3_getInt32(fmiHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3_getInt32(fmuHandle *fmu,
                                      const fmi3ValueReference valueReferences[],
                                      size_t nValueReferences,
                                      fmi3Int32 values[],
                                      size_t nValues);
 
-FMI4C_DLLAPI fmi3Status fmi3_getUInt32(fmiHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3_getUInt32(fmuHandle *fmu,
                                       const fmi3ValueReference valueReferences[],
                                       size_t nValueReferences,
                                       fmi3UInt32 values[],
                                       size_t nValues);
 
-FMI4C_DLLAPI fmi3Status fmi3_getInt64(fmiHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3_getInt64(fmuHandle *fmu,
                                      const fmi3ValueReference valueReferences[],
                                      size_t nValueReferences,
                                      fmi3Int64 values[],
                                      size_t nValues);
 
-FMI4C_DLLAPI fmi3Status fmi3_getUInt64(fmiHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3_getUInt64(fmuHandle *fmu,
                                       const fmi3ValueReference valueReferences[],
                                       size_t nValueReferences,
                                       fmi3UInt64 values[],
                                       size_t nValues);
 
-FMI4C_DLLAPI fmi3Status fmi3_getBoolean(fmiHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3_getBoolean(fmuHandle *fmu,
                                        const fmi3ValueReference valueReferences[],
                                        size_t nValueReferences,
                                        fmi3Boolean values[],
                                        size_t nValues);
 
-FMI4C_DLLAPI fmi3Status fmi3_getString(fmiHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3_getString(fmuHandle *fmu,
                                       const fmi3ValueReference valueReferences[],
                                       size_t nValueReferences,
                                       fmi3String values[],
                                       size_t nValues);
 
-FMI4C_DLLAPI fmi3Status fmi3_getBinary(fmiHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3_getBinary(fmuHandle *fmu,
                                       const fmi3ValueReference valueReferences[],
                                       size_t nValueReferences,
                                       size_t valueSizes[],
                                       fmi3Binary values[],
                                       size_t nValues);
 
-FMI4C_DLLAPI fmi3Status fmi3_getClock(fmiHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3_getClock(fmuHandle *fmu,
                                      const fmi3ValueReference valueReferences[],
                                      size_t nValueReferences,
                                      fmi3Clock values[]);
 
-FMI4C_DLLAPI fmi3Status fmi3_setFloat32(fmiHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3_setFloat32(fmuHandle *fmu,
                                        const fmi3ValueReference valueReferences[],
                                        size_t nValueReferences,
                                        const fmi3Float32 values[],
                                        size_t nValues);
 
-FMI4C_DLLAPI fmi3Status fmi3_setInt8(fmiHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3_setInt8(fmuHandle *fmu,
                                     const fmi3ValueReference valueReferences[],
                                     size_t nValueReferences,
                                     const fmi3Int8 values[],
                                     size_t nValues);
 
-FMI4C_DLLAPI fmi3Status fmi3_setUInt8(fmiHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3_setUInt8(fmuHandle *fmu,
                                      const fmi3ValueReference valueReferences[],
                                      size_t nValueReferences,
                                      const fmi3UInt8 values[],
                                      size_t nValues);
 
-FMI4C_DLLAPI fmi3Status fmi3_setInt16(fmiHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3_setInt16(fmuHandle *fmu,
                                      const fmi3ValueReference valueReferences[],
                                      size_t nValueReferences,
                                      const fmi3Int16 values[],
                                      size_t nValues);
 
-FMI4C_DLLAPI fmi3Status fmi3_setUInt16(fmiHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3_setUInt16(fmuHandle *fmu,
                                       const fmi3ValueReference valueReferences[],
                                       size_t nValueReferences,
                                       const fmi3UInt16 values[],
                                       size_t nValues);
 
-FMI4C_DLLAPI fmi3Status fmi3_setInt32(fmiHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3_setInt32(fmuHandle *fmu,
                                      const fmi3ValueReference valueReferences[],
                                      size_t nValueReferences,
                                      const fmi3Int32 values[],
                                      size_t nValues);
 
-FMI4C_DLLAPI fmi3Status fmi3_setUInt32(fmiHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3_setUInt32(fmuHandle *fmu,
                                       const fmi3ValueReference valueReferences[],
                                       size_t nValueReferences,
                                       const fmi3UInt32 values[],
                                       size_t nValues);
 
-FMI4C_DLLAPI fmi3Status fmi3_setInt64(fmiHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3_setInt64(fmuHandle *fmu,
                                      const fmi3ValueReference valueReferences[],
                                      size_t nValueReferences,
                                      const fmi3Int64 values[],
                                      size_t nValues);
 
-FMI4C_DLLAPI fmi3Status fmi3_setUInt64(fmiHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3_setUInt64(fmuHandle *fmu,
                                       const fmi3ValueReference valueReferences[],
                                       size_t nValueReferences,
                                       const fmi3UInt64 values[],
                                       size_t nValues);
 
-FMI4C_DLLAPI fmi3Status fmi3_setBoolean(fmiHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3_setBoolean(fmuHandle *fmu,
                                        const fmi3ValueReference valueReferences[],
                                        size_t nValueReferences,
                                        const fmi3Boolean values[],
                                        size_t nValues);
 
-FMI4C_DLLAPI fmi3Status fmi3_setString(fmiHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3_setString(fmuHandle *fmu,
                                       const fmi3ValueReference valueReferences[],
                                       size_t nValueReferences,
                                       const fmi3String values[],
                                       size_t nValues);
 
-FMI4C_DLLAPI fmi3Status fmi3_setBinary(fmiHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3_setBinary(fmuHandle *fmu,
                                       const fmi3ValueReference valueReferences[],
                                       size_t nValueReferences,
                                       const size_t valueSizes[],
                                       const fmi3Binary values[],
                                       size_t nValues);
 
-FMI4C_DLLAPI fmi3Status fmi3_setClock(fmiHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3_setClock(fmuHandle *fmu,
                                      const fmi3ValueReference valueReferences[],
                                      size_t nValueReferences,
                                      const fmi3Clock values[]);
 
-FMI4C_DLLAPI fmi3Status fmi3_getNumberOfVariableDependencies(fmiHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3_getNumberOfVariableDependencies(fmuHandle *fmu,
                                                             fmi3ValueReference valueReference,
                                                             size_t* nDependencies);
 
-FMI4C_DLLAPI fmi3Status fmi3_getVariableDependencies(fmiHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3_getVariableDependencies(fmuHandle *fmu,
                                                     fmi3ValueReference dependent,
                                                     size_t elementIndicesOfDependent[],
                                                     fmi3ValueReference independents[],
@@ -786,27 +786,27 @@ FMI4C_DLLAPI fmi3Status fmi3_getVariableDependencies(fmiHandle *fmu,
                                                     fmi3DependencyKind dependencyKinds[],
                                                     size_t nDependencies);
 
-FMI4C_DLLAPI fmi3Status fmi3_getFMUState(fmiHandle *fmu, fmi3FMUState* FMUState);
+FMI4C_DLLAPI fmi3Status fmi3_getFMUState(fmuHandle *fmu, fmi3FMUState* FMUState);
 
-FMI4C_DLLAPI fmi3Status fmi3_setFMUState(fmiHandle *fmu, fmi3FMUState  FMUState);
+FMI4C_DLLAPI fmi3Status fmi3_setFMUState(fmuHandle *fmu, fmi3FMUState  FMUState);
 
-FMI4C_DLLAPI fmi3Status fmi3_freeFMUState(fmiHandle *fmu, fmi3FMUState* FMUState);
+FMI4C_DLLAPI fmi3Status fmi3_freeFMUState(fmuHandle *fmu, fmi3FMUState* FMUState);
 
-FMI4C_DLLAPI fmi3Status fmi3_serializedFMUStateSize(fmiHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3_serializedFMUStateSize(fmuHandle *fmu,
                                                    fmi3FMUState  FMUState,
                                                    size_t* size);
 
-FMI4C_DLLAPI fmi3Status fmi3_serializeFMUState(fmiHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3_serializeFMUState(fmuHandle *fmu,
                                               fmi3FMUState  FMUState,
                                               fmi3Byte serializedState[],
                                               size_t size);
 
-FMI4C_DLLAPI fmi3Status fmi3_deserializeFMUState(fmiHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3_deserializeFMUState(fmuHandle *fmu,
                                                 const fmi3Byte serializedState[],
                                                 size_t size,
                                                 fmi3FMUState* FMUState);
 
-FMI4C_DLLAPI fmi3Status fmi3_getDirectionalDerivative(fmiHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3_getDirectionalDerivative(fmuHandle *fmu,
                                                      const fmi3ValueReference unknowns[],
                                                      size_t nUnknowns,
                                                      const fmi3ValueReference knowns[],
@@ -816,7 +816,7 @@ FMI4C_DLLAPI fmi3Status fmi3_getDirectionalDerivative(fmiHandle *fmu,
                                                      fmi3Float64 sensitivity[],
                                                      size_t nSensitivity);
 
-FMI4C_DLLAPI fmi3Status fmi3_getAdjointDerivative(fmiHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3_getAdjointDerivative(fmuHandle *fmu,
                                                  const fmi3ValueReference unknowns[],
                                                  size_t nUnknowns,
                                                  const fmi3ValueReference knowns[],
@@ -826,48 +826,48 @@ FMI4C_DLLAPI fmi3Status fmi3_getAdjointDerivative(fmiHandle *fmu,
                                                  fmi3Float64 sensitivity[],
                                                  size_t nSensitivity);
 
-FMI4C_DLLAPI fmi3Status fmi3_enterConfigurationMode(fmiHandle *fmu);
+FMI4C_DLLAPI fmi3Status fmi3_enterConfigurationMode(fmuHandle *fmu);
 
-FMI4C_DLLAPI fmi3Status fmi3_exitConfigurationMode(fmiHandle *fmu);
+FMI4C_DLLAPI fmi3Status fmi3_exitConfigurationMode(fmuHandle *fmu);
 
-FMI4C_DLLAPI fmi3Status fmi3_getIntervalDecimal(fmiHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3_getIntervalDecimal(fmuHandle *fmu,
                                                const fmi3ValueReference valueReferences[],
                                                size_t nValueReferences,
                                                fmi3Float64 intervals[],
                                                fmi3IntervalQualifier qualifiers[]);
 
-FMI4C_DLLAPI fmi3Status fmi3_getIntervalFraction(fmiHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3_getIntervalFraction(fmuHandle *fmu,
                                                 const fmi3ValueReference valueReferences[],
                                                 size_t nValueReferences,
                                                 fmi3UInt64 intervalCounters[],
                                                 fmi3UInt64 resolutions[],
                                                 fmi3IntervalQualifier qualifiers[]);
 
-FMI4C_DLLAPI fmi3Status fmi3_getShiftDecimal(fmiHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3_getShiftDecimal(fmuHandle *fmu,
                                             const fmi3ValueReference valueReferences[],
                                             size_t nValueReferences,
                                             fmi3Float64 shifts[]);
 
-FMI4C_DLLAPI fmi3Status fmi3_getShiftFraction(fmiHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3_getShiftFraction(fmuHandle *fmu,
                                              const fmi3ValueReference valueReferences[],
                                              size_t nValueReferences,
                                              fmi3UInt64 shiftCounters[],
                                              fmi3UInt64 resolutions[]);
 
-FMI4C_DLLAPI fmi3Status fmi3_setIntervalDecimal(fmiHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3_setIntervalDecimal(fmuHandle *fmu,
                                                const fmi3ValueReference valueReferences[],
                                                size_t nValueReferences,
                                                const fmi3Float64 intervals[]);
 
-FMI4C_DLLAPI fmi3Status fmi3_setIntervalFraction(fmiHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3_setIntervalFraction(fmuHandle *fmu,
                                                 const fmi3ValueReference valueReferences[],
                                                 size_t nValueReferences,
                                                 const fmi3UInt64 intervalCounters[],
                                                 const fmi3UInt64 resolutions[]);
 
-FMI4C_DLLAPI fmi3Status fmi3_evaluateDiscreteStates(fmiHandle *fmu);
+FMI4C_DLLAPI fmi3Status fmi3_evaluateDiscreteStates(fmuHandle *fmu);
 
-FMI4C_DLLAPI fmi3Status fmi3_updateDiscreteStates(fmiHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3_updateDiscreteStates(fmuHandle *fmu,
                                                  fmi3Boolean* discreteStatesNeedUpdate,
                                                  fmi3Boolean* terminateSimulation,
                                                  fmi3Boolean* nominalsOfContinuousStatesChanged,
@@ -875,51 +875,51 @@ FMI4C_DLLAPI fmi3Status fmi3_updateDiscreteStates(fmiHandle *fmu,
                                                  fmi3Boolean* nextEventTimeDefined,
                                                  fmi3Float64* nextEventTime);
 
-FMI4C_DLLAPI fmi3Status fmi3_enterContinuousTimeMode(fmiHandle *fmu);
+FMI4C_DLLAPI fmi3Status fmi3_enterContinuousTimeMode(fmuHandle *fmu);
 
-FMI4C_DLLAPI fmi3Status fmi3_completedIntegratorStep(fmiHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3_completedIntegratorStep(fmuHandle *fmu,
                                                     fmi3Boolean  noSetFMUStatePriorToCurrentPoint,
                                                     fmi3Boolean* enterEventMode,
                                                     fmi3Boolean* terminateSimulation);
 
-FMI4C_DLLAPI fmi3Status fmi3_setTime(fmiHandle *fmu, fmi3Float64 time);
+FMI4C_DLLAPI fmi3Status fmi3_setTime(fmuHandle *fmu, fmi3Float64 time);
 
-FMI4C_DLLAPI fmi3Status fmi3_setContinuousStates(fmiHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3_setContinuousStates(fmuHandle *fmu,
                                                 const fmi3Float64 continuousStates[],
                                                 size_t nContinuousStates);
 
-FMI4C_DLLAPI fmi3Status fmi3_getContinuousStateDerivatives(fmiHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3_getContinuousStateDerivatives(fmuHandle *fmu,
                                                           fmi3Float64 derivatives[],
                                                           size_t nContinuousStates);
 
-FMI4C_DLLAPI fmi3Status fmi3_getEventIndicators(fmiHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3_getEventIndicators(fmuHandle *fmu,
                                                fmi3Float64 eventIndicators[],
                                                size_t nEventIndicators);
 
-FMI4C_DLLAPI fmi3Status fmi3_getContinuousStates(fmiHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3_getContinuousStates(fmuHandle *fmu,
                                                 fmi3Float64 continuousStates[],
                                                 size_t nContinuousStates);
 
-FMI4C_DLLAPI fmi3Status fmi3_getNominalsOfContinuousStates(fmiHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3_getNominalsOfContinuousStates(fmuHandle *fmu,
                                                           fmi3Float64 nominals[],
                                                           size_t nContinuousStates);
 
-FMI4C_DLLAPI fmi3Status fmi3_getNumberOfEventIndicators(fmiHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3_getNumberOfEventIndicators(fmuHandle *fmu,
                                                        size_t* nEventIndicators);
 
-FMI4C_DLLAPI fmi3Status fmi3_getNumberOfContinuousStates(fmiHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3_getNumberOfContinuousStates(fmuHandle *fmu,
                                                         size_t* nContinuousStates);
 
-FMI4C_DLLAPI fmi3Status fmi3_enterStepMode(fmiHandle *fmu);
+FMI4C_DLLAPI fmi3Status fmi3_enterStepMode(fmuHandle *fmu);
 
-FMI4C_DLLAPI fmi3Status fmi3_getOutputDerivatives(fmiHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3_getOutputDerivatives(fmuHandle *fmu,
                                                  const fmi3ValueReference valueReferences[],
                                                  size_t nValueReferences,
                                                  const fmi3Int32 orders[],
                                                  fmi3Float64 values[],
                                                  size_t nValues);
 
-FMI4C_DLLAPI fmi3Status fmi3_activateModelPartition(fmiHandle *fmu,
+FMI4C_DLLAPI fmi3Status fmi3_activateModelPartition(fmuHandle *fmu,
                                                    fmi3ValueReference clockReference,
                                                    fmi3Float64 activationTime);
 

--- a/include/fmi4c.h
+++ b/include/fmi4c.h
@@ -91,7 +91,7 @@ FMI4C_DLLAPI fmi1DataType fmi1_getVariableDataType(fmi1VariableHandle* var);
 
 FMI4C_DLLAPI const char* fmi1_getTypesPlatform(fmuHandle* fmu);
 FMI4C_DLLAPI const char* fmi1_getVersion(fmuHandle* fmu);
-FMI4C_DLLAPI fmi1Status fmi1_setDebugLogging(fmuHandle* fmu, fmi1Boolean loggingOn);
+FMI4C_DLLAPI fmi1Status fmi1_setDebugLogging(fmi1InstanceHandle *instance, fmi1Boolean loggingOn);
 
 FMI4C_DLLAPI int fmi1_getNumberOfBaseUnits(fmuHandle *fmu);
 FMI4C_DLLAPI fmi1BaseUnitHandle *fmi1_getBaseUnitByIndex(fmuHandle *fmu, int i);
@@ -99,46 +99,46 @@ FMI4C_DLLAPI const char* fmi1_getBaseUnitUnit(fmi1BaseUnitHandle *baseUnit);
 FMI4C_DLLAPI int fmi1_getNumberOfDisplayUnits(fmi1BaseUnitHandle *baseUnit);
 FMI4C_DLLAPI void fmi1_getDisplayUnitByIndex(fmi1BaseUnitHandle *baseUnit, int id, const char **displayUnit, double *gain, double *offset);
 
-FMI4C_DLLAPI fmi1Status fmi1_getReal(fmuHandle* fmu, const fmi1ValueReference valueReferences[], size_t nValueReferences, fmi1Real values[]);
-FMI4C_DLLAPI fmi1Status fmi1_getInteger(fmuHandle* fmu, const fmi1ValueReference valueReferences[], size_t nValueReferences, fmi1Integer values[]);
-FMI4C_DLLAPI fmi1Status fmi1_getBoolean(fmuHandle* fmu, const fmi1ValueReference valueReferences[], size_t nValueReferences, fmi1Boolean values[]);
-FMI4C_DLLAPI fmi1Status fmi1_getString(fmuHandle* fmu, const fmi1ValueReference valueReferences[], size_t nValueReferences, fmi1String values[]);
+FMI4C_DLLAPI fmi1Status fmi1_getReal(fmi1InstanceHandle *i, const fmi1ValueReference valueReferences[], size_t nValueReferences, fmi1Real values[]);
+FMI4C_DLLAPI fmi1Status fmi1_getInteger(fmi1InstanceHandle *i, const fmi1ValueReference valueReferences[], size_t nValueReferences, fmi1Integer values[]);
+FMI4C_DLLAPI fmi1Status fmi1_getBoolean(fmi1InstanceHandle *i, const fmi1ValueReference valueReferences[], size_t nValueReferences, fmi1Boolean values[]);
+FMI4C_DLLAPI fmi1Status fmi1_getString(fmi1InstanceHandle *i, const fmi1ValueReference valueReferences[], size_t nValueReferences, fmi1String values[]);
 
-FMI4C_DLLAPI fmi1Status fmi1_setReal(fmuHandle* fmu, const fmi1ValueReference valueReferences[], size_t nValueReferences, const fmi1Real values[]);
-FMI4C_DLLAPI fmi1Status fmi1_setInteger(fmuHandle* fmu, const fmi1ValueReference valueReferences[], size_t nValueReferences, const fmi1Integer values[]);
-FMI4C_DLLAPI fmi1Status fmi1_setBoolean(fmuHandle* fmu, const fmi1ValueReference valueReferences[], size_t nValueReferences, const fmi1Boolean values[]);
-FMI4C_DLLAPI fmi1Status fmi1_setString(fmuHandle* fmu, const fmi1ValueReference valueReferences[], size_t nValueReferences, const fmi1String values[]);
+FMI4C_DLLAPI fmi1Status fmi1_setReal(fmi1InstanceHandle *i, const fmi1ValueReference valueReferences[], size_t nValueReferences, const fmi1Real values[]);
+FMI4C_DLLAPI fmi1Status fmi1_setInteger(fmi1InstanceHandle *i, const fmi1ValueReference valueReferences[], size_t nValueReferences, const fmi1Integer values[]);
+FMI4C_DLLAPI fmi1Status fmi1_setBoolean(fmi1InstanceHandle *i, const fmi1ValueReference valueReferences[], size_t nValueReferences, const fmi1Boolean values[]);
+FMI4C_DLLAPI fmi1Status fmi1_setString(fmi1InstanceHandle *i, const fmi1ValueReference valueReferences[], size_t nValueReferences, const fmi1String values[]);
 
-FMI4C_DLLAPI bool fmi1_instantiateSlave(fmuHandle *fmu, fmi1String mimeType, fmi1Real timeOut, fmi1Boolean visible, fmi1Boolean interactive, fmi1CallbackLogger_t logger, fmi1CallbackAllocateMemory_t allocateMemory, fmi1CallbackFreeMemory_t freeMemory, fmi1StepFinished_t stepFinished, fmi1Boolean loggingOn);
-FMI4C_DLLAPI fmi1Status fmi1_initializeSlave(fmuHandle* fmu, fmi1Real startTime, fmi1Boolean stopTimeDefined, fmi1Real stopTime);
-FMI4C_DLLAPI fmi1Status fmi1_terminateSlave(fmuHandle* fmu);
-FMI4C_DLLAPI fmi1Status fmi1_resetSlave(fmuHandle* fmu);
-FMI4C_DLLAPI void fmi1_freeSlaveInstance(fmuHandle* fmu);
+FMI4C_DLLAPI fmi1InstanceHandle *fmi1_instantiateSlave(fmuHandle *fmu, fmi1String mimeType, fmi1Real timeOut, fmi1Boolean visible, fmi1Boolean interactive, fmi1CallbackLogger_t logger, fmi1CallbackAllocateMemory_t allocateMemory, fmi1CallbackFreeMemory_t freeMemory, fmi1StepFinished_t stepFinished, fmi1Boolean loggingOn);
+FMI4C_DLLAPI fmi1Status fmi1_initializeSlave(fmi1InstanceHandle *instance, fmi1Real startTime, fmi1Boolean stopTimeDefined, fmi1Real stopTime);
+FMI4C_DLLAPI fmi1Status fmi1_terminateSlave(fmi1InstanceHandle *instance);
+FMI4C_DLLAPI fmi1Status fmi1_resetSlave(fmi1InstanceHandle *instance);
+FMI4C_DLLAPI void fmi1_freeSlaveInstance(fmi1InstanceHandle *instance);
 
-FMI4C_DLLAPI fmi1Status fmi1_setRealInputDerivatives(fmuHandle *fmu, const fmi1ValueReference valueReferences[], size_t nValueReferences, const fmi1Integer orders[], const fmi1Real values[]);
-FMI4C_DLLAPI fmi1Status fmi1_getRealOutputDerivatives(fmuHandle *fmu, const fmi1ValueReference valueReferences[], size_t nValueReferences, const fmi1Integer orders[], fmi1Real values[]);
-FMI4C_DLLAPI fmi1Status fmi1_cancelStep(fmuHandle* fmu);
-FMI4C_DLLAPI fmi1Status fmi1_doStep(fmuHandle *fmu, fmi1Real currentCommunicationPoint, fmi1Real communicationStepSize, fmi1Boolean newStep);
-FMI4C_DLLAPI fmi1Status fmi1_getStatus(fmuHandle* fmu, const fmi1StatusKind statusKind, fmi1Status* value);
-FMI4C_DLLAPI fmi1Status fmi1_getRealStatus(fmuHandle* fmu, const fmi1StatusKind statusKind, fmi1Real* value);
-FMI4C_DLLAPI fmi1Status fmi1_getIntegerStatus(fmuHandle* fmu, const fmi1StatusKind statusKind, fmi1Integer* value);
-FMI4C_DLLAPI fmi1Status fmi1_getBooleanStatus(fmuHandle* fmu, const fmi1StatusKind statusKind, fmi1Boolean* value);
-FMI4C_DLLAPI fmi1Status fmi1_getStringStatus(fmuHandle* fmu, const fmi1StatusKind statusKind, fmi1String* value);
+FMI4C_DLLAPI fmi1Status fmi1_setRealInputDerivatives(fmi1InstanceHandle *i, const fmi1ValueReference valueReferences[], size_t nValueReferences, const fmi1Integer orders[], const fmi1Real values[]);
+FMI4C_DLLAPI fmi1Status fmi1_getRealOutputDerivatives(fmi1InstanceHandle *i, const fmi1ValueReference valueReferences[], size_t nValueReferences, const fmi1Integer orders[], fmi1Real values[]);
+FMI4C_DLLAPI fmi1Status fmi1_cancelStep(fmi1InstanceHandle *instance);
+FMI4C_DLLAPI fmi1Status fmi1_doStep(fmi1InstanceHandle *i, fmi1Real currentCommunicationPoint, fmi1Real communicationStepSize, fmi1Boolean newStep);
+FMI4C_DLLAPI fmi1Status fmi1_getStatus(fmi1InstanceHandle *instance, const fmi1StatusKind statusKind, fmi1Status* value);
+FMI4C_DLLAPI fmi1Status fmi1_getRealStatus(fmi1InstanceHandle *instance, const fmi1StatusKind statusKind, fmi1Real* value);
+FMI4C_DLLAPI fmi1Status fmi1_getIntegerStatus(fmi1InstanceHandle *instance, const fmi1StatusKind statusKind, fmi1Integer* value);
+FMI4C_DLLAPI fmi1Status fmi1_getBooleanStatus(fmi1InstanceHandle *instance, const fmi1StatusKind statusKind, fmi1Boolean* value);
+FMI4C_DLLAPI fmi1Status fmi1_getStringStatus(fmi1InstanceHandle *instance, const fmi1StatusKind statusKind, fmi1String* value);
 
 FMI4C_DLLAPI const char *fmi1_getModelTypesPlatform(fmuHandle* fmu);
-FMI4C_DLLAPI bool fmi1_instantiateModel(fmuHandle *fmu, fmi1CallbackLogger_t logger, fmi1CallbackAllocateMemory_t allocateMemory, fmi1CallbackFreeMemory_t freeMemory, fmi1Boolean loggingOn);
-FMI4C_DLLAPI void fmi1_freeModelInstance(fmuHandle* fmu);
-FMI4C_DLLAPI fmi1Status fmi1_setTime(fmuHandle* fmu, fmi1Real time);
-FMI4C_DLLAPI fmi1Status fmi1_setContinuousStates(fmuHandle *fmu, const fmi1Real values[], size_t nStates);
-FMI4C_DLLAPI fmi1Status fmi1_completedIntegratorStep(fmuHandle* fmu, fmi1Boolean* callEventUpdate);
-FMI4C_DLLAPI fmi1Status fmi1_initialize(fmuHandle *fmu, fmi1Boolean toleranceControlled, fmi1Real relativeTolerance, fmi1EventInfo *eventInfo);
-FMI4C_DLLAPI fmi1Status fmi1_getDerivatives(fmuHandle *fmu, fmi1Real derivatives[], size_t nDerivatives);
-FMI4C_DLLAPI fmi1Status fmi1_getEventIndicators(fmuHandle *fmu, fmi1Real indicators[], size_t nIndicators);
-FMI4C_DLLAPI fmi1Status fmi1_eventUpdate(fmuHandle *fmu, fmi1Boolean intermediateResults, fmi1EventInfo *eventInfo);
-FMI4C_DLLAPI fmi1Status fmi1_getContinuousStates(fmuHandle *fmu, fmi1Real states[], size_t nStates);
-FMI4C_DLLAPI fmi1Status fmi1_getNominalContinuousStates(fmuHandle* fmu, fmi1Real nominals[], size_t nNominals);
-FMI4C_DLLAPI fmi1Status fmi1_getStateValueReferences(fmuHandle* fmu, fmi1ValueReference valueReferences[], size_t nValueReferences);
-FMI4C_DLLAPI fmi1Status fmi1_terminate(fmuHandle* fmu);
+FMI4C_DLLAPI fmi1InstanceHandle *fmi1_instantiateModel(fmuHandle *fmu, fmi1CallbackLogger_t logger, fmi1CallbackAllocateMemory_t allocateMemory, fmi1CallbackFreeMemory_t freeMemory, fmi1Boolean loggingOn);
+FMI4C_DLLAPI void fmi1_freeModelInstance(fmi1InstanceHandle *i);
+FMI4C_DLLAPI fmi1Status fmi1_setTime(fmi1InstanceHandle *i, fmi1Real time);
+FMI4C_DLLAPI fmi1Status fmi1_setContinuousStates(fmi1InstanceHandle *i, const fmi1Real values[], size_t nStates);
+FMI4C_DLLAPI fmi1Status fmi1_completedIntegratorStep(fmi1InstanceHandle *i, fmi1Boolean* callEventUpdate);
+FMI4C_DLLAPI fmi1Status fmi1_initialize(fmi1InstanceHandle *i, fmi1Boolean toleranceControlled, fmi1Real relativeTolerance, fmi1EventInfo *eventInfo);
+FMI4C_DLLAPI fmi1Status fmi1_getDerivatives(fmi1InstanceHandle *i, fmi1Real derivatives[], size_t nDerivatives);
+FMI4C_DLLAPI fmi1Status fmi1_getEventIndicators(fmi1InstanceHandle *i, fmi1Real indicators[], size_t nIndicators);
+FMI4C_DLLAPI fmi1Status fmi1_eventUpdate(fmi1InstanceHandle *i, fmi1Boolean intermediateResults, fmi1EventInfo *eventInfo);
+FMI4C_DLLAPI fmi1Status fmi1_getContinuousStates(fmi1InstanceHandle *i, fmi1Real states[], size_t nStates);
+FMI4C_DLLAPI fmi1Status fmi1_getNominalContinuousStates(fmi1InstanceHandle *i, fmi1Real nominals[], size_t nNominals);
+FMI4C_DLLAPI fmi1Status fmi1_getStateValueReferences(fmi1InstanceHandle *i, fmi1ValueReference valueReferences[], size_t nValueReferences);
+FMI4C_DLLAPI fmi1Status fmi1_terminate(fmi1InstanceHandle *i);
 
 // FMI 2 wrapper functions
 

--- a/include/fmi4c_functions_fmi1.h
+++ b/include/fmi4c_functions_fmi1.h
@@ -11,7 +11,7 @@
 #endif
 
 // Callback functions
-typedef void (*fmi1CallbackLogger_t)(fmi1Component_t,
+typedef void (*fmi1CallbackLogger_t)(fmi1InstanceHandle*,
                                      fmi1String instanceName,
                                      fmi1Status status,
                                      fmi1String category,
@@ -19,7 +19,7 @@ typedef void (*fmi1CallbackLogger_t)(fmi1Component_t,
                                      ...);
 typedef void* (*fmi1CallbackAllocateMemory_t)(size_t nobj, size_t size);
 typedef void (*fmi1CallbackFreeMemory_t)(void* obj);
-typedef void  (*fmi1StepFinished_t)(fmi1Component_t, fmi1Status status);
+typedef void  (*fmi1StepFinished_t)(fmi1InstanceHandle*,fmi1Status status);
 
 
 // Structs
@@ -49,46 +49,46 @@ typedef struct {
 // API functions
 typedef const char* (STDCALL *fmiGetTypesPlatform_t)();
 typedef const char* (STDCALL *fmiGetVersion_t)();
-typedef fmi1Status (STDCALL *fmiSetDebugLogging_t)(fmi1Component_t, fmi1Boolean);
-typedef fmi1Status (STDCALL *fmiGetReal_t)(fmi1Component_t, const fmi1ValueReference[], size_t, fmi1Real[]);
-typedef fmi1Status (STDCALL *fmiGetInteger_t)(fmi1Component_t, const fmi1ValueReference[], size_t, fmi1Integer[]);
-typedef fmi1Status (STDCALL *fmiGetBoolean_t)(fmi1Component_t, const fmi1ValueReference[], size_t, fmi1Boolean[]);
-typedef fmi1Status (STDCALL *fmiGetString_t)(fmi1Component_t, const fmi1ValueReference[], size_t, fmi1String []);
-typedef fmi1Status (STDCALL *fmiSetReal_t)(fmi1Component_t, const fmi1ValueReference[], size_t, const fmi1Real[]);
-typedef fmi1Status (STDCALL *fmiSetInteger_t)(fmi1Component_t, const fmi1ValueReference[], size_t, const fmi1Integer[]);
-typedef fmi1Status (STDCALL *fmiSetBoolean_t)(fmi1Component_t, const fmi1ValueReference[], size_t, const fmi1Boolean[]);
-typedef fmi1Status (STDCALL *fmiSetString_t)(fmi1Component_t, const fmi1ValueReference[], size_t, const fmi1String[]);
-typedef fmi1Component_t (STDCALL *fmiInstantiateSlave_t)(fmi1String, fmi1String, fmi1String, fmi1String, fmi1Real, fmi1Boolean,
+typedef fmi1Status (STDCALL *fmiSetDebugLogging_t)(fmi1InstanceHandle*,fmi1Boolean);
+typedef fmi1Status (STDCALL *fmiGetReal_t)(fmi1InstanceHandle*,const fmi1ValueReference[], size_t, fmi1Real[]);
+typedef fmi1Status (STDCALL *fmiGetInteger_t)(fmi1InstanceHandle*,const fmi1ValueReference[], size_t, fmi1Integer[]);
+typedef fmi1Status (STDCALL *fmiGetBoolean_t)(fmi1InstanceHandle*,const fmi1ValueReference[], size_t, fmi1Boolean[]);
+typedef fmi1Status (STDCALL *fmiGetString_t)(fmi1InstanceHandle*,const fmi1ValueReference[], size_t, fmi1String []);
+typedef fmi1Status (STDCALL *fmiSetReal_t)(fmi1InstanceHandle*,const fmi1ValueReference[], size_t, const fmi1Real[]);
+typedef fmi1Status (STDCALL *fmiSetInteger_t)(fmi1InstanceHandle*,const fmi1ValueReference[], size_t, const fmi1Integer[]);
+typedef fmi1Status (STDCALL *fmiSetBoolean_t)(fmi1InstanceHandle*,const fmi1ValueReference[], size_t, const fmi1Boolean[]);
+typedef fmi1Status (STDCALL *fmiSetString_t)(fmi1InstanceHandle*,const fmi1ValueReference[], size_t, const fmi1String[]);
+typedef fmi1InstanceHandle *(STDCALL *fmiInstantiateSlave_t)(fmi1String, fmi1String, fmi1String, fmi1String, fmi1Real, fmi1Boolean,
                                                           fmi1Boolean, fmi1CallbackFunctionsCoSimulation, fmi1Boolean);
-typedef fmi1Status (STDCALL *fmiInitializeSlave_t)(fmi1Component_t ,  fmi1Real, fmi1Boolean, fmi1Real);
-typedef fmi1Status (STDCALL *fmiTerminateSlave_t)(fmi1Component_t );
-typedef fmi1Status (STDCALL *fmiResetSlave_t)(fmi1Component_t );
-typedef void (STDCALL *fmiFreeSlaveInstance_t)(fmi1Component_t );
-typedef fmi1Status (STDCALL *fmiSetRealInputDerivatives_t)(fmi1Component_t , const fmi1ValueReference[], size_t,
+typedef fmi1Status (STDCALL *fmiInitializeSlave_t)(fmi1InstanceHandle*, fmi1Real, fmi1Boolean, fmi1Real);
+typedef fmi1Status (STDCALL *fmiTerminateSlave_t)(fmi1InstanceHandle*);
+typedef fmi1Status (STDCALL *fmiResetSlave_t)(fmi1InstanceHandle*);
+typedef void (STDCALL *fmiFreeSlaveInstance_t)(fmi1InstanceHandle*);
+typedef fmi1Status (STDCALL *fmiSetRealInputDerivatives_t)(fmi1InstanceHandle*, const fmi1ValueReference[], size_t,
                                                               const fmi1Integer[], const fmi1Real[]);
-typedef fmi1Status (STDCALL *fmiGetRealOutputDerivatives_t)(fmi1Component_t , const fmi1ValueReference[], size_t,
+typedef fmi1Status (STDCALL *fmiGetRealOutputDerivatives_t)(fmi1InstanceHandle*, const fmi1ValueReference[], size_t,
                                                                const fmi1Integer[], fmi1Real[]);
-typedef fmi1Status (STDCALL *fmiCancelStep_t)(fmi1Component_t );
-typedef fmi1Status (STDCALL *fmiDoStep_t)(fmi1Component_t , fmi1Real, fmi1Real, fmi1Boolean);
-typedef fmi1Status (STDCALL *fmiGetStatus_t)(fmi1Component_t , const fmi1StatusKind, fmi1Status*);
-typedef fmi1Status (STDCALL *fmiGetRealStatus_t)(fmi1Component_t , const fmi1StatusKind, fmi1Real*);
-typedef fmi1Status (STDCALL *fmiGetIntegerStatus_t)(fmi1Component_t , const fmi1StatusKind, fmi1Integer*);
-typedef fmi1Status (STDCALL *fmiGetBooleanStatus_t)(fmi1Component_t , const fmi1StatusKind, fmi1Boolean*);
-typedef fmi1Status (STDCALL *fmiGetStringStatus_t)(fmi1Component_t , const fmi1StatusKind, fmi1String*);
+typedef fmi1Status (STDCALL *fmiCancelStep_t)(fmi1InstanceHandle*);
+typedef fmi1Status (STDCALL *fmiDoStep_t)(fmi1InstanceHandle*, fmi1Real, fmi1Real, fmi1Boolean);
+typedef fmi1Status (STDCALL *fmiGetStatus_t)(fmi1InstanceHandle*, const fmi1StatusKind, fmi1Status*);
+typedef fmi1Status (STDCALL *fmiGetRealStatus_t)(fmi1InstanceHandle*, const fmi1StatusKind, fmi1Real*);
+typedef fmi1Status (STDCALL *fmiGetIntegerStatus_t)(fmi1InstanceHandle*, const fmi1StatusKind, fmi1Integer*);
+typedef fmi1Status (STDCALL *fmiGetBooleanStatus_t)(fmi1InstanceHandle*, const fmi1StatusKind, fmi1Boolean*);
+typedef fmi1Status (STDCALL *fmiGetStringStatus_t)(fmi1InstanceHandle*, const fmi1StatusKind, fmi1String*);
 typedef const char* (STDCALL *fmiGetModelTypesPlatform_t)();
-typedef fmi1Component_t (STDCALL *fmiInstantiateModel_t)(fmi1String, fmi1String,
+typedef fmi1InstanceHandle *(STDCALL *fmiInstantiateModel_t)(fmi1String, fmi1String,
                                                           fmi1CallbackFunctionsModelExchange, fmi1Boolean);
-typedef void (STDCALL *fmiFreeModelInstance_t)(fmi1Component_t );
-typedef fmi1Status (STDCALL *fmiSetTime_t)(fmi1Component_t , fmi1Real);
-typedef fmi1Status (STDCALL *fmiSetContinuousStates_t)(fmi1Component_t , const fmi1Real[], size_t);
-typedef fmi1Status (STDCALL *fmiCompletedIntegratorStep_t)(fmi1Component_t , fmi1Boolean*);
-typedef fmi1Status (STDCALL *fmiInitialize_t)(fmi1Component_t , fmi1Boolean, fmi1Real, fmi1EventInfo*);
-typedef fmi1Status (STDCALL *fmiGetDerivatives_t)(fmi1Component_t , fmi1Real[], size_t);
-typedef fmi1Status (STDCALL *fmiGetEventIndicators_t)(fmi1Component_t , fmi1Real[], size_t);
-typedef fmi1Status (STDCALL *fmiEventUpdate_t)(fmi1Component_t , fmi1Boolean, fmi1EventInfo*);
-typedef fmi1Status (STDCALL *fmiGetContinuousStates_t)(fmi1Component_t , fmi1Real[], size_t);
-typedef fmi1Status (STDCALL *fmiGetNominalContinuousStates_t)(fmi1Component_t , fmi1Real[], size_t);
-typedef fmi1Status (STDCALL *fmiGetStateValueReferences_t)(fmi1Component_t , fmi1ValueReference[], size_t);
-typedef fmi1Status (STDCALL *fmiTerminate_t)(fmi1Component_t );
+typedef void (STDCALL *fmiFreeModelInstance_t)(fmi1InstanceHandle*);
+typedef fmi1Status (STDCALL *fmiSetTime_t)(fmi1InstanceHandle*, fmi1Real);
+typedef fmi1Status (STDCALL *fmiSetContinuousStates_t)(fmi1InstanceHandle*, const fmi1Real[], size_t);
+typedef fmi1Status (STDCALL *fmiCompletedIntegratorStep_t)(fmi1InstanceHandle*, fmi1Boolean*);
+typedef fmi1Status (STDCALL *fmiInitialize_t)(fmi1InstanceHandle*, fmi1Boolean, fmi1Real, fmi1EventInfo*);
+typedef fmi1Status (STDCALL *fmiGetDerivatives_t)(fmi1InstanceHandle*, fmi1Real[], size_t);
+typedef fmi1Status (STDCALL *fmiGetEventIndicators_t)(fmi1InstanceHandle*, fmi1Real[], size_t);
+typedef fmi1Status (STDCALL *fmiEventUpdate_t)(fmi1InstanceHandle*, fmi1Boolean, fmi1EventInfo*);
+typedef fmi1Status (STDCALL *fmiGetContinuousStates_t)(fmi1InstanceHandle*, fmi1Real[], size_t);
+typedef fmi1Status (STDCALL *fmiGetNominalContinuousStates_t)(fmi1InstanceHandle*, fmi1Real[], size_t);
+typedef fmi1Status (STDCALL *fmiGetStateValueReferences_t)(fmi1InstanceHandle*, fmi1ValueReference[], size_t);
+typedef fmi1Status (STDCALL *fmiTerminate_t)(fmi1InstanceHandle*);
 
 #endif // FMIC_FUNCTIONS_FMI1_H

--- a/include/fmi4c_functions_fmi1.h
+++ b/include/fmi4c_functions_fmi1.h
@@ -11,7 +11,7 @@
 #endif
 
 // Callback functions
-typedef void (*fmi1CallbackLogger_t)(fmi1InstanceHandle*,
+typedef void (*fmi1CallbackLogger_t)(fmi1Component*,
                                      fmi1String instanceName,
                                      fmi1Status status,
                                      fmi1String category,
@@ -19,7 +19,7 @@ typedef void (*fmi1CallbackLogger_t)(fmi1InstanceHandle*,
                                      ...);
 typedef void* (*fmi1CallbackAllocateMemory_t)(size_t nobj, size_t size);
 typedef void (*fmi1CallbackFreeMemory_t)(void* obj);
-typedef void  (*fmi1StepFinished_t)(fmi1InstanceHandle*,fmi1Status status);
+typedef void  (*fmi1StepFinished_t)(fmi1Component*,fmi1Status status);
 
 
 // Structs
@@ -49,46 +49,46 @@ typedef struct {
 // API functions
 typedef const char* (STDCALL *fmiGetTypesPlatform_t)();
 typedef const char* (STDCALL *fmiGetVersion_t)();
-typedef fmi1Status (STDCALL *fmiSetDebugLogging_t)(fmi1InstanceHandle*,fmi1Boolean);
-typedef fmi1Status (STDCALL *fmiGetReal_t)(fmi1InstanceHandle*,const fmi1ValueReference[], size_t, fmi1Real[]);
-typedef fmi1Status (STDCALL *fmiGetInteger_t)(fmi1InstanceHandle*,const fmi1ValueReference[], size_t, fmi1Integer[]);
-typedef fmi1Status (STDCALL *fmiGetBoolean_t)(fmi1InstanceHandle*,const fmi1ValueReference[], size_t, fmi1Boolean[]);
-typedef fmi1Status (STDCALL *fmiGetString_t)(fmi1InstanceHandle*,const fmi1ValueReference[], size_t, fmi1String []);
-typedef fmi1Status (STDCALL *fmiSetReal_t)(fmi1InstanceHandle*,const fmi1ValueReference[], size_t, const fmi1Real[]);
-typedef fmi1Status (STDCALL *fmiSetInteger_t)(fmi1InstanceHandle*,const fmi1ValueReference[], size_t, const fmi1Integer[]);
-typedef fmi1Status (STDCALL *fmiSetBoolean_t)(fmi1InstanceHandle*,const fmi1ValueReference[], size_t, const fmi1Boolean[]);
-typedef fmi1Status (STDCALL *fmiSetString_t)(fmi1InstanceHandle*,const fmi1ValueReference[], size_t, const fmi1String[]);
+typedef fmi1Status (STDCALL *fmiSetDebugLogging_t)(fmi1Component*,fmi1Boolean);
+typedef fmi1Status (STDCALL *fmiGetReal_t)(fmi1Component*,const fmi1ValueReference[], size_t, fmi1Real[]);
+typedef fmi1Status (STDCALL *fmiGetInteger_t)(fmi1Component*,const fmi1ValueReference[], size_t, fmi1Integer[]);
+typedef fmi1Status (STDCALL *fmiGetBoolean_t)(fmi1Component*,const fmi1ValueReference[], size_t, fmi1Boolean[]);
+typedef fmi1Status (STDCALL *fmiGetString_t)(fmi1Component*,const fmi1ValueReference[], size_t, fmi1String []);
+typedef fmi1Status (STDCALL *fmiSetReal_t)(fmi1Component*,const fmi1ValueReference[], size_t, const fmi1Real[]);
+typedef fmi1Status (STDCALL *fmiSetInteger_t)(fmi1Component*,const fmi1ValueReference[], size_t, const fmi1Integer[]);
+typedef fmi1Status (STDCALL *fmiSetBoolean_t)(fmi1Component*,const fmi1ValueReference[], size_t, const fmi1Boolean[]);
+typedef fmi1Status (STDCALL *fmiSetString_t)(fmi1Component*,const fmi1ValueReference[], size_t, const fmi1String[]);
 typedef fmi1InstanceHandle *(STDCALL *fmiInstantiateSlave_t)(fmi1String, fmi1String, fmi1String, fmi1String, fmi1Real, fmi1Boolean,
                                                           fmi1Boolean, fmi1CallbackFunctionsCoSimulation, fmi1Boolean);
-typedef fmi1Status (STDCALL *fmiInitializeSlave_t)(fmi1InstanceHandle*, fmi1Real, fmi1Boolean, fmi1Real);
-typedef fmi1Status (STDCALL *fmiTerminateSlave_t)(fmi1InstanceHandle*);
-typedef fmi1Status (STDCALL *fmiResetSlave_t)(fmi1InstanceHandle*);
-typedef void (STDCALL *fmiFreeSlaveInstance_t)(fmi1InstanceHandle*);
-typedef fmi1Status (STDCALL *fmiSetRealInputDerivatives_t)(fmi1InstanceHandle*, const fmi1ValueReference[], size_t,
+typedef fmi1Status (STDCALL *fmiInitializeSlave_t)(fmi1Component*, fmi1Real, fmi1Boolean, fmi1Real);
+typedef fmi1Status (STDCALL *fmiTerminateSlave_t)(fmi1Component*);
+typedef fmi1Status (STDCALL *fmiResetSlave_t)(fmi1Component*);
+typedef void (STDCALL *fmiFreeSlaveInstance_t)(fmi1Component*);
+typedef fmi1Status (STDCALL *fmiSetRealInputDerivatives_t)(fmi1Component*, const fmi1ValueReference[], size_t,
                                                               const fmi1Integer[], const fmi1Real[]);
-typedef fmi1Status (STDCALL *fmiGetRealOutputDerivatives_t)(fmi1InstanceHandle*, const fmi1ValueReference[], size_t,
+typedef fmi1Status (STDCALL *fmiGetRealOutputDerivatives_t)(fmi1Component*, const fmi1ValueReference[], size_t,
                                                                const fmi1Integer[], fmi1Real[]);
-typedef fmi1Status (STDCALL *fmiCancelStep_t)(fmi1InstanceHandle*);
-typedef fmi1Status (STDCALL *fmiDoStep_t)(fmi1InstanceHandle*, fmi1Real, fmi1Real, fmi1Boolean);
-typedef fmi1Status (STDCALL *fmiGetStatus_t)(fmi1InstanceHandle*, const fmi1StatusKind, fmi1Status*);
-typedef fmi1Status (STDCALL *fmiGetRealStatus_t)(fmi1InstanceHandle*, const fmi1StatusKind, fmi1Real*);
-typedef fmi1Status (STDCALL *fmiGetIntegerStatus_t)(fmi1InstanceHandle*, const fmi1StatusKind, fmi1Integer*);
-typedef fmi1Status (STDCALL *fmiGetBooleanStatus_t)(fmi1InstanceHandle*, const fmi1StatusKind, fmi1Boolean*);
-typedef fmi1Status (STDCALL *fmiGetStringStatus_t)(fmi1InstanceHandle*, const fmi1StatusKind, fmi1String*);
+typedef fmi1Status (STDCALL *fmiCancelStep_t)(fmi1Component*);
+typedef fmi1Status (STDCALL *fmiDoStep_t)(fmi1Component*, fmi1Real, fmi1Real, fmi1Boolean);
+typedef fmi1Status (STDCALL *fmiGetStatus_t)(fmi1Component*, const fmi1StatusKind, fmi1Status*);
+typedef fmi1Status (STDCALL *fmiGetRealStatus_t)(fmi1Component*, const fmi1StatusKind, fmi1Real*);
+typedef fmi1Status (STDCALL *fmiGetIntegerStatus_t)(fmi1Component*, const fmi1StatusKind, fmi1Integer*);
+typedef fmi1Status (STDCALL *fmiGetBooleanStatus_t)(fmi1Component*, const fmi1StatusKind, fmi1Boolean*);
+typedef fmi1Status (STDCALL *fmiGetStringStatus_t)(fmi1Component*, const fmi1StatusKind, fmi1String*);
 typedef const char* (STDCALL *fmiGetModelTypesPlatform_t)();
 typedef fmi1InstanceHandle *(STDCALL *fmiInstantiateModel_t)(fmi1String, fmi1String,
                                                           fmi1CallbackFunctionsModelExchange, fmi1Boolean);
-typedef void (STDCALL *fmiFreeModelInstance_t)(fmi1InstanceHandle*);
-typedef fmi1Status (STDCALL *fmiSetTime_t)(fmi1InstanceHandle*, fmi1Real);
-typedef fmi1Status (STDCALL *fmiSetContinuousStates_t)(fmi1InstanceHandle*, const fmi1Real[], size_t);
-typedef fmi1Status (STDCALL *fmiCompletedIntegratorStep_t)(fmi1InstanceHandle*, fmi1Boolean*);
-typedef fmi1Status (STDCALL *fmiInitialize_t)(fmi1InstanceHandle*, fmi1Boolean, fmi1Real, fmi1EventInfo*);
-typedef fmi1Status (STDCALL *fmiGetDerivatives_t)(fmi1InstanceHandle*, fmi1Real[], size_t);
-typedef fmi1Status (STDCALL *fmiGetEventIndicators_t)(fmi1InstanceHandle*, fmi1Real[], size_t);
-typedef fmi1Status (STDCALL *fmiEventUpdate_t)(fmi1InstanceHandle*, fmi1Boolean, fmi1EventInfo*);
-typedef fmi1Status (STDCALL *fmiGetContinuousStates_t)(fmi1InstanceHandle*, fmi1Real[], size_t);
-typedef fmi1Status (STDCALL *fmiGetNominalContinuousStates_t)(fmi1InstanceHandle*, fmi1Real[], size_t);
-typedef fmi1Status (STDCALL *fmiGetStateValueReferences_t)(fmi1InstanceHandle*, fmi1ValueReference[], size_t);
-typedef fmi1Status (STDCALL *fmiTerminate_t)(fmi1InstanceHandle*);
+typedef void (STDCALL *fmiFreeModelInstance_t)(fmi1Component*);
+typedef fmi1Status (STDCALL *fmiSetTime_t)(fmi1Component*, fmi1Real);
+typedef fmi1Status (STDCALL *fmiSetContinuousStates_t)(fmi1Component*, const fmi1Real[], size_t);
+typedef fmi1Status (STDCALL *fmiCompletedIntegratorStep_t)(fmi1Component*, fmi1Boolean*);
+typedef fmi1Status (STDCALL *fmiInitialize_t)(fmi1Component*, fmi1Boolean, fmi1Real, fmi1EventInfo*);
+typedef fmi1Status (STDCALL *fmiGetDerivatives_t)(fmi1Component*, fmi1Real[], size_t);
+typedef fmi1Status (STDCALL *fmiGetEventIndicators_t)(fmi1Component*, fmi1Real[], size_t);
+typedef fmi1Status (STDCALL *fmiEventUpdate_t)(fmi1Component*, fmi1Boolean, fmi1EventInfo*);
+typedef fmi1Status (STDCALL *fmiGetContinuousStates_t)(fmi1Component*, fmi1Real[], size_t);
+typedef fmi1Status (STDCALL *fmiGetNominalContinuousStates_t)(fmi1Component*, fmi1Real[], size_t);
+typedef fmi1Status (STDCALL *fmiGetStateValueReferences_t)(fmi1Component*, fmi1ValueReference[], size_t);
+typedef fmi1Status (STDCALL *fmiTerminate_t)(fmi1Component*);
 
 #endif // FMIC_FUNCTIONS_FMI1_H

--- a/include/fmi4c_functions_fmi2.h
+++ b/include/fmi4c_functions_fmi2.h
@@ -39,7 +39,7 @@ typedef const char* (STDCALL *fmi2GetTypesPlatform_t)(void);
 
 typedef const char* (STDCALL *fmi2GetVersion_t)(void);
 
-typedef fmi2Status (STDCALL *fmi2SetDebugLogging_t)(fmi2Component,
+typedef fmi2Status (STDCALL *fmi2SetDebugLogging_t)(fmi2InstanceHandle*,
                                                       fmi2Boolean,
                                                       size_t,
                                                       const fmi2String[]);
@@ -52,49 +52,49 @@ typedef fmi2Component (STDCALL *fmi2Instantiate_t)(fmi2String,
                                                      fmi2Boolean,
                                                      fmi2Boolean);
 
-typedef void (STDCALL *fmi2FreeInstance_t)(fmi2Component);
-typedef fmi2Status (STDCALL *fmi2SetupExperiment_t)(fmi2Component, fmi2Boolean, fmi2Real, fmi2Real, fmi2Boolean, fmi2Real);
-typedef fmi2Status (STDCALL *fmi2EnterInitializationMode_t)(fmi2Component);
-typedef fmi2Status (STDCALL *fmi2ExitInitializationMode_t)(fmi2Component);
-typedef fmi2Status (STDCALL *fmi2Terminate_t)(fmi2Component);
-typedef fmi2Status (STDCALL *fmi2Reset_t)(fmi2Component);
-typedef fmi2Status (STDCALL *fmi2GetReal_t)(fmi2Component, const fmi2ValueReference[], size_t, fmi2Real []);
-typedef fmi2Status (STDCALL *fmi2GetInteger_t)(fmi2Component, const fmi2ValueReference[], size_t, fmi2Integer[]);
-typedef fmi2Status (STDCALL *fmi2GetBoolean_t)(fmi2Component, const fmi2ValueReference[], size_t, fmi2Boolean[]);
-typedef fmi2Status (STDCALL *fmi2GetString_t)(fmi2Component, const fmi2ValueReference[], size_t, fmi2String []);
-typedef fmi2Status (STDCALL *fmi2SetReal_t)(fmi2Component, const fmi2ValueReference[], size_t, const fmi2Real []);
-typedef fmi2Status (STDCALL *fmi2SetInteger_t)(fmi2Component, const fmi2ValueReference[], size_t, const fmi2Integer[]);
-typedef fmi2Status (STDCALL *fmi2SetBoolean_t)(fmi2Component, const fmi2ValueReference[], size_t, const fmi2Boolean[]);
-typedef fmi2Status (STDCALL *fmi2SetString_t)(fmi2Component, const fmi2ValueReference[], size_t, const fmi2String []);
-typedef fmi2Status (STDCALL *fmi2GetFMUstate_t)(fmi2Component, fmi2FMUstate*);
-typedef fmi2Status (STDCALL *fmi2SetFMUstate_t)(fmi2Component, fmi2FMUstate);
-typedef fmi2Status (STDCALL *fmi2FreeFMUstate_t)(fmi2Component, fmi2FMUstate*);
-typedef fmi2Status (STDCALL *fmi2SerializedFMUstateSize_t)(fmi2Component, fmi2FMUstate, size_t*);
-typedef fmi2Status (STDCALL *fmi2SerializeFMUstate_t)(fmi2Component, fmi2FMUstate, fmi2Byte[], size_t);
-typedef fmi2Status (STDCALL *fmi2DeSerializeFMUstate_t)(fmi2Component, const fmi2Byte[], size_t, fmi2FMUstate*);
-typedef fmi2Status (STDCALL *fmi2GetDirectionalDerivative_t)(fmi2Component, const fmi2ValueReference[], size_t,
+typedef void (STDCALL *fmi2FreeInstance_t)(fmi2InstanceHandle*);
+typedef fmi2Status (STDCALL *fmi2SetupExperiment_t)(fmi2InstanceHandle*, fmi2Boolean, fmi2Real, fmi2Real, fmi2Boolean, fmi2Real);
+typedef fmi2Status (STDCALL *fmi2EnterInitializationMode_t)(fmi2InstanceHandle*);
+typedef fmi2Status (STDCALL *fmi2ExitInitializationMode_t)(fmi2InstanceHandle*);
+typedef fmi2Status (STDCALL *fmi2Terminate_t)(fmi2InstanceHandle*);
+typedef fmi2Status (STDCALL *fmi2Reset_t)(fmi2InstanceHandle*);
+typedef fmi2Status (STDCALL *fmi2GetReal_t)(fmi2InstanceHandle*, const fmi2ValueReference[], size_t, fmi2Real []);
+typedef fmi2Status (STDCALL *fmi2GetInteger_t)(fmi2InstanceHandle*, const fmi2ValueReference[], size_t, fmi2Integer[]);
+typedef fmi2Status (STDCALL *fmi2GetBoolean_t)(fmi2InstanceHandle*, const fmi2ValueReference[], size_t, fmi2Boolean[]);
+typedef fmi2Status (STDCALL *fmi2GetString_t)(fmi2InstanceHandle*, const fmi2ValueReference[], size_t, fmi2String []);
+typedef fmi2Status (STDCALL *fmi2SetReal_t)(fmi2InstanceHandle*, const fmi2ValueReference[], size_t, const fmi2Real []);
+typedef fmi2Status (STDCALL *fmi2SetInteger_t)(fmi2InstanceHandle*, const fmi2ValueReference[], size_t, const fmi2Integer[]);
+typedef fmi2Status (STDCALL *fmi2SetBoolean_t)(fmi2InstanceHandle*, const fmi2ValueReference[], size_t, const fmi2Boolean[]);
+typedef fmi2Status (STDCALL *fmi2SetString_t)(fmi2InstanceHandle*, const fmi2ValueReference[], size_t, const fmi2String []);
+typedef fmi2Status (STDCALL *fmi2GetFMUstate_t)(fmi2InstanceHandle*, fmi2FMUstate*);
+typedef fmi2Status (STDCALL *fmi2SetFMUstate_t)(fmi2InstanceHandle*, fmi2FMUstate);
+typedef fmi2Status (STDCALL *fmi2FreeFMUstate_t)(fmi2InstanceHandle*, fmi2FMUstate*);
+typedef fmi2Status (STDCALL *fmi2SerializedFMUstateSize_t)(fmi2InstanceHandle*, fmi2FMUstate, size_t*);
+typedef fmi2Status (STDCALL *fmi2SerializeFMUstate_t)(fmi2InstanceHandle*, fmi2FMUstate, fmi2Byte[], size_t);
+typedef fmi2Status (STDCALL *fmi2DeSerializeFMUstate_t)(fmi2InstanceHandle*, const fmi2Byte[], size_t, fmi2FMUstate*);
+typedef fmi2Status (STDCALL *fmi2GetDirectionalDerivative_t)(fmi2InstanceHandle*, const fmi2ValueReference[], size_t,
                                                                const fmi2ValueReference[], size_t,
                                                                const fmi2Real[], fmi2Real[]);
-typedef fmi2Status (STDCALL *fmi2EnterEventMode_t)(fmi2Component);
-typedef fmi2Status (STDCALL *fmi2NewDiscreteStates_t)(fmi2Component, fmi2EventInfo*);
-typedef fmi2Status (STDCALL *fmi2EnterContinuousTimeMode_t)(fmi2Component);
-typedef fmi2Status (STDCALL *fmi2CompletedIntegratorStep_t)(fmi2Component, fmi2Boolean, fmi2Boolean*, fmi2Boolean*);
-typedef fmi2Status (STDCALL *fmi2SetTime_t)(fmi2Component, fmi2Real);
-typedef fmi2Status (STDCALL *fmi2SetContinuousStates_t)(fmi2Component, const fmi2Real[], size_t);
-typedef fmi2Status (STDCALL *fmi2GetDerivatives_t)(fmi2Component, fmi2Real[], size_t);
-typedef fmi2Status (STDCALL *fmi2GetEventIndicators_t)(fmi2Component, fmi2Real[], size_t);
-typedef fmi2Status (STDCALL *fmi2GetContinuousStates_t)(fmi2Component, fmi2Real[], size_t);
-typedef fmi2Status (STDCALL *fmi2GetNominalsOfContinuousStates_t)(fmi2Component, fmi2Real[], size_t);
-typedef fmi2Status (STDCALL *fmi2SetRealInputDerivatives_t)(fmi2Component, const fmi2ValueReference [],
+typedef fmi2Status (STDCALL *fmi2EnterEventMode_t)(fmi2InstanceHandle*);
+typedef fmi2Status (STDCALL *fmi2NewDiscreteStates_t)(fmi2InstanceHandle*, fmi2EventInfo*);
+typedef fmi2Status (STDCALL *fmi2EnterContinuousTimeMode_t)(fmi2InstanceHandle*);
+typedef fmi2Status (STDCALL *fmi2CompletedIntegratorStep_t)(fmi2InstanceHandle*, fmi2Boolean, fmi2Boolean*, fmi2Boolean*);
+typedef fmi2Status (STDCALL *fmi2SetTime_t)(fmi2InstanceHandle*, fmi2Real);
+typedef fmi2Status (STDCALL *fmi2SetContinuousStates_t)(fmi2InstanceHandle*, const fmi2Real[], size_t);
+typedef fmi2Status (STDCALL *fmi2GetDerivatives_t)(fmi2InstanceHandle*, fmi2Real[], size_t);
+typedef fmi2Status (STDCALL *fmi2GetEventIndicators_t)(fmi2InstanceHandle*, fmi2Real[], size_t);
+typedef fmi2Status (STDCALL *fmi2GetContinuousStates_t)(fmi2InstanceHandle*, fmi2Real[], size_t);
+typedef fmi2Status (STDCALL *fmi2GetNominalsOfContinuousStates_t)(fmi2InstanceHandle*, fmi2Real[], size_t);
+typedef fmi2Status (STDCALL *fmi2SetRealInputDerivatives_t)(fmi2InstanceHandle*, const fmi2ValueReference [],
                                                               size_t, const fmi2Integer [], const fmi2Real []);
-typedef fmi2Status (STDCALL *fmi2GetRealOutputDerivatives_t)(fmi2Component, const fmi2ValueReference [],
+typedef fmi2Status (STDCALL *fmi2GetRealOutputDerivatives_t)(fmi2InstanceHandle*, const fmi2ValueReference [],
                                                                size_t, const fmi2Integer [], fmi2Real []);
-typedef fmi2Status (STDCALL *fmi2DoStep_t)(fmi2Component, fmi2Real, fmi2Real, fmi2Boolean);
-typedef fmi2Status (STDCALL *fmi2CancelStep_t)(fmi2Component);
-typedef fmi2Status (STDCALL *fmi2GetStatus_t)(fmi2Component, const fmi2StatusKind, fmi2Status* );
-typedef fmi2Status (STDCALL *fmi2GetRealStatus_t)(fmi2Component, const fmi2StatusKind, fmi2Real* );
-typedef fmi2Status (STDCALL *fmi2GetIntegerStatus_t)(fmi2Component, const fmi2StatusKind, fmi2Integer*);
-typedef fmi2Status (STDCALL *fmi2GetBooleanStatus_t)(fmi2Component, const fmi2StatusKind, fmi2Boolean*);
-typedef fmi2Status (STDCALL *fmi2GetStringStatus_t)(fmi2Component, const fmi2StatusKind, fmi2String* );
+typedef fmi2Status (STDCALL *fmi2DoStep_t)(fmi2InstanceHandle*, fmi2Real, fmi2Real, fmi2Boolean);
+typedef fmi2Status (STDCALL *fmi2CancelStep_t)(fmi2InstanceHandle*);
+typedef fmi2Status (STDCALL *fmi2GetStatus_t)(fmi2InstanceHandle*, const fmi2StatusKind, fmi2Status* );
+typedef fmi2Status (STDCALL *fmi2GetRealStatus_t)(fmi2InstanceHandle*, const fmi2StatusKind, fmi2Real* );
+typedef fmi2Status (STDCALL *fmi2GetIntegerStatus_t)(fmi2InstanceHandle*, const fmi2StatusKind, fmi2Integer*);
+typedef fmi2Status (STDCALL *fmi2GetBooleanStatus_t)(fmi2InstanceHandle*, const fmi2StatusKind, fmi2Boolean*);
+typedef fmi2Status (STDCALL *fmi2GetStringStatus_t)(fmi2InstanceHandle*, const fmi2StatusKind, fmi2String* );
 
 #endif // FMIC_FUNCTIONS_FMI2_H

--- a/include/fmi4c_functions_fmi2.h
+++ b/include/fmi4c_functions_fmi2.h
@@ -39,7 +39,7 @@ typedef const char* (STDCALL *fmi2GetTypesPlatform_t)(void);
 
 typedef const char* (STDCALL *fmi2GetVersion_t)(void);
 
-typedef fmi2Status (STDCALL *fmi2SetDebugLogging_t)(fmi2InstanceHandle*,
+typedef fmi2Status (STDCALL *fmi2SetDebugLogging_t)(fmi2Component*,
                                                       fmi2Boolean,
                                                       size_t,
                                                       const fmi2String[]);
@@ -52,49 +52,49 @@ typedef fmi2Component (STDCALL *fmi2Instantiate_t)(fmi2String,
                                                      fmi2Boolean,
                                                      fmi2Boolean);
 
-typedef void (STDCALL *fmi2FreeInstance_t)(fmi2InstanceHandle*);
-typedef fmi2Status (STDCALL *fmi2SetupExperiment_t)(fmi2InstanceHandle*, fmi2Boolean, fmi2Real, fmi2Real, fmi2Boolean, fmi2Real);
-typedef fmi2Status (STDCALL *fmi2EnterInitializationMode_t)(fmi2InstanceHandle*);
-typedef fmi2Status (STDCALL *fmi2ExitInitializationMode_t)(fmi2InstanceHandle*);
-typedef fmi2Status (STDCALL *fmi2Terminate_t)(fmi2InstanceHandle*);
-typedef fmi2Status (STDCALL *fmi2Reset_t)(fmi2InstanceHandle*);
-typedef fmi2Status (STDCALL *fmi2GetReal_t)(fmi2InstanceHandle*, const fmi2ValueReference[], size_t, fmi2Real []);
-typedef fmi2Status (STDCALL *fmi2GetInteger_t)(fmi2InstanceHandle*, const fmi2ValueReference[], size_t, fmi2Integer[]);
-typedef fmi2Status (STDCALL *fmi2GetBoolean_t)(fmi2InstanceHandle*, const fmi2ValueReference[], size_t, fmi2Boolean[]);
-typedef fmi2Status (STDCALL *fmi2GetString_t)(fmi2InstanceHandle*, const fmi2ValueReference[], size_t, fmi2String []);
-typedef fmi2Status (STDCALL *fmi2SetReal_t)(fmi2InstanceHandle*, const fmi2ValueReference[], size_t, const fmi2Real []);
-typedef fmi2Status (STDCALL *fmi2SetInteger_t)(fmi2InstanceHandle*, const fmi2ValueReference[], size_t, const fmi2Integer[]);
-typedef fmi2Status (STDCALL *fmi2SetBoolean_t)(fmi2InstanceHandle*, const fmi2ValueReference[], size_t, const fmi2Boolean[]);
-typedef fmi2Status (STDCALL *fmi2SetString_t)(fmi2InstanceHandle*, const fmi2ValueReference[], size_t, const fmi2String []);
-typedef fmi2Status (STDCALL *fmi2GetFMUstate_t)(fmi2InstanceHandle*, fmi2FMUstate*);
-typedef fmi2Status (STDCALL *fmi2SetFMUstate_t)(fmi2InstanceHandle*, fmi2FMUstate);
-typedef fmi2Status (STDCALL *fmi2FreeFMUstate_t)(fmi2InstanceHandle*, fmi2FMUstate*);
-typedef fmi2Status (STDCALL *fmi2SerializedFMUstateSize_t)(fmi2InstanceHandle*, fmi2FMUstate, size_t*);
-typedef fmi2Status (STDCALL *fmi2SerializeFMUstate_t)(fmi2InstanceHandle*, fmi2FMUstate, fmi2Byte[], size_t);
-typedef fmi2Status (STDCALL *fmi2DeSerializeFMUstate_t)(fmi2InstanceHandle*, const fmi2Byte[], size_t, fmi2FMUstate*);
-typedef fmi2Status (STDCALL *fmi2GetDirectionalDerivative_t)(fmi2InstanceHandle*, const fmi2ValueReference[], size_t,
+typedef void (STDCALL *fmi2FreeInstance_t)(fmi2Component*);
+typedef fmi2Status (STDCALL *fmi2SetupExperiment_t)(fmi2Component*, fmi2Boolean, fmi2Real, fmi2Real, fmi2Boolean, fmi2Real);
+typedef fmi2Status (STDCALL *fmi2EnterInitializationMode_t)(fmi2Component*);
+typedef fmi2Status (STDCALL *fmi2ExitInitializationMode_t)(fmi2Component*);
+typedef fmi2Status (STDCALL *fmi2Terminate_t)(fmi2Component*);
+typedef fmi2Status (STDCALL *fmi2Reset_t)(fmi2Component*);
+typedef fmi2Status (STDCALL *fmi2GetReal_t)(fmi2Component*, const fmi2ValueReference[], size_t, fmi2Real []);
+typedef fmi2Status (STDCALL *fmi2GetInteger_t)(fmi2Component*, const fmi2ValueReference[], size_t, fmi2Integer[]);
+typedef fmi2Status (STDCALL *fmi2GetBoolean_t)(fmi2Component*, const fmi2ValueReference[], size_t, fmi2Boolean[]);
+typedef fmi2Status (STDCALL *fmi2GetString_t)(fmi2Component*, const fmi2ValueReference[], size_t, fmi2String []);
+typedef fmi2Status (STDCALL *fmi2SetReal_t)(fmi2Component*, const fmi2ValueReference[], size_t, const fmi2Real []);
+typedef fmi2Status (STDCALL *fmi2SetInteger_t)(fmi2Component*, const fmi2ValueReference[], size_t, const fmi2Integer[]);
+typedef fmi2Status (STDCALL *fmi2SetBoolean_t)(fmi2Component*, const fmi2ValueReference[], size_t, const fmi2Boolean[]);
+typedef fmi2Status (STDCALL *fmi2SetString_t)(fmi2Component*, const fmi2ValueReference[], size_t, const fmi2String []);
+typedef fmi2Status (STDCALL *fmi2GetFMUstate_t)(fmi2Component*, fmi2FMUstate*);
+typedef fmi2Status (STDCALL *fmi2SetFMUstate_t)(fmi2Component*, fmi2FMUstate);
+typedef fmi2Status (STDCALL *fmi2FreeFMUstate_t)(fmi2Component*, fmi2FMUstate*);
+typedef fmi2Status (STDCALL *fmi2SerializedFMUstateSize_t)(fmi2Component*, fmi2FMUstate, size_t*);
+typedef fmi2Status (STDCALL *fmi2SerializeFMUstate_t)(fmi2Component*, fmi2FMUstate, fmi2Byte[], size_t);
+typedef fmi2Status (STDCALL *fmi2DeSerializeFMUstate_t)(fmi2Component*, const fmi2Byte[], size_t, fmi2FMUstate*);
+typedef fmi2Status (STDCALL *fmi2GetDirectionalDerivative_t)(fmi2Component*, const fmi2ValueReference[], size_t,
                                                                const fmi2ValueReference[], size_t,
                                                                const fmi2Real[], fmi2Real[]);
-typedef fmi2Status (STDCALL *fmi2EnterEventMode_t)(fmi2InstanceHandle*);
-typedef fmi2Status (STDCALL *fmi2NewDiscreteStates_t)(fmi2InstanceHandle*, fmi2EventInfo*);
-typedef fmi2Status (STDCALL *fmi2EnterContinuousTimeMode_t)(fmi2InstanceHandle*);
-typedef fmi2Status (STDCALL *fmi2CompletedIntegratorStep_t)(fmi2InstanceHandle*, fmi2Boolean, fmi2Boolean*, fmi2Boolean*);
-typedef fmi2Status (STDCALL *fmi2SetTime_t)(fmi2InstanceHandle*, fmi2Real);
-typedef fmi2Status (STDCALL *fmi2SetContinuousStates_t)(fmi2InstanceHandle*, const fmi2Real[], size_t);
-typedef fmi2Status (STDCALL *fmi2GetDerivatives_t)(fmi2InstanceHandle*, fmi2Real[], size_t);
-typedef fmi2Status (STDCALL *fmi2GetEventIndicators_t)(fmi2InstanceHandle*, fmi2Real[], size_t);
-typedef fmi2Status (STDCALL *fmi2GetContinuousStates_t)(fmi2InstanceHandle*, fmi2Real[], size_t);
-typedef fmi2Status (STDCALL *fmi2GetNominalsOfContinuousStates_t)(fmi2InstanceHandle*, fmi2Real[], size_t);
-typedef fmi2Status (STDCALL *fmi2SetRealInputDerivatives_t)(fmi2InstanceHandle*, const fmi2ValueReference [],
+typedef fmi2Status (STDCALL *fmi2EnterEventMode_t)(fmi2Component*);
+typedef fmi2Status (STDCALL *fmi2NewDiscreteStates_t)(fmi2Component*, fmi2EventInfo*);
+typedef fmi2Status (STDCALL *fmi2EnterContinuousTimeMode_t)(fmi2Component*);
+typedef fmi2Status (STDCALL *fmi2CompletedIntegratorStep_t)(fmi2Component*, fmi2Boolean, fmi2Boolean*, fmi2Boolean*);
+typedef fmi2Status (STDCALL *fmi2SetTime_t)(fmi2Component*, fmi2Real);
+typedef fmi2Status (STDCALL *fmi2SetContinuousStates_t)(fmi2Component*, const fmi2Real[], size_t);
+typedef fmi2Status (STDCALL *fmi2GetDerivatives_t)(fmi2Component*, fmi2Real[], size_t);
+typedef fmi2Status (STDCALL *fmi2GetEventIndicators_t)(fmi2Component*, fmi2Real[], size_t);
+typedef fmi2Status (STDCALL *fmi2GetContinuousStates_t)(fmi2Component*, fmi2Real[], size_t);
+typedef fmi2Status (STDCALL *fmi2GetNominalsOfContinuousStates_t)(fmi2Component*, fmi2Real[], size_t);
+typedef fmi2Status (STDCALL *fmi2SetRealInputDerivatives_t)(fmi2Component*, const fmi2ValueReference [],
                                                               size_t, const fmi2Integer [], const fmi2Real []);
-typedef fmi2Status (STDCALL *fmi2GetRealOutputDerivatives_t)(fmi2InstanceHandle*, const fmi2ValueReference [],
+typedef fmi2Status (STDCALL *fmi2GetRealOutputDerivatives_t)(fmi2Component*, const fmi2ValueReference [],
                                                                size_t, const fmi2Integer [], fmi2Real []);
-typedef fmi2Status (STDCALL *fmi2DoStep_t)(fmi2InstanceHandle*, fmi2Real, fmi2Real, fmi2Boolean);
-typedef fmi2Status (STDCALL *fmi2CancelStep_t)(fmi2InstanceHandle*);
-typedef fmi2Status (STDCALL *fmi2GetStatus_t)(fmi2InstanceHandle*, const fmi2StatusKind, fmi2Status* );
-typedef fmi2Status (STDCALL *fmi2GetRealStatus_t)(fmi2InstanceHandle*, const fmi2StatusKind, fmi2Real* );
-typedef fmi2Status (STDCALL *fmi2GetIntegerStatus_t)(fmi2InstanceHandle*, const fmi2StatusKind, fmi2Integer*);
-typedef fmi2Status (STDCALL *fmi2GetBooleanStatus_t)(fmi2InstanceHandle*, const fmi2StatusKind, fmi2Boolean*);
-typedef fmi2Status (STDCALL *fmi2GetStringStatus_t)(fmi2InstanceHandle*, const fmi2StatusKind, fmi2String* );
+typedef fmi2Status (STDCALL *fmi2DoStep_t)(fmi2Component*, fmi2Real, fmi2Real, fmi2Boolean);
+typedef fmi2Status (STDCALL *fmi2CancelStep_t)(fmi2Component*);
+typedef fmi2Status (STDCALL *fmi2GetStatus_t)(fmi2Component*, const fmi2StatusKind, fmi2Status* );
+typedef fmi2Status (STDCALL *fmi2GetRealStatus_t)(fmi2Component*, const fmi2StatusKind, fmi2Real* );
+typedef fmi2Status (STDCALL *fmi2GetIntegerStatus_t)(fmi2Component*, const fmi2StatusKind, fmi2Integer*);
+typedef fmi2Status (STDCALL *fmi2GetBooleanStatus_t)(fmi2Component*, const fmi2StatusKind, fmi2Boolean*);
+typedef fmi2Status (STDCALL *fmi2GetStringStatus_t)(fmi2Component*, const fmi2StatusKind, fmi2String* );
 
 #endif // FMIC_FUNCTIONS_FMI2_H

--- a/include/fmi4c_functions_fmi3.h
+++ b/include/fmi4c_functions_fmi3.h
@@ -30,106 +30,106 @@ typedef void (*fmi3CallbackUnlockPreemption)();
 
 // API functions
 typedef const char* (STDCALL *fmi3GetVersion_t)();
-typedef fmi3Status (STDCALL *fmi3SetDebugLogging_t)(fmi3Instance, fmi3Boolean, size_t, const fmi3String[]);
-typedef fmi3Instance (STDCALL *fmi3InstantiateModelExchange_t)(fmi3String, fmi3String, fmi3String, fmi3Boolean, fmi3Boolean,
-                                                                 fmi3InstanceEnvironment, fmi3LogMessageCallback);
-typedef fmi3Instance (STDCALL *fmi3InstantiateCoSimulation_t)(fmi3String, fmi3String, fmi3String, fmi3Boolean, fmi3Boolean,
-                                                                fmi3Boolean, fmi3Boolean, const fmi3ValueReference[], size_t,
-                                                                fmi3InstanceEnvironment, fmi3LogMessageCallback,
-                                                                fmi3IntermediateUpdateCallback);
-typedef fmi3Instance (STDCALL *fmi3InstantiateScheduledExecution_t)(fmi3String, fmi3String, fmi3String, fmi3Boolean,
-                                                                      fmi3Boolean,
-                                                                      fmi3InstanceEnvironment, fmi3LogMessageCallback,
-                                                                      fmi3IntermediateUpdateCallback,
-                                                                      fmi3CallbackLockPreemption,
-                                                                      fmi3CallbackUnlockPreemption);
-typedef void (STDCALL *fmi3FreeInstance_t)(fmi3Instance);
-typedef fmi3Status (STDCALL *fmi3EnterInitializationMode_t)(fmi3Instance, fmi3Boolean, fmi3Float64,
+typedef fmi3Status (STDCALL *fmi3SetDebugLogging_t)(fmi3InstanceHandle*, fmi3Boolean, size_t, const fmi3String[]);
+typedef fmi3InstanceHandle *(STDCALL *fmi3InstantiateModelExchange_t)(fmi3String, fmi3String, fmi3String, fmi3Boolean, fmi3Boolean,
+                                                                      fmi3InstanceEnvironment, fmi3LogMessageCallback);
+typedef fmi3InstanceHandle *(STDCALL *fmi3InstantiateCoSimulation_t)(fmi3String, fmi3String, fmi3String, fmi3Boolean, fmi3Boolean,
+                                                                     fmi3Boolean, fmi3Boolean, const fmi3ValueReference[], size_t,
+                                                                     fmi3InstanceEnvironment, fmi3LogMessageCallback,
+                                                                     fmi3IntermediateUpdateCallback);
+typedef fmi3InstanceHandle *(STDCALL *fmi3InstantiateScheduledExecution_t)(fmi3String, fmi3String, fmi3String, fmi3Boolean,
+                                                                           fmi3Boolean,
+                                                                           fmi3InstanceEnvironment, fmi3LogMessageCallback,
+                                                                           fmi3IntermediateUpdateCallback,
+                                                                           fmi3CallbackLockPreemption,
+                                                                           fmi3CallbackUnlockPreemption);
+typedef void (STDCALL *fmi3FreeInstance_t)(fmi3InstanceHandle*);
+typedef fmi3Status (STDCALL *fmi3EnterInitializationMode_t)(fmi3InstanceHandle*, fmi3Boolean, fmi3Float64,
                                                               fmi3Float64, fmi3Boolean, fmi3Float64);
-typedef fmi3Status (STDCALL *fmi3ExitInitializationMode_t)(fmi3Instance);
-typedef fmi3Status (STDCALL *fmi3Terminate_t)(fmi3Instance);
-typedef fmi3Status (STDCALL *fmi3GetFloat64_t)(fmi3Instance, const fmi3ValueReference[], size_t, fmi3Float64[], size_t);
-typedef fmi3Status (STDCALL *fmi3SetFloat64_t)(fmi3Instance, const fmi3ValueReference[], size_t, const fmi3Float64[], size_t);
-typedef fmi3Status (STDCALL *fmi3DoStep_t)(fmi3Instance, fmi3Float64, fmi3Float64, fmi3Boolean,
+typedef fmi3Status (STDCALL *fmi3ExitInitializationMode_t)(fmi3InstanceHandle*);
+typedef fmi3Status (STDCALL *fmi3Terminate_t)(fmi3InstanceHandle*);
+typedef fmi3Status (STDCALL *fmi3GetFloat64_t)(fmi3InstanceHandle*, const fmi3ValueReference[], size_t, fmi3Float64[], size_t);
+typedef fmi3Status (STDCALL *fmi3SetFloat64_t)(fmi3InstanceHandle*, const fmi3ValueReference[], size_t, const fmi3Float64[], size_t);
+typedef fmi3Status (STDCALL *fmi3DoStep_t)(fmi3InstanceHandle*, fmi3Float64, fmi3Float64, fmi3Boolean,
                                              fmi3Boolean*, fmi3Boolean*, fmi3Boolean*, fmi3Float64*);
-typedef fmi3Status (STDCALL *fmi3EnterEventMode_t)(fmi3Instance);
-typedef fmi3Status (STDCALL *fmi3Reset_t)(fmi3Instance);
-typedef fmi3Status (STDCALL *fmi3GetFloat32_t)(fmi3Instance, const fmi3ValueReference[], size_t, fmi3Float32[], size_t);
-typedef fmi3Status (STDCALL *fmi3GetInt8_t)(fmi3Instance, const fmi3ValueReference[], size_t, fmi3Int8[], size_t);
-typedef fmi3Status (STDCALL *fmi3GetUInt8_t)(fmi3Instance, const fmi3ValueReference[], size_t, fmi3UInt8[], size_t);
-typedef fmi3Status (STDCALL *fmi3GetInt16_t)(fmi3Instance, const fmi3ValueReference[], size_t, fmi3Int16[], size_t);
-typedef fmi3Status (STDCALL *fmi3GetUInt16_t)(fmi3Instance, const fmi3ValueReference[], size_t, fmi3UInt16[], size_t);
-typedef fmi3Status (STDCALL *fmi3GetInt32_t)(fmi3Instance, const fmi3ValueReference[], size_t, fmi3Int32[], size_t);
-typedef fmi3Status (STDCALL *fmi3GetUInt32_t)(fmi3Instance, const fmi3ValueReference[], size_t, fmi3UInt32[], size_t);
-typedef fmi3Status (STDCALL *fmi3GetInt64_t)(fmi3Instance, const fmi3ValueReference[], size_t, fmi3Int64[], size_t);
-typedef fmi3Status (STDCALL *fmi3GetUInt64_t)(fmi3Instance, const fmi3ValueReference[], size_t, fmi3UInt64[], size_t);
-typedef fmi3Status (STDCALL *fmi3GetBoolean_t)(fmi3Instance, const fmi3ValueReference[], size_t, fmi3Boolean[], size_t);
-typedef fmi3Status (STDCALL *fmi3GetString_t)(fmi3Instance, const fmi3ValueReference[], size_t, fmi3String[], size_t);
-typedef fmi3Status (STDCALL *fmi3GetBinary_t)(fmi3Instance, const fmi3ValueReference[], size_t, size_t[], fmi3Binary[], size_t);
-typedef fmi3Status (STDCALL *fmi3GetClock_t)(fmi3Instance, const fmi3ValueReference[], size_t, fmi3Clock[]);
-typedef fmi3Status (STDCALL *fmi3SetFloat32_t)(fmi3Instance, const fmi3ValueReference[], size_t, const fmi3Float32[], size_t);
-typedef fmi3Status (STDCALL *fmi3SetInt8_t)(fmi3Instance, const fmi3ValueReference[], size_t, const fmi3Int8[], size_t);
-typedef fmi3Status (STDCALL *fmi3SetUInt8_t)(fmi3Instance, const fmi3ValueReference[], size_t, const fmi3UInt8[], size_t);
-typedef fmi3Status (STDCALL *fmi3SetInt16_t)(fmi3Instance, const fmi3ValueReference[], size_t, const fmi3Int16[], size_t);
-typedef fmi3Status (STDCALL *fmi3SetUInt16_t)(fmi3Instance, const fmi3ValueReference[], size_t, const fmi3UInt16[], size_t);
-typedef fmi3Status (STDCALL *fmi3SetInt32_t)(fmi3Instance, const fmi3ValueReference[], size_t, const fmi3Int32[], size_t);
-typedef fmi3Status (STDCALL *fmi3SetUInt32_t)(fmi3Instance, const fmi3ValueReference[], size_t, const fmi3UInt32[], size_t);
-typedef fmi3Status (STDCALL *fmi3SetInt64_t)(fmi3Instance, const fmi3ValueReference[], size_t, const fmi3Int64[], size_t);
-typedef fmi3Status (STDCALL *fmi3SetUInt64_t)(fmi3Instance, const fmi3ValueReference[], size_t, const fmi3UInt64[], size_t);
-typedef fmi3Status (STDCALL *fmi3SetBoolean_t)(fmi3Instance, const fmi3ValueReference[], size_t, const fmi3Boolean[], size_t);
-typedef fmi3Status (STDCALL *fmi3SetString_t)(fmi3Instance, const fmi3ValueReference[], size_t, const fmi3String[], size_t);
-typedef fmi3Status (STDCALL *fmi3SetBinary_t)(fmi3Instance, const fmi3ValueReference[], size_t, const size_t[], const fmi3Binary[], size_t);
-typedef fmi3Status (STDCALL *fmi3SetClock_t)(fmi3Instance, const fmi3ValueReference[], size_t, const fmi3Clock[]);
-typedef fmi3Status (STDCALL *fmi3GetNumberOfVariableDependencies_t)(fmi3Instance, fmi3ValueReference, size_t*);
-typedef fmi3Status (STDCALL *fmi3GetVariableDependencies_t)(fmi3Instance, fmi3ValueReference, size_t[], fmi3ValueReference[],
+typedef fmi3Status (STDCALL *fmi3EnterEventMode_t)(fmi3InstanceHandle*);
+typedef fmi3Status (STDCALL *fmi3Reset_t)(fmi3InstanceHandle*);
+typedef fmi3Status (STDCALL *fmi3GetFloat32_t)(fmi3InstanceHandle*, const fmi3ValueReference[], size_t, fmi3Float32[], size_t);
+typedef fmi3Status (STDCALL *fmi3GetInt8_t)(fmi3InstanceHandle*, const fmi3ValueReference[], size_t, fmi3Int8[], size_t);
+typedef fmi3Status (STDCALL *fmi3GetUInt8_t)(fmi3InstanceHandle*, const fmi3ValueReference[], size_t, fmi3UInt8[], size_t);
+typedef fmi3Status (STDCALL *fmi3GetInt16_t)(fmi3InstanceHandle*, const fmi3ValueReference[], size_t, fmi3Int16[], size_t);
+typedef fmi3Status (STDCALL *fmi3GetUInt16_t)(fmi3InstanceHandle*, const fmi3ValueReference[], size_t, fmi3UInt16[], size_t);
+typedef fmi3Status (STDCALL *fmi3GetInt32_t)(fmi3InstanceHandle*, const fmi3ValueReference[], size_t, fmi3Int32[], size_t);
+typedef fmi3Status (STDCALL *fmi3GetUInt32_t)(fmi3InstanceHandle*, const fmi3ValueReference[], size_t, fmi3UInt32[], size_t);
+typedef fmi3Status (STDCALL *fmi3GetInt64_t)(fmi3InstanceHandle*, const fmi3ValueReference[], size_t, fmi3Int64[], size_t);
+typedef fmi3Status (STDCALL *fmi3GetUInt64_t)(fmi3InstanceHandle*, const fmi3ValueReference[], size_t, fmi3UInt64[], size_t);
+typedef fmi3Status (STDCALL *fmi3GetBoolean_t)(fmi3InstanceHandle*, const fmi3ValueReference[], size_t, fmi3Boolean[], size_t);
+typedef fmi3Status (STDCALL *fmi3GetString_t)(fmi3InstanceHandle*, const fmi3ValueReference[], size_t, fmi3String[], size_t);
+typedef fmi3Status (STDCALL *fmi3GetBinary_t)(fmi3InstanceHandle*, const fmi3ValueReference[], size_t, size_t[], fmi3Binary[], size_t);
+typedef fmi3Status (STDCALL *fmi3GetClock_t)(fmi3InstanceHandle*, const fmi3ValueReference[], size_t, fmi3Clock[]);
+typedef fmi3Status (STDCALL *fmi3SetFloat32_t)(fmi3InstanceHandle*, const fmi3ValueReference[], size_t, const fmi3Float32[], size_t);
+typedef fmi3Status (STDCALL *fmi3SetInt8_t)(fmi3InstanceHandle*, const fmi3ValueReference[], size_t, const fmi3Int8[], size_t);
+typedef fmi3Status (STDCALL *fmi3SetUInt8_t)(fmi3InstanceHandle*, const fmi3ValueReference[], size_t, const fmi3UInt8[], size_t);
+typedef fmi3Status (STDCALL *fmi3SetInt16_t)(fmi3InstanceHandle*, const fmi3ValueReference[], size_t, const fmi3Int16[], size_t);
+typedef fmi3Status (STDCALL *fmi3SetUInt16_t)(fmi3InstanceHandle*, const fmi3ValueReference[], size_t, const fmi3UInt16[], size_t);
+typedef fmi3Status (STDCALL *fmi3SetInt32_t)(fmi3InstanceHandle*, const fmi3ValueReference[], size_t, const fmi3Int32[], size_t);
+typedef fmi3Status (STDCALL *fmi3SetUInt32_t)(fmi3InstanceHandle*, const fmi3ValueReference[], size_t, const fmi3UInt32[], size_t);
+typedef fmi3Status (STDCALL *fmi3SetInt64_t)(fmi3InstanceHandle*, const fmi3ValueReference[], size_t, const fmi3Int64[], size_t);
+typedef fmi3Status (STDCALL *fmi3SetUInt64_t)(fmi3InstanceHandle*, const fmi3ValueReference[], size_t, const fmi3UInt64[], size_t);
+typedef fmi3Status (STDCALL *fmi3SetBoolean_t)(fmi3InstanceHandle*, const fmi3ValueReference[], size_t, const fmi3Boolean[], size_t);
+typedef fmi3Status (STDCALL *fmi3SetString_t)(fmi3InstanceHandle*, const fmi3ValueReference[], size_t, const fmi3String[], size_t);
+typedef fmi3Status (STDCALL *fmi3SetBinary_t)(fmi3InstanceHandle*, const fmi3ValueReference[], size_t, const size_t[], const fmi3Binary[], size_t);
+typedef fmi3Status (STDCALL *fmi3SetClock_t)(fmi3InstanceHandle*, const fmi3ValueReference[], size_t, const fmi3Clock[]);
+typedef fmi3Status (STDCALL *fmi3GetNumberOfVariableDependencies_t)(fmi3InstanceHandle*, fmi3ValueReference, size_t*);
+typedef fmi3Status (STDCALL *fmi3GetVariableDependencies_t)(fmi3InstanceHandle*, fmi3ValueReference, size_t[], fmi3ValueReference[],
                                                               size_t[], fmi3DependencyKind[], size_t);
-typedef fmi3Status (STDCALL *fmi3GetFMUState_t)(fmi3Instance, fmi3FMUState*);
-typedef fmi3Status (STDCALL *fmi3SetFMUState_t)(fmi3Instance, fmi3FMUState);
-typedef fmi3Status (STDCALL *fmi3FreeFMUState_t)(fmi3Instance, fmi3FMUState*);
-typedef fmi3Status (STDCALL *fmi3SerializedFMUStateSize_t)(fmi3Instance, fmi3FMUState, size_t*);
-typedef fmi3Status (STDCALL *fmi3SerializeFMUState_t)(fmi3Instance, fmi3FMUState, fmi3Byte[], size_t);
-typedef fmi3Status (STDCALL *fmi3DeserializeFMUState_t)(fmi3Instance, const fmi3Byte[], size_t, fmi3FMUState*);
-typedef fmi3Status (STDCALL *fmi3GetDirectionalDerivative_t)(fmi3Instance, const fmi3ValueReference[], size_t,
+typedef fmi3Status (STDCALL *fmi3GetFMUState_t)(fmi3InstanceHandle*, fmi3FMUState*);
+typedef fmi3Status (STDCALL *fmi3SetFMUState_t)(fmi3InstanceHandle*, fmi3FMUState);
+typedef fmi3Status (STDCALL *fmi3FreeFMUState_t)(fmi3InstanceHandle*, fmi3FMUState*);
+typedef fmi3Status (STDCALL *fmi3SerializedFMUStateSize_t)(fmi3InstanceHandle*, fmi3FMUState, size_t*);
+typedef fmi3Status (STDCALL *fmi3SerializeFMUState_t)(fmi3InstanceHandle*, fmi3FMUState, fmi3Byte[], size_t);
+typedef fmi3Status (STDCALL *fmi3DeserializeFMUState_t)(fmi3InstanceHandle*, const fmi3Byte[], size_t, fmi3FMUState*);
+typedef fmi3Status (STDCALL *fmi3GetDirectionalDerivative_t)(fmi3InstanceHandle*, const fmi3ValueReference[], size_t,
                                                                const fmi3ValueReference[], size_t, const fmi3Float64[],
                                                                size_t, fmi3Float64[], size_t);
-typedef fmi3Status (STDCALL *fmi3GetAdjointDerivative_t)(fmi3Instance, const fmi3ValueReference[], size_t,
+typedef fmi3Status (STDCALL *fmi3GetAdjointDerivative_t)(fmi3InstanceHandle*, const fmi3ValueReference[], size_t,
                                                            const fmi3ValueReference[], size_t, const fmi3Float64[],
                                                            size_t, fmi3Float64[], size_t);
-typedef fmi3Status (STDCALL *fmi3EnterConfigurationMode_t)(fmi3Instance);
-typedef fmi3Status (STDCALL *fmi3ExitConfigurationMode_t)(fmi3Instance);
-typedef fmi3Status (STDCALL *fmi3GetIntervalDecimal_t)(fmi3Instance, const fmi3ValueReference[], size_t,
+typedef fmi3Status (STDCALL *fmi3EnterConfigurationMode_t)(fmi3InstanceHandle*);
+typedef fmi3Status (STDCALL *fmi3ExitConfigurationMode_t)(fmi3InstanceHandle*);
+typedef fmi3Status (STDCALL *fmi3GetIntervalDecimal_t)(fmi3InstanceHandle*, const fmi3ValueReference[], size_t,
                                                          fmi3Float64[], fmi3IntervalQualifier[]);
-typedef fmi3Status (STDCALL *fmi3GetIntervalFraction_t)(fmi3Instance, const fmi3ValueReference[], size_t,
+typedef fmi3Status (STDCALL *fmi3GetIntervalFraction_t)(fmi3InstanceHandle*, const fmi3ValueReference[], size_t,
                                                           fmi3UInt64[], fmi3UInt64[], fmi3IntervalQualifier[]);
-typedef fmi3Status (STDCALL *fmi3GetShiftDecimal_t)(fmi3Instance, const fmi3ValueReference[], size_t, fmi3Float64[]);
-typedef fmi3Status (STDCALL *fmi3GetShiftFraction_t)(fmi3Instance, const fmi3ValueReference[], size_t,
+typedef fmi3Status (STDCALL *fmi3GetShiftDecimal_t)(fmi3InstanceHandle*, const fmi3ValueReference[], size_t, fmi3Float64[]);
+typedef fmi3Status (STDCALL *fmi3GetShiftFraction_t)(fmi3InstanceHandle*, const fmi3ValueReference[], size_t,
                                                        fmi3UInt64[], fmi3UInt64[]);
-typedef fmi3Status (STDCALL *fmi3SetIntervalDecimal_t)(fmi3Instance, const fmi3ValueReference[],
+typedef fmi3Status (STDCALL *fmi3SetIntervalDecimal_t)(fmi3InstanceHandle*, const fmi3ValueReference[],
                                                          size_t, const fmi3Float64[]);
-typedef fmi3Status (STDCALL *fmi3SetIntervalFraction_t)(fmi3Instance, const fmi3ValueReference[],
+typedef fmi3Status (STDCALL *fmi3SetIntervalFraction_t)(fmi3InstanceHandle*, const fmi3ValueReference[],
                                                           size_t, const fmi3UInt64[], const fmi3UInt64[]);
-typedef fmi3Status (STDCALL *fmi3SetShiftDecimal_t)(fmi3Instance instance, const fmi3ValueReference valueReferences[],
+typedef fmi3Status (STDCALL *fmi3SetShiftDecimal_t)(fmi3InstanceHandle* instance, const fmi3ValueReference valueReferences[],
                                                   size_t nValueReferences, const fmi3Float64 shifts[]);
-typedef fmi3Status (STDCALL *fmi3SetShiftFraction_t)(fmi3Instance instance, const fmi3ValueReference valueReferences[],
+typedef fmi3Status (STDCALL *fmi3SetShiftFraction_t)(fmi3InstanceHandle* instance, const fmi3ValueReference valueReferences[],
                                                     size_t nValueReferences, const fmi3UInt64 counters[],
                                                     const fmi3UInt64 resolutions[]);
 
-typedef fmi3Status (STDCALL *fmi3EvaluateDiscreteStates_t)(fmi3Instance);
-typedef fmi3Status (STDCALL *fmi3UpdateDiscreteStates_t)(fmi3Instance, fmi3Boolean*, fmi3Boolean*, fmi3Boolean*,
+typedef fmi3Status (STDCALL *fmi3EvaluateDiscreteStates_t)(fmi3InstanceHandle*);
+typedef fmi3Status (STDCALL *fmi3UpdateDiscreteStates_t)(fmi3InstanceHandle*, fmi3Boolean*, fmi3Boolean*, fmi3Boolean*,
                                                            fmi3Boolean*, fmi3Boolean*, fmi3Float64*);
-typedef fmi3Status (STDCALL *fmi3EnterContinuousTimeMode_t)(fmi3Instance);
-typedef fmi3Status (STDCALL *fmi3CompletedIntegratorStep_t)(fmi3Instance, fmi3Boolean, fmi3Boolean*, fmi3Boolean*);
-typedef fmi3Status (STDCALL *fmi3SetTime_t)(fmi3Instance, fmi3Float64);
-typedef fmi3Status (STDCALL *fmi3SetContinuousStates_t)(fmi3Instance, const fmi3Float64[], size_t);
-typedef fmi3Status (STDCALL *fmi3GetContinuousStateDerivatives_t)(fmi3Instance, fmi3Float64[], size_t);
-typedef fmi3Status (STDCALL *fmi3GetEventIndicators_t)(fmi3Instance, fmi3Float64[], size_t);
-typedef fmi3Status (STDCALL *fmi3GetContinuousStates_t)(fmi3Instance, fmi3Float64[], size_t);
-typedef fmi3Status (STDCALL *fmi3GetNominalsOfContinuousStates_t)(fmi3Instance, fmi3Float64[], size_t);
-typedef fmi3Status (STDCALL *fmi3GetNumberOfEventIndicators_t)(fmi3Instance, size_t*);
-typedef fmi3Status (STDCALL *fmi3GetNumberOfContinuousStates_t)(fmi3Instance, size_t*);
-typedef fmi3Status (STDCALL *fmi3EnterStepMode_t)(fmi3Instance);
-typedef fmi3Status (STDCALL *fmi3GetOutputDerivatives_t)(fmi3Instance, const fmi3ValueReference[], size_t,
+typedef fmi3Status (STDCALL *fmi3EnterContinuousTimeMode_t)(fmi3InstanceHandle*);
+typedef fmi3Status (STDCALL *fmi3CompletedIntegratorStep_t)(fmi3InstanceHandle*, fmi3Boolean, fmi3Boolean*, fmi3Boolean*);
+typedef fmi3Status (STDCALL *fmi3SetTime_t)(fmi3InstanceHandle*, fmi3Float64);
+typedef fmi3Status (STDCALL *fmi3SetContinuousStates_t)(fmi3InstanceHandle*, const fmi3Float64[], size_t);
+typedef fmi3Status (STDCALL *fmi3GetContinuousStateDerivatives_t)(fmi3InstanceHandle*, fmi3Float64[], size_t);
+typedef fmi3Status (STDCALL *fmi3GetEventIndicators_t)(fmi3InstanceHandle*, fmi3Float64[], size_t);
+typedef fmi3Status (STDCALL *fmi3GetContinuousStates_t)(fmi3InstanceHandle*, fmi3Float64[], size_t);
+typedef fmi3Status (STDCALL *fmi3GetNominalsOfContinuousStates_t)(fmi3InstanceHandle*, fmi3Float64[], size_t);
+typedef fmi3Status (STDCALL *fmi3GetNumberOfEventIndicators_t)(fmi3InstanceHandle*, size_t*);
+typedef fmi3Status (STDCALL *fmi3GetNumberOfContinuousStates_t)(fmi3InstanceHandle*, size_t*);
+typedef fmi3Status (STDCALL *fmi3EnterStepMode_t)(fmi3InstanceHandle*);
+typedef fmi3Status (STDCALL *fmi3GetOutputDerivatives_t)(fmi3InstanceHandle*, const fmi3ValueReference[], size_t,
                                                            const fmi3Int32[], fmi3Float64[], size_t);
-typedef fmi3Status (STDCALL *fmi3ActivateModelPartition_t)(fmi3Instance, fmi3ValueReference, fmi3Float64);
+typedef fmi3Status (STDCALL *fmi3ActivateModelPartition_t)(fmi3InstanceHandle*, fmi3ValueReference, fmi3Float64);
 
 #endif // FMIC_FUNCTIONS_FMI3_H

--- a/include/fmi4c_functions_fmi3.h
+++ b/include/fmi4c_functions_fmi3.h
@@ -30,10 +30,10 @@ typedef void (*fmi3CallbackUnlockPreemption)();
 
 // API functions
 typedef const char* (STDCALL *fmi3GetVersion_t)();
-typedef fmi3Status (STDCALL *fmi3SetDebugLogging_t)(fmi3InstanceHandle*, fmi3Boolean, size_t, const fmi3String[]);
-typedef fmi3InstanceHandle *(STDCALL *fmi3InstantiateModelExchange_t)(fmi3String, fmi3String, fmi3String, fmi3Boolean, fmi3Boolean,
+typedef fmi3Status (STDCALL *fmi3SetDebugLogging_t)(fmi3Component*, fmi3Boolean, size_t, const fmi3String[]);
+typedef fmi3Component *(STDCALL *fmi3InstantiateModelExchange_t)(fmi3String, fmi3String, fmi3String, fmi3Boolean, fmi3Boolean,
                                                                       fmi3InstanceEnvironment, fmi3LogMessageCallback);
-typedef fmi3InstanceHandle *(STDCALL *fmi3InstantiateCoSimulation_t)(fmi3String, fmi3String, fmi3String, fmi3Boolean, fmi3Boolean,
+typedef fmi3Component *(STDCALL *fmi3InstantiateCoSimulation_t)(fmi3String, fmi3String, fmi3String, fmi3Boolean, fmi3Boolean,
                                                                      fmi3Boolean, fmi3Boolean, const fmi3ValueReference[], size_t,
                                                                      fmi3InstanceEnvironment, fmi3LogMessageCallback,
                                                                      fmi3IntermediateUpdateCallback);
@@ -43,93 +43,93 @@ typedef fmi3InstanceHandle *(STDCALL *fmi3InstantiateScheduledExecution_t)(fmi3S
                                                                            fmi3IntermediateUpdateCallback,
                                                                            fmi3CallbackLockPreemption,
                                                                            fmi3CallbackUnlockPreemption);
-typedef void (STDCALL *fmi3FreeInstance_t)(fmi3InstanceHandle*);
-typedef fmi3Status (STDCALL *fmi3EnterInitializationMode_t)(fmi3InstanceHandle*, fmi3Boolean, fmi3Float64,
+typedef void (STDCALL *fmi3FreeInstance_t)(fmi3Component*);
+typedef fmi3Status (STDCALL *fmi3EnterInitializationMode_t)(fmi3Component*, fmi3Boolean, fmi3Float64,
                                                               fmi3Float64, fmi3Boolean, fmi3Float64);
-typedef fmi3Status (STDCALL *fmi3ExitInitializationMode_t)(fmi3InstanceHandle*);
-typedef fmi3Status (STDCALL *fmi3Terminate_t)(fmi3InstanceHandle*);
-typedef fmi3Status (STDCALL *fmi3GetFloat64_t)(fmi3InstanceHandle*, const fmi3ValueReference[], size_t, fmi3Float64[], size_t);
-typedef fmi3Status (STDCALL *fmi3SetFloat64_t)(fmi3InstanceHandle*, const fmi3ValueReference[], size_t, const fmi3Float64[], size_t);
-typedef fmi3Status (STDCALL *fmi3DoStep_t)(fmi3InstanceHandle*, fmi3Float64, fmi3Float64, fmi3Boolean,
+typedef fmi3Status (STDCALL *fmi3ExitInitializationMode_t)(fmi3Component*);
+typedef fmi3Status (STDCALL *fmi3Terminate_t)(fmi3Component*);
+typedef fmi3Status (STDCALL *fmi3GetFloat64_t)(fmi3Component*, const fmi3ValueReference[], size_t, fmi3Float64[], size_t);
+typedef fmi3Status (STDCALL *fmi3SetFloat64_t)(fmi3Component*, const fmi3ValueReference[], size_t, const fmi3Float64[], size_t);
+typedef fmi3Status (STDCALL *fmi3DoStep_t)(fmi3Component*, fmi3Float64, fmi3Float64, fmi3Boolean,
                                              fmi3Boolean*, fmi3Boolean*, fmi3Boolean*, fmi3Float64*);
-typedef fmi3Status (STDCALL *fmi3EnterEventMode_t)(fmi3InstanceHandle*);
-typedef fmi3Status (STDCALL *fmi3Reset_t)(fmi3InstanceHandle*);
-typedef fmi3Status (STDCALL *fmi3GetFloat32_t)(fmi3InstanceHandle*, const fmi3ValueReference[], size_t, fmi3Float32[], size_t);
-typedef fmi3Status (STDCALL *fmi3GetInt8_t)(fmi3InstanceHandle*, const fmi3ValueReference[], size_t, fmi3Int8[], size_t);
-typedef fmi3Status (STDCALL *fmi3GetUInt8_t)(fmi3InstanceHandle*, const fmi3ValueReference[], size_t, fmi3UInt8[], size_t);
-typedef fmi3Status (STDCALL *fmi3GetInt16_t)(fmi3InstanceHandle*, const fmi3ValueReference[], size_t, fmi3Int16[], size_t);
-typedef fmi3Status (STDCALL *fmi3GetUInt16_t)(fmi3InstanceHandle*, const fmi3ValueReference[], size_t, fmi3UInt16[], size_t);
-typedef fmi3Status (STDCALL *fmi3GetInt32_t)(fmi3InstanceHandle*, const fmi3ValueReference[], size_t, fmi3Int32[], size_t);
-typedef fmi3Status (STDCALL *fmi3GetUInt32_t)(fmi3InstanceHandle*, const fmi3ValueReference[], size_t, fmi3UInt32[], size_t);
-typedef fmi3Status (STDCALL *fmi3GetInt64_t)(fmi3InstanceHandle*, const fmi3ValueReference[], size_t, fmi3Int64[], size_t);
-typedef fmi3Status (STDCALL *fmi3GetUInt64_t)(fmi3InstanceHandle*, const fmi3ValueReference[], size_t, fmi3UInt64[], size_t);
-typedef fmi3Status (STDCALL *fmi3GetBoolean_t)(fmi3InstanceHandle*, const fmi3ValueReference[], size_t, fmi3Boolean[], size_t);
-typedef fmi3Status (STDCALL *fmi3GetString_t)(fmi3InstanceHandle*, const fmi3ValueReference[], size_t, fmi3String[], size_t);
-typedef fmi3Status (STDCALL *fmi3GetBinary_t)(fmi3InstanceHandle*, const fmi3ValueReference[], size_t, size_t[], fmi3Binary[], size_t);
-typedef fmi3Status (STDCALL *fmi3GetClock_t)(fmi3InstanceHandle*, const fmi3ValueReference[], size_t, fmi3Clock[]);
-typedef fmi3Status (STDCALL *fmi3SetFloat32_t)(fmi3InstanceHandle*, const fmi3ValueReference[], size_t, const fmi3Float32[], size_t);
-typedef fmi3Status (STDCALL *fmi3SetInt8_t)(fmi3InstanceHandle*, const fmi3ValueReference[], size_t, const fmi3Int8[], size_t);
-typedef fmi3Status (STDCALL *fmi3SetUInt8_t)(fmi3InstanceHandle*, const fmi3ValueReference[], size_t, const fmi3UInt8[], size_t);
-typedef fmi3Status (STDCALL *fmi3SetInt16_t)(fmi3InstanceHandle*, const fmi3ValueReference[], size_t, const fmi3Int16[], size_t);
-typedef fmi3Status (STDCALL *fmi3SetUInt16_t)(fmi3InstanceHandle*, const fmi3ValueReference[], size_t, const fmi3UInt16[], size_t);
-typedef fmi3Status (STDCALL *fmi3SetInt32_t)(fmi3InstanceHandle*, const fmi3ValueReference[], size_t, const fmi3Int32[], size_t);
-typedef fmi3Status (STDCALL *fmi3SetUInt32_t)(fmi3InstanceHandle*, const fmi3ValueReference[], size_t, const fmi3UInt32[], size_t);
-typedef fmi3Status (STDCALL *fmi3SetInt64_t)(fmi3InstanceHandle*, const fmi3ValueReference[], size_t, const fmi3Int64[], size_t);
-typedef fmi3Status (STDCALL *fmi3SetUInt64_t)(fmi3InstanceHandle*, const fmi3ValueReference[], size_t, const fmi3UInt64[], size_t);
-typedef fmi3Status (STDCALL *fmi3SetBoolean_t)(fmi3InstanceHandle*, const fmi3ValueReference[], size_t, const fmi3Boolean[], size_t);
-typedef fmi3Status (STDCALL *fmi3SetString_t)(fmi3InstanceHandle*, const fmi3ValueReference[], size_t, const fmi3String[], size_t);
-typedef fmi3Status (STDCALL *fmi3SetBinary_t)(fmi3InstanceHandle*, const fmi3ValueReference[], size_t, const size_t[], const fmi3Binary[], size_t);
-typedef fmi3Status (STDCALL *fmi3SetClock_t)(fmi3InstanceHandle*, const fmi3ValueReference[], size_t, const fmi3Clock[]);
-typedef fmi3Status (STDCALL *fmi3GetNumberOfVariableDependencies_t)(fmi3InstanceHandle*, fmi3ValueReference, size_t*);
-typedef fmi3Status (STDCALL *fmi3GetVariableDependencies_t)(fmi3InstanceHandle*, fmi3ValueReference, size_t[], fmi3ValueReference[],
+typedef fmi3Status (STDCALL *fmi3EnterEventMode_t)(fmi3Component*);
+typedef fmi3Status (STDCALL *fmi3Reset_t)(fmi3Component*);
+typedef fmi3Status (STDCALL *fmi3GetFloat32_t)(fmi3Component*, const fmi3ValueReference[], size_t, fmi3Float32[], size_t);
+typedef fmi3Status (STDCALL *fmi3GetInt8_t)(fmi3Component*, const fmi3ValueReference[], size_t, fmi3Int8[], size_t);
+typedef fmi3Status (STDCALL *fmi3GetUInt8_t)(fmi3Component*, const fmi3ValueReference[], size_t, fmi3UInt8[], size_t);
+typedef fmi3Status (STDCALL *fmi3GetInt16_t)(fmi3Component*, const fmi3ValueReference[], size_t, fmi3Int16[], size_t);
+typedef fmi3Status (STDCALL *fmi3GetUInt16_t)(fmi3Component*, const fmi3ValueReference[], size_t, fmi3UInt16[], size_t);
+typedef fmi3Status (STDCALL *fmi3GetInt32_t)(fmi3Component*, const fmi3ValueReference[], size_t, fmi3Int32[], size_t);
+typedef fmi3Status (STDCALL *fmi3GetUInt32_t)(fmi3Component*, const fmi3ValueReference[], size_t, fmi3UInt32[], size_t);
+typedef fmi3Status (STDCALL *fmi3GetInt64_t)(fmi3Component*, const fmi3ValueReference[], size_t, fmi3Int64[], size_t);
+typedef fmi3Status (STDCALL *fmi3GetUInt64_t)(fmi3Component*, const fmi3ValueReference[], size_t, fmi3UInt64[], size_t);
+typedef fmi3Status (STDCALL *fmi3GetBoolean_t)(fmi3Component*, const fmi3ValueReference[], size_t, fmi3Boolean[], size_t);
+typedef fmi3Status (STDCALL *fmi3GetString_t)(fmi3Component*, const fmi3ValueReference[], size_t, fmi3String[], size_t);
+typedef fmi3Status (STDCALL *fmi3GetBinary_t)(fmi3Component*, const fmi3ValueReference[], size_t, size_t[], fmi3Binary[], size_t);
+typedef fmi3Status (STDCALL *fmi3GetClock_t)(fmi3Component*, const fmi3ValueReference[], size_t, fmi3Clock[]);
+typedef fmi3Status (STDCALL *fmi3SetFloat32_t)(fmi3Component*, const fmi3ValueReference[], size_t, const fmi3Float32[], size_t);
+typedef fmi3Status (STDCALL *fmi3SetInt8_t)(fmi3Component*, const fmi3ValueReference[], size_t, const fmi3Int8[], size_t);
+typedef fmi3Status (STDCALL *fmi3SetUInt8_t)(fmi3Component*, const fmi3ValueReference[], size_t, const fmi3UInt8[], size_t);
+typedef fmi3Status (STDCALL *fmi3SetInt16_t)(fmi3Component*, const fmi3ValueReference[], size_t, const fmi3Int16[], size_t);
+typedef fmi3Status (STDCALL *fmi3SetUInt16_t)(fmi3Component*, const fmi3ValueReference[], size_t, const fmi3UInt16[], size_t);
+typedef fmi3Status (STDCALL *fmi3SetInt32_t)(fmi3Component*, const fmi3ValueReference[], size_t, const fmi3Int32[], size_t);
+typedef fmi3Status (STDCALL *fmi3SetUInt32_t)(fmi3Component*, const fmi3ValueReference[], size_t, const fmi3UInt32[], size_t);
+typedef fmi3Status (STDCALL *fmi3SetInt64_t)(fmi3Component*, const fmi3ValueReference[], size_t, const fmi3Int64[], size_t);
+typedef fmi3Status (STDCALL *fmi3SetUInt64_t)(fmi3Component*, const fmi3ValueReference[], size_t, const fmi3UInt64[], size_t);
+typedef fmi3Status (STDCALL *fmi3SetBoolean_t)(fmi3Component*, const fmi3ValueReference[], size_t, const fmi3Boolean[], size_t);
+typedef fmi3Status (STDCALL *fmi3SetString_t)(fmi3Component*, const fmi3ValueReference[], size_t, const fmi3String[], size_t);
+typedef fmi3Status (STDCALL *fmi3SetBinary_t)(fmi3Component*, const fmi3ValueReference[], size_t, const size_t[], const fmi3Binary[], size_t);
+typedef fmi3Status (STDCALL *fmi3SetClock_t)(fmi3Component*, const fmi3ValueReference[], size_t, const fmi3Clock[]);
+typedef fmi3Status (STDCALL *fmi3GetNumberOfVariableDependencies_t)(fmi3Component*, fmi3ValueReference, size_t*);
+typedef fmi3Status (STDCALL *fmi3GetVariableDependencies_t)(fmi3Component*, fmi3ValueReference, size_t[], fmi3ValueReference[],
                                                               size_t[], fmi3DependencyKind[], size_t);
-typedef fmi3Status (STDCALL *fmi3GetFMUState_t)(fmi3InstanceHandle*, fmi3FMUState*);
-typedef fmi3Status (STDCALL *fmi3SetFMUState_t)(fmi3InstanceHandle*, fmi3FMUState);
-typedef fmi3Status (STDCALL *fmi3FreeFMUState_t)(fmi3InstanceHandle*, fmi3FMUState*);
-typedef fmi3Status (STDCALL *fmi3SerializedFMUStateSize_t)(fmi3InstanceHandle*, fmi3FMUState, size_t*);
-typedef fmi3Status (STDCALL *fmi3SerializeFMUState_t)(fmi3InstanceHandle*, fmi3FMUState, fmi3Byte[], size_t);
-typedef fmi3Status (STDCALL *fmi3DeserializeFMUState_t)(fmi3InstanceHandle*, const fmi3Byte[], size_t, fmi3FMUState*);
-typedef fmi3Status (STDCALL *fmi3GetDirectionalDerivative_t)(fmi3InstanceHandle*, const fmi3ValueReference[], size_t,
+typedef fmi3Status (STDCALL *fmi3GetFMUState_t)(fmi3Component*, fmi3FMUState*);
+typedef fmi3Status (STDCALL *fmi3SetFMUState_t)(fmi3Component*, fmi3FMUState);
+typedef fmi3Status (STDCALL *fmi3FreeFMUState_t)(fmi3Component*, fmi3FMUState*);
+typedef fmi3Status (STDCALL *fmi3SerializedFMUStateSize_t)(fmi3Component*, fmi3FMUState, size_t*);
+typedef fmi3Status (STDCALL *fmi3SerializeFMUState_t)(fmi3Component*, fmi3FMUState, fmi3Byte[], size_t);
+typedef fmi3Status (STDCALL *fmi3DeserializeFMUState_t)(fmi3Component*, const fmi3Byte[], size_t, fmi3FMUState*);
+typedef fmi3Status (STDCALL *fmi3GetDirectionalDerivative_t)(fmi3Component*, const fmi3ValueReference[], size_t,
                                                                const fmi3ValueReference[], size_t, const fmi3Float64[],
                                                                size_t, fmi3Float64[], size_t);
-typedef fmi3Status (STDCALL *fmi3GetAdjointDerivative_t)(fmi3InstanceHandle*, const fmi3ValueReference[], size_t,
+typedef fmi3Status (STDCALL *fmi3GetAdjointDerivative_t)(fmi3Component*, const fmi3ValueReference[], size_t,
                                                            const fmi3ValueReference[], size_t, const fmi3Float64[],
                                                            size_t, fmi3Float64[], size_t);
-typedef fmi3Status (STDCALL *fmi3EnterConfigurationMode_t)(fmi3InstanceHandle*);
-typedef fmi3Status (STDCALL *fmi3ExitConfigurationMode_t)(fmi3InstanceHandle*);
-typedef fmi3Status (STDCALL *fmi3GetIntervalDecimal_t)(fmi3InstanceHandle*, const fmi3ValueReference[], size_t,
+typedef fmi3Status (STDCALL *fmi3EnterConfigurationMode_t)(fmi3Component*);
+typedef fmi3Status (STDCALL *fmi3ExitConfigurationMode_t)(fmi3Component*);
+typedef fmi3Status (STDCALL *fmi3GetIntervalDecimal_t)(fmi3Component*, const fmi3ValueReference[], size_t,
                                                          fmi3Float64[], fmi3IntervalQualifier[]);
-typedef fmi3Status (STDCALL *fmi3GetIntervalFraction_t)(fmi3InstanceHandle*, const fmi3ValueReference[], size_t,
+typedef fmi3Status (STDCALL *fmi3GetIntervalFraction_t)(fmi3Component*, const fmi3ValueReference[], size_t,
                                                           fmi3UInt64[], fmi3UInt64[], fmi3IntervalQualifier[]);
-typedef fmi3Status (STDCALL *fmi3GetShiftDecimal_t)(fmi3InstanceHandle*, const fmi3ValueReference[], size_t, fmi3Float64[]);
-typedef fmi3Status (STDCALL *fmi3GetShiftFraction_t)(fmi3InstanceHandle*, const fmi3ValueReference[], size_t,
+typedef fmi3Status (STDCALL *fmi3GetShiftDecimal_t)(fmi3Component*, const fmi3ValueReference[], size_t, fmi3Float64[]);
+typedef fmi3Status (STDCALL *fmi3GetShiftFraction_t)(fmi3Component*, const fmi3ValueReference[], size_t,
                                                        fmi3UInt64[], fmi3UInt64[]);
-typedef fmi3Status (STDCALL *fmi3SetIntervalDecimal_t)(fmi3InstanceHandle*, const fmi3ValueReference[],
+typedef fmi3Status (STDCALL *fmi3SetIntervalDecimal_t)(fmi3Component*, const fmi3ValueReference[],
                                                          size_t, const fmi3Float64[]);
-typedef fmi3Status (STDCALL *fmi3SetIntervalFraction_t)(fmi3InstanceHandle*, const fmi3ValueReference[],
+typedef fmi3Status (STDCALL *fmi3SetIntervalFraction_t)(fmi3Component*, const fmi3ValueReference[],
                                                           size_t, const fmi3UInt64[], const fmi3UInt64[]);
-typedef fmi3Status (STDCALL *fmi3SetShiftDecimal_t)(fmi3InstanceHandle* instance, const fmi3ValueReference valueReferences[],
+typedef fmi3Status (STDCALL *fmi3SetShiftDecimal_t)(fmi3Component* instance, const fmi3ValueReference valueReferences[],
                                                   size_t nValueReferences, const fmi3Float64 shifts[]);
-typedef fmi3Status (STDCALL *fmi3SetShiftFraction_t)(fmi3InstanceHandle* instance, const fmi3ValueReference valueReferences[],
+typedef fmi3Status (STDCALL *fmi3SetShiftFraction_t)(fmi3Component* instance, const fmi3ValueReference valueReferences[],
                                                     size_t nValueReferences, const fmi3UInt64 counters[],
                                                     const fmi3UInt64 resolutions[]);
 
-typedef fmi3Status (STDCALL *fmi3EvaluateDiscreteStates_t)(fmi3InstanceHandle*);
-typedef fmi3Status (STDCALL *fmi3UpdateDiscreteStates_t)(fmi3InstanceHandle*, fmi3Boolean*, fmi3Boolean*, fmi3Boolean*,
+typedef fmi3Status (STDCALL *fmi3EvaluateDiscreteStates_t)(fmi3Component*);
+typedef fmi3Status (STDCALL *fmi3UpdateDiscreteStates_t)(fmi3Component*, fmi3Boolean*, fmi3Boolean*, fmi3Boolean*,
                                                            fmi3Boolean*, fmi3Boolean*, fmi3Float64*);
-typedef fmi3Status (STDCALL *fmi3EnterContinuousTimeMode_t)(fmi3InstanceHandle*);
-typedef fmi3Status (STDCALL *fmi3CompletedIntegratorStep_t)(fmi3InstanceHandle*, fmi3Boolean, fmi3Boolean*, fmi3Boolean*);
-typedef fmi3Status (STDCALL *fmi3SetTime_t)(fmi3InstanceHandle*, fmi3Float64);
-typedef fmi3Status (STDCALL *fmi3SetContinuousStates_t)(fmi3InstanceHandle*, const fmi3Float64[], size_t);
-typedef fmi3Status (STDCALL *fmi3GetContinuousStateDerivatives_t)(fmi3InstanceHandle*, fmi3Float64[], size_t);
-typedef fmi3Status (STDCALL *fmi3GetEventIndicators_t)(fmi3InstanceHandle*, fmi3Float64[], size_t);
-typedef fmi3Status (STDCALL *fmi3GetContinuousStates_t)(fmi3InstanceHandle*, fmi3Float64[], size_t);
-typedef fmi3Status (STDCALL *fmi3GetNominalsOfContinuousStates_t)(fmi3InstanceHandle*, fmi3Float64[], size_t);
-typedef fmi3Status (STDCALL *fmi3GetNumberOfEventIndicators_t)(fmi3InstanceHandle*, size_t*);
-typedef fmi3Status (STDCALL *fmi3GetNumberOfContinuousStates_t)(fmi3InstanceHandle*, size_t*);
-typedef fmi3Status (STDCALL *fmi3EnterStepMode_t)(fmi3InstanceHandle*);
-typedef fmi3Status (STDCALL *fmi3GetOutputDerivatives_t)(fmi3InstanceHandle*, const fmi3ValueReference[], size_t,
+typedef fmi3Status (STDCALL *fmi3EnterContinuousTimeMode_t)(fmi3Component*);
+typedef fmi3Status (STDCALL *fmi3CompletedIntegratorStep_t)(fmi3Component*, fmi3Boolean, fmi3Boolean*, fmi3Boolean*);
+typedef fmi3Status (STDCALL *fmi3SetTime_t)(fmi3Component*, fmi3Float64);
+typedef fmi3Status (STDCALL *fmi3SetContinuousStates_t)(fmi3Component*, const fmi3Float64[], size_t);
+typedef fmi3Status (STDCALL *fmi3GetContinuousStateDerivatives_t)(fmi3Component*, fmi3Float64[], size_t);
+typedef fmi3Status (STDCALL *fmi3GetEventIndicators_t)(fmi3Component*, fmi3Float64[], size_t);
+typedef fmi3Status (STDCALL *fmi3GetContinuousStates_t)(fmi3Component*, fmi3Float64[], size_t);
+typedef fmi3Status (STDCALL *fmi3GetNominalsOfContinuousStates_t)(fmi3Component*, fmi3Float64[], size_t);
+typedef fmi3Status (STDCALL *fmi3GetNumberOfEventIndicators_t)(fmi3Component*, size_t*);
+typedef fmi3Status (STDCALL *fmi3GetNumberOfContinuousStates_t)(fmi3Component*, size_t*);
+typedef fmi3Status (STDCALL *fmi3EnterStepMode_t)(fmi3Component*);
+typedef fmi3Status (STDCALL *fmi3GetOutputDerivatives_t)(fmi3Component*, const fmi3ValueReference[], size_t,
                                                            const fmi3Int32[], fmi3Float64[], size_t);
-typedef fmi3Status (STDCALL *fmi3ActivateModelPartition_t)(fmi3InstanceHandle*, fmi3ValueReference, fmi3Float64);
+typedef fmi3Status (STDCALL *fmi3ActivateModelPartition_t)(fmi3Component*, fmi3ValueReference, fmi3Float64);
 
 #endif // FMIC_FUNCTIONS_FMI3_H

--- a/include/fmi4c_public.h
+++ b/include/fmi4c_public.h
@@ -1,7 +1,7 @@
 #ifndef FMIC_PUBLIC_H
 #define FMIC_PUBLIC_H
 
-typedef struct fmiHandle fmiHandle;
+typedef struct fmuHandle fmuHandle;
 typedef struct fmi1VariableHandle fmi1VariableHandle;
 typedef struct fmi1BaseUnitHandle fmi1BaseUnitHandle;
 typedef struct fmi2VariableHandle fmi2VariableHandle;

--- a/include/fmi4c_types_fmi1.h
+++ b/include/fmi4c_types_fmi1.h
@@ -10,9 +10,9 @@ struct fmuHandle;
 typedef struct fmuHandle fmuHandle;
 
 // Types
-typedef void* fmi1Component_t;
+typedef void* fmi1Component;
 struct fmi1InstanceHandle {
-    fmi1Component_t component;
+    fmi1Component component;
     fmuHandle *fmu;
 };
 typedef struct fmi1InstanceHandle fmi1InstanceHandle;

--- a/include/fmi4c_types_fmi1.h
+++ b/include/fmi4c_types_fmi1.h
@@ -5,8 +5,18 @@
 #define fmi1True  1
 #define fmi1False 0
 
+//Forward declarations
+struct fmuHandle;
+typedef struct fmuHandle fmuHandle;
+
 // Types
 typedef void* fmi1Component_t;
+struct fmi1InstanceHandle {
+    fmi1Component_t component;
+    fmuHandle *fmu;
+};
+typedef struct fmi1InstanceHandle fmi1InstanceHandle;
+
 typedef unsigned int fmi1ValueReference;
 typedef double fmi1Real;
 typedef int fmi1Integer;

--- a/include/fmi4c_types_fmi2.h
+++ b/include/fmi4c_types_fmi2.h
@@ -5,10 +5,16 @@
 #define fmi2True  1
 #define fmi2False 0
 
-struct fmiHandle;
+struct fmuHandle;
+typedef struct fmuHandle fmuHandle;
 
 // Types
 typedef void* fmi2Component;
+struct fmi2InstanceHandle {
+    fmi2Component component;
+    fmuHandle *fmu;
+};
+typedef struct fmi2InstanceHandle fmi2InstanceHandle;
 typedef void* fmi2ComponentEnvironment;
 typedef void* fmi2FMUstate;
 typedef unsigned int fmi2ValueReference;

--- a/include/fmi4c_types_fmi2.h
+++ b/include/fmi4c_types_fmi2.h
@@ -5,6 +5,7 @@
 #define fmi2True  1
 #define fmi2False 0
 
+//Forward declarations
 struct fmuHandle;
 typedef struct fmuHandle fmuHandle;
 

--- a/include/fmi4c_types_fmi2.h
+++ b/include/fmi4c_types_fmi2.h
@@ -5,6 +5,8 @@
 #define fmi2True  1
 #define fmi2False 0
 
+struct fmiHandle;
+
 // Types
 typedef void* fmi2Component;
 typedef void* fmi2ComponentEnvironment;

--- a/include/fmi4c_types_fmi3.h
+++ b/include/fmi4c_types_fmi3.h
@@ -8,8 +8,17 @@
 #define fmi3True  true
 #define fmi3False false
 
+//Forward declarations
+struct fmuHandle;
+typedef struct fmuHandle fmuHandle;
+
 // Types
-typedef void* fmi3Instance;
+typedef void* fmi3Component;
+struct fmi3InstanceHandle {
+    fmi3Component component;
+    fmuHandle *fmu;
+};
+typedef struct fmi3InstanceHandle fmi3InstanceHandle;
 typedef void* fmi3InstanceEnvironment;
 typedef void* fmi3FMUState;
 typedef uint32_t fmi3ValueReference;

--- a/src/fmi4c.c
+++ b/src/fmi4c.c
@@ -2779,7 +2779,10 @@ fmi2Status fmi2_terminate(fmi2InstanceHandle *instance)
 {
     TRACEFUNC
 
-    return instance->fmu->fmi2.terminate(instance->component);
+    fmi2Status status = instance->fmu->fmi2.terminate(instance->component);
+    free(instance);
+    return status;
+
 }
 
 fmi2Status fmi2_reset(fmi2InstanceHandle *instance)
@@ -5294,7 +5297,9 @@ fmi1Status fmi1_initializeSlave(fmi1InstanceHandle *instance, fmi1Real startTime
 fmi1Status fmi1_terminateSlave(fmi1InstanceHandle *instance)
 {
     TRACEFUNC
-    return instance->fmu->fmi1.terminateSlave(instance->component);
+    fmi1Status status = instance->fmu->fmi1.terminateSlave(instance->component);
+    free(instance);
+    return status;
 }
 
 fmi1Status fmi1_resetSlave(fmi1InstanceHandle *instance)
@@ -5453,7 +5458,9 @@ fmi1Status fmi1_getStateValueReferences(fmi1InstanceHandle *instance, fmi1ValueR
 fmi1Status fmi1_terminate(fmi1InstanceHandle *instance)
 {
     TRACEFUNC
-    return instance->fmu->fmi1.terminate(instance->component);
+    fmi1Status status = instance->fmu->fmi1.terminate(instance->component);
+    free(instance);
+    return status;
 }
 
 fmi1DataType fmi1_getVariableDataType(fmi1VariableHandle *var)

--- a/src/fmi4c.c
+++ b/src/fmi4c.c
@@ -4004,7 +4004,7 @@ fmi2Status fmi2_doStep(fmi2InstanceHandle *instance, fmi2Real currentCommunicati
 fmi2Status fmi2_cancelStep(fmi2InstanceHandle *instance)
 {
     TRACEFUNC
-    return instance->fmu->fmi2.cancelStep(instance->fmu);
+    return instance->fmu->fmi2.cancelStep(instance);
 }
 
 fmi2Status fmi2_getStatus(fmi2InstanceHandle *instance, const fmi2StatusKind s, fmi2Status* value)
@@ -4874,7 +4874,7 @@ fmuHandle *fmi4c_loadUnzippedFmu_internal(const char *instanceName, const char *
 //! Parses modelDescription.xml, and then loads all required FMI functions.
 //! @param fmu FMU handle
 //! @returns Handle to FMU
-fmiHandle *fmi4c_loadUnzippedFmu(const char *instanceName, const char *unzipLocation)
+fmuHandle *fmi4c_loadUnzippedFmu(const char *instanceName, const char *unzipLocation)
 {
     return fmi4c_loadUnzippedFmu_internal(instanceName, unzipLocation, false);
 }

--- a/src/fmi4c.c
+++ b/src/fmi4c.c
@@ -2752,6 +2752,7 @@ void fmi2_freeInstance(fmi2InstanceHandle *instance)
     TRACEFUNC
 
     instance->fmu->fmi2.freeInstance(instance->component);
+    free(instance);
 }
 
 fmi2Status fmi2_setupExperiment(fmi2InstanceHandle *instance, fmi2Boolean toleranceDefined, fmi2Real tolerance, fmi2Real startTime, fmi2Boolean stopTimeDefined, fmi2Real stopTime)
@@ -2779,9 +2780,7 @@ fmi2Status fmi2_terminate(fmi2InstanceHandle *instance)
 {
     TRACEFUNC
 
-    fmi2Status status = instance->fmu->fmi2.terminate(instance->component);
-    free(instance);
-    return status;
+    return instance->fmu->fmi2.terminate(instance->component);
 
 }
 
@@ -5297,9 +5296,7 @@ fmi1Status fmi1_initializeSlave(fmi1InstanceHandle *instance, fmi1Real startTime
 fmi1Status fmi1_terminateSlave(fmi1InstanceHandle *instance)
 {
     TRACEFUNC
-    fmi1Status status = instance->fmu->fmi1.terminateSlave(instance->component);
-    free(instance);
-    return status;
+    return instance->fmu->fmi1.terminateSlave(instance->component);
 }
 
 fmi1Status fmi1_resetSlave(fmi1InstanceHandle *instance)
@@ -5312,6 +5309,7 @@ void fmi1_freeSlaveInstance(fmi1InstanceHandle *instance)
 {
     TRACEFUNC
     instance->fmu->fmi1.freeSlaveInstance(instance->component);
+    free(instance);
 }
 
 fmi1Status fmi1_setRealInputDerivatives(fmi1InstanceHandle *instance, const fmi1ValueReference valueReferences[], size_t nValueReferences, const fmi1Integer orders[], const fmi1Real values[])
@@ -5393,6 +5391,7 @@ void fmi1_freeModelInstance(fmi1InstanceHandle *instance)
 {
     TRACEFUNC
     instance->fmu->fmi1.freeModelInstance(instance->component);
+    free(instance);
 }
 
 fmi1Status fmi1_setTime(fmi1InstanceHandle *instance, fmi1Real time)
@@ -5458,9 +5457,7 @@ fmi1Status fmi1_getStateValueReferences(fmi1InstanceHandle *instance, fmi1ValueR
 fmi1Status fmi1_terminate(fmi1InstanceHandle *instance)
 {
     TRACEFUNC
-    fmi1Status status = instance->fmu->fmi1.terminate(instance->component);
-    free(instance);
-    return status;
+    return instance->fmu->fmi1.terminate(instance->component);
 }
 
 fmi1DataType fmi1_getVariableDataType(fmi1VariableHandle *var)

--- a/src/fmi4c.c
+++ b/src/fmi4c.c
@@ -2707,7 +2707,7 @@ const char *fmi2_getVersion(fmuHandle *fmu)
 fmi2Status fmi2_setDebugLogging(fmi2InstanceHandle *instance, fmi2Boolean loggingOn, size_t nCategories, const fmi2String categories[])
 {
     TRACEFUNC
-    return instance->fmu->fmi2.setDebugLogging(instance, loggingOn, nCategories, categories);
+    return instance->fmu->fmi2.setDebugLogging(instance->component, loggingOn, nCategories, categories);
 }
 
 fmi2InstanceHandle *fmi2_instantiate(fmuHandle *fmu, fmi2Type type, fmi2CallbackLogger logger, fmi2CallbackAllocateMemory allocateMemory, fmi2CallbackFreeMemory freeMemory, fmi2StepFinished stepFinished, fmi2ComponentEnvironment componentEnvironment, fmi2Boolean visible, fmi2Boolean loggingOn)

--- a/src/fmi4c.c
+++ b/src/fmi4c.c
@@ -2704,14 +2704,14 @@ const char *fmi2_getVersion(fmiHandle *fmu)
     return fmu->fmi2.version;
 }
 
-fmi2Status fmi2_setDebugLogging(fmiHandle *fmu, fmi2Boolean loggingOn, size_t nCategories, const fmi2String categories[])
+fmi2Status fmi2_setDebugLogging(fmiHandle *fmu, fmi2Component comp, fmi2Boolean loggingOn, size_t nCategories, const fmi2String categories[])
 {
     TRACEFUNC
 
-    return fmu->fmi2.setDebugLogging(fmu->fmi2.component, loggingOn, nCategories, categories);
+    return fmu->fmi2.setDebugLogging(comp, loggingOn, nCategories, categories);
 }
 
-bool fmi2_instantiate(fmiHandle *fmu, fmi2Type type, fmi2CallbackLogger logger, fmi2CallbackAllocateMemory allocateMemory, fmi2CallbackFreeMemory freeMemory, fmi2StepFinished stepFinished, fmi2ComponentEnvironment componentEnvironment, fmi2Boolean visible, fmi2Boolean loggingOn)
+fmi2Component fmi2_instantiate(fmiHandle *fmu, fmi2Type type, fmi2CallbackLogger logger, fmi2CallbackAllocateMemory allocateMemory, fmi2CallbackFreeMemory freeMemory, fmi2StepFinished stepFinished, fmi2ComponentEnvironment componentEnvironment, fmi2Boolean visible, fmi2Boolean loggingOn)
 {
     TRACEFUNC
     if(type == fmi2CoSimulation && !fmu->fmi2.supportsCoSimulation) {
@@ -2740,50 +2740,50 @@ bool fmi2_instantiate(fmiHandle *fmu, fmi2Type type, fmi2CallbackLogger logger, 
     // printf("  unzipped location:  %s\n", fmu->unzippedLocation);
     // printf("  resources location: %s\n", fmu->resourcesLocation);
 
-    fmu->fmi2.component = fmu->fmi2.instantiate(fmu->instanceName, type, fmu->fmi2.guid, fmu->resourcesLocation, &fmu->fmi2.callbacks, visible, loggingOn);
-    return (fmu->fmi2.component != NULL);
+    fmi2Component comp = fmu->fmi2.instantiate(fmu->instanceName, type, fmu->fmi2.guid, fmu->resourcesLocation, &fmu->fmi2.callbacks, visible, loggingOn);
+    return comp;
 }
 
-void fmi2_freeInstance(fmiHandle *fmu)
+void fmi2_freeInstance(fmiHandle *fmu, fmi2Component comp)
 {
     TRACEFUNC
 
-    fmu->fmi2.freeInstance(fmu->fmi2.component);
+    fmu->fmi2.freeInstance(comp);
 }
 
-fmi2Status fmi2_setupExperiment(fmiHandle *fmu, fmi2Boolean toleranceDefined, fmi2Real tolerance, fmi2Real startTime, fmi2Boolean stopTimeDefined, fmi2Real stopTime)
+fmi2Status fmi2_setupExperiment(fmiHandle *fmu, fmi2Component comp, fmi2Boolean toleranceDefined, fmi2Real tolerance, fmi2Real startTime, fmi2Boolean stopTimeDefined, fmi2Real stopTime)
 {
     TRACEFUNC
 
-    return fmu->fmi2.setupExperiment(fmu->fmi2.component, toleranceDefined, tolerance, startTime, stopTimeDefined, stopTime);
+    return fmu->fmi2.setupExperiment(comp, toleranceDefined, tolerance, startTime, stopTimeDefined, stopTime);
 }
 
-fmi2Status fmi2_enterInitializationMode(fmiHandle *fmu)
+fmi2Status fmi2_enterInitializationMode(fmiHandle *fmu, fmi2Component comp)
 {
     TRACEFUNC
 
-    return fmu->fmi2.enterInitializationMode(fmu->fmi2.component);
+    return fmu->fmi2.enterInitializationMode(comp);
 }
 
-fmi2Status fmi2_exitInitializationMode(fmiHandle *fmu)
+fmi2Status fmi2_exitInitializationMode(fmiHandle *fmu, fmi2Component comp)
 {
     TRACEFUNC
 
-    return fmu->fmi2.exitInitializationMode(fmu->fmi2.component);
+    return fmu->fmi2.exitInitializationMode(comp);
 }
 
-fmi2Status fmi2_terminate(fmiHandle *fmu)
+fmi2Status fmi2_terminate(fmiHandle *fmu, fmi2Component comp)
 {
     TRACEFUNC
 
-    return fmu->fmi2.terminate(fmu->fmi2.component);
+    return fmu->fmi2.terminate(comp);
 }
 
-fmi2Status fmi2_reset(fmiHandle *fmu)
+fmi2Status fmi2_reset(fmiHandle *fmu, fmi2Component comp)
 {
     TRACEFUNC
 
-    return fmu->fmi2.reset(fmu->fmi2.component);
+    return fmu->fmi2.reset(comp);
 }
 
 int fmi2_getNumberOfUnits(fmiHandle *fmu)
@@ -3747,257 +3747,268 @@ fmi2DataType fmi2_getVariableDataType(fmi2VariableHandle *var)
 }
 
 fmi2Status fmi2_getReal(fmiHandle *fmu,
-                       const fmi2ValueReference valueReferences[],
-                       size_t nValueReferences,
-                       fmi2Real values[])
+                        fmi2Component comp,
+                        const fmi2ValueReference valueReferences[],
+                        size_t nValueReferences,
+                        fmi2Real values[])
 {
-    return fmu->fmi2.getReal(fmu->fmi2.component,
-                            valueReferences,
-                            nValueReferences,
-                            values);
+    return fmu->fmi2.getReal(comp,
+                             valueReferences,
+                             nValueReferences,
+                             values);
 }
 
 fmi2Status fmi2_getInteger(fmiHandle *fmu,
-                          const fmi2ValueReference valueReferences[],
-                          size_t nValueReferences,
-                          fmi2Integer values[])
+                           fmi2Component comp,
+                           const fmi2ValueReference valueReferences[],
+                           size_t nValueReferences,
+                           fmi2Integer values[])
 {
     TRACEFUNC
 
-    return fmu->fmi2.getInteger(fmu->fmi2.component,
-                                  valueReferences,
-                                  nValueReferences,
-                                  values);
+            return fmu->fmi2.getInteger(comp,
+                                        valueReferences,
+                                        nValueReferences,
+                                        values);
 }
 
 fmi2Status fmi2_getBoolean(fmiHandle *fmu,
-                          const fmi2ValueReference valueReferences[],
-                          size_t nValueReferences,
-                          fmi2Boolean values[])
+                           fmi2Component comp,
+                           const fmi2ValueReference valueReferences[],
+                           size_t nValueReferences,
+                           fmi2Boolean values[])
 {
     TRACEFUNC
 
-    return fmu->fmi2.getBoolean(fmu->fmi2.component,
-                                  valueReferences,
-                                  nValueReferences,
-                                  values);
+            return fmu->fmi2.getBoolean(comp,
+                                        valueReferences,
+                                        nValueReferences,
+                                        values);
 }
 
 fmi2Status fmi2_getString(fmiHandle *fmu,
-                         const fmi2ValueReference valueReferences[],
-                         size_t nValueReferences,
-                         fmi2String values[])
+                          fmi2Component comp,
+                          const fmi2ValueReference valueReferences[],
+                          size_t nValueReferences,
+                          fmi2String values[])
 {
     TRACEFUNC
 
-    return fmu->fmi2.getString(fmu->fmi2.component,
-                                 valueReferences,
-                                 nValueReferences,
-                                 values);
+            return fmu->fmi2.getString(comp,
+                                       valueReferences,
+                                       nValueReferences,
+                                       values);
 }
 
 fmi2Status fmi2_setReal(fmiHandle *fmu,
-                       const fmi2ValueReference valueReferences[],
-                       size_t nValueReferences,
-                       const fmi2Real values[])
+                        fmi2Component comp,
+                        const fmi2ValueReference valueReferences[],
+                        size_t nValueReferences,
+                        const fmi2Real values[])
 {
-    return fmu->fmi2.setReal(fmu->fmi2.component,
+    return fmu->fmi2.setReal(comp,
                                valueReferences,
                                nValueReferences,
-                               values);
+                             values);
 }
 
 fmi2Status fmi2_setInteger(fmiHandle *fmu,
-                          const fmi2ValueReference valueReferences[],
-                          size_t nValueReferences,
-                          const fmi2Integer values[])
+                           fmi2Component comp,
+                           const fmi2ValueReference valueReferences[],
+                           size_t nValueReferences,
+                           const fmi2Integer values[])
 {
     TRACEFUNC
 
-    return fmu->fmi2.setInteger(fmu->fmi2.component,
+    return fmu->fmi2.setInteger(comp,
                                valueReferences,
                                nValueReferences,
                                values);
 }
 
 fmi2Status fmi2_setBoolean(fmiHandle *fmu,
-                          const fmi2ValueReference valueReferences[],
-                          size_t nValueReferences,
-                          const fmi2Boolean values[])
+                           fmi2Component comp,
+                           const fmi2ValueReference valueReferences[],
+                           size_t nValueReferences,
+                           const fmi2Boolean values[])
 {
     TRACEFUNC
 
-    return fmu->fmi2.setBoolean(fmu->fmi2.component,
+    return fmu->fmi2.setBoolean(comp,
                                valueReferences,
                                nValueReferences,
                                values);
 }
 
 fmi2Status fmi2_setString(fmiHandle *fmu,
-                         const fmi2ValueReference valueReferences[],
-                         size_t nValueReferences,
-                         const fmi2String values[])
+                          fmi2Component comp,
+                          const fmi2ValueReference valueReferences[],
+                          size_t nValueReferences,
+                          const fmi2String values[])
 {
     TRACEFUNC
 
-    return fmu->fmi2.setString(fmu->fmi2.component,
+    return fmu->fmi2.setString(comp,
                                valueReferences,
                                nValueReferences,
                                values);
 }
 
-fmi2Status fmi2_getFMUstate(fmiHandle* fmu, fmi2FMUstate* FMUstate)
+fmi2Status fmi2_getFMUstate(fmiHandle* fmu, fmi2Component comp, fmi2FMUstate* FMUstate)
 {
     TRACEFUNC
-    return fmu->fmi2.getFMUstate(fmu->fmi2.component, FMUstate);
+    return fmu->fmi2.getFMUstate(comp, FMUstate);
 }
 
-fmi2Status fmi2_setFMUstate(fmiHandle* fmu, fmi2FMUstate FMUstate)
+fmi2Status fmi2_setFMUstate(fmiHandle* fmu, fmi2Component comp, fmi2FMUstate FMUstate)
 {
     TRACEFUNC
-    return fmu->fmi2.setFMUstate(fmu->fmi2.component, FMUstate);
+    return fmu->fmi2.setFMUstate(comp, FMUstate);
 }
 
-fmi2Status fmi2_freeFMUstate(fmiHandle* fmu, fmi2FMUstate* FMUstate)
+fmi2Status fmi2_freeFMUstate(fmiHandle* fmu, fmi2Component comp, fmi2FMUstate* FMUstate)
 {
     TRACEFUNC
-    return fmu->fmi2.freeFMUstate(fmu->fmi2.component, FMUstate);
+    return fmu->fmi2.freeFMUstate(comp, FMUstate);
 }
 
-fmi2Status fmi2_serializedFMUstateSize(fmiHandle* fmu, fmi2FMUstate FMUstate, size_t* size)
+fmi2Status fmi2_serializedFMUstateSize(fmiHandle* fmu, fmi2Component comp, fmi2FMUstate FMUstate, size_t* size)
 {
     TRACEFUNC
-    return fmu->fmi2.serializedFMUstateSize(fmu->fmi2.component, FMUstate, size);
+    return fmu->fmi2.serializedFMUstateSize(comp, FMUstate, size);
 }
 
-fmi2Status fmi2_serializeFMUstate(fmiHandle* fmu, fmi2FMUstate FMUstate, fmi2Byte serializedState[], size_t size)
+fmi2Status fmi2_serializeFMUstate(fmiHandle* fmu, fmi2Component comp, fmi2FMUstate FMUstate, fmi2Byte serializedState[], size_t size)
 {
     TRACEFUNC
-    return fmu->fmi2.serializeFMUstate(fmu->fmi2.component, FMUstate, serializedState, size);
+    return fmu->fmi2.serializeFMUstate(comp, FMUstate, serializedState, size);
 }
 
-fmi2Status fmi2_deSerializeFMUstate(fmiHandle* fmu, const fmi2Byte serializedState[], size_t size, fmi2FMUstate* FMUstate)
+fmi2Status fmi2_deSerializeFMUstate(fmiHandle* fmu, fmi2Component comp, const fmi2Byte serializedState[], size_t size, fmi2FMUstate* FMUstate)
 {
     TRACEFUNC
-    return fmu->fmi2.deSerializeFMUstate(fmu->fmi2.component, serializedState, size, FMUstate);
+    return fmu->fmi2.deSerializeFMUstate(comp, serializedState, size, FMUstate);
 }
 
 fmi2Status fmi2_getDirectionalDerivative(fmiHandle* fmu,
-                                        const fmi2ValueReference unknownReferences[],
-                                        size_t nUnknown,
-                                        const fmi2ValueReference knownReferences[],
-                                        size_t nKnown,
-                                        const fmi2Real dvKnown[],
-                                        fmi2Real dvUnknown[])
+                                         fmi2Component comp,
+                                         const fmi2ValueReference unknownReferences[],
+                                         size_t nUnknown,
+                                         const fmi2ValueReference knownReferences[],
+                                         size_t nKnown,
+                                         const fmi2Real dvKnown[],
+                                         fmi2Real dvUnknown[])
 {
     TRACEFUNC
-    return fmu->fmi2.getDirectionalDerivative(fmu->fmi2.component,
-                                             unknownReferences,
-                                             nUnknown,
-                                             knownReferences,
-                                             nKnown,
-                                             dvKnown,
-                                             dvUnknown);
+        return fmu->fmi2.getDirectionalDerivative(comp,
+                                                  unknownReferences,
+                                                  nUnknown,
+                                                  knownReferences,
+                                                  nKnown,
+                                                  dvKnown,
+                                                  dvUnknown);
 }
 
-fmi2Status fmi2_enterEventMode(fmiHandle* fmu)
+fmi2Status fmi2_enterEventMode(fmiHandle* fmu, fmi2Component comp)
 {
     TRACEFUNC
-    return fmu->fmi2.enterEventMode(fmu->fmi2.component);
+    return fmu->fmi2.enterEventMode(comp);
 }
 
-fmi2Status fmi2_newDiscreteStates(fmiHandle* fmu, fmi2EventInfo* eventInfo)
+fmi2Status fmi2_newDiscreteStates(fmiHandle* fmu, fmi2Component comp, fmi2EventInfo* eventInfo)
 {
     TRACEFUNC
-            return fmu->fmi2.newDiscreteStates(fmu->fmi2.component, eventInfo);
+            return fmu->fmi2.newDiscreteStates(comp, eventInfo);
 }
 
-fmi2Status fmi2_enterContinuousTimeMode(fmiHandle* fmu)
+fmi2Status fmi2_enterContinuousTimeMode(fmiHandle* fmu, fmi2Component comp)
 {
     TRACEFUNC
-    return fmu->fmi2.enterContinuousTimeMode(fmu->fmi2.component);
+    return fmu->fmi2.enterContinuousTimeMode(comp);
 }
 
 fmi2Status fmi2_completedIntegratorStep(fmiHandle* fmu,
-                                       fmi2Boolean noSetFMUStatePriorToCurrentPoint,
-                                       fmi2Boolean* enterEventMode,
-                                       fmi2Boolean* terminateSimulation)
+                                        fmi2Component comp,
+                                        fmi2Boolean noSetFMUStatePriorToCurrentPoint,
+                                        fmi2Boolean* enterEventMode,
+                                        fmi2Boolean* terminateSimulation)
 {
     TRACEFUNC
-    return fmu->fmi2.completedIntegratorStep(fmu->fmi2.component,
-                                            noSetFMUStatePriorToCurrentPoint,
-                                            enterEventMode,
-                                            terminateSimulation);
+    return fmu->fmi2.completedIntegratorStep(comp,
+                                             noSetFMUStatePriorToCurrentPoint,
+                                             enterEventMode,
+                                             terminateSimulation);
 }
 
-fmi2Status fmi2_setTime(fmiHandle* fmu, fmi2Real time)
+fmi2Status fmi2_setTime(fmiHandle* fmu, fmi2Component comp, fmi2Real time)
 {
     TRACEFUNC
-    return fmu->fmi2.setTime(fmu->fmi2.component, time);
+    return fmu->fmi2.setTime(comp, time);
 }
 
 fmi2Status fmi2_setContinuousStates(fmiHandle* fmu,
-                                   const fmi2Real x[],
-                                   size_t nx)
+                                    fmi2Component comp,
+                                    const fmi2Real x[],
+                                    size_t nx)
 {
     TRACEFUNC
-    return fmu->fmi2.setContinuousStates(fmu->fmi2.component, x, nx);
+    return fmu->fmi2.setContinuousStates(comp, x, nx);
 }
 
-fmi2Status fmi2_getDerivatives(fmiHandle* fmu, fmi2Real derivatives[], size_t nx)
+fmi2Status fmi2_getDerivatives(fmiHandle* fmu, fmi2Component comp, fmi2Real derivatives[], size_t nx)
 {
     TRACEFUNC
-    return fmu->fmi2.getDerivatives(fmu->fmi2.component, derivatives, nx);
+    return fmu->fmi2.getDerivatives(comp, derivatives, nx);
 }
 
-fmi2Status fmi2_getEventIndicators(fmiHandle* fmu, fmi2Real eventIndicators[], size_t ni)
+fmi2Status fmi2_getEventIndicators(fmiHandle* fmu, fmi2Component comp, fmi2Real eventIndicators[], size_t ni)
 {
     TRACEFUNC
-    return fmu->fmi2.getEventIndicators(fmu->fmi2.component, eventIndicators, ni);
+    return fmu->fmi2.getEventIndicators(comp, eventIndicators, ni);
 }
 
-fmi2Status fmi2_getContinuousStates(fmiHandle* fmu, fmi2Real x[], size_t nx)
+fmi2Status fmi2_getContinuousStates(fmiHandle* fmu, fmi2Component comp, fmi2Real x[], size_t nx)
 {
     TRACEFUNC
-    return fmu->fmi2.getContinuousStates(fmu->fmi2.component, x, nx);
+    return fmu->fmi2.getContinuousStates(comp, x, nx);
 }
 
-fmi2Status fmi2_getNominalsOfContinuousStates(fmiHandle* fmu, fmi2Real x_nominal[], size_t nx)
+fmi2Status fmi2_getNominalsOfContinuousStates(fmiHandle* fmu, fmi2Component comp, fmi2Real x_nominal[], size_t nx)
 {
     TRACEFUNC
-    return fmu->fmi2.getNominalsOfContinuousStates(fmu->fmi2.component, x_nominal, nx);
+    return fmu->fmi2.getNominalsOfContinuousStates(comp, x_nominal, nx);
 }
 
-fmi2Status fmi2_setRealInputDerivatives(fmiHandle* fmu, const fmi2ValueReference [], size_t, const fmi2Integer [], const fmi2Real []);
-fmi2Status fmi2_getRealOutputDerivatives(fmiHandle* fmu, const fmi2ValueReference [], size_t, const fmi2Integer [], fmi2Real []);
 
 fmi2Status fmi2_setRealInputDerivatives(fmiHandle* fmu,
-                                       const fmi2ValueReference vr[],
-                                       size_t nvr,
-                                       const fmi2Integer order[],
-                                       const fmi2Real value[])
+                                        fmi2Component comp,
+                                        const fmi2ValueReference vr[],
+                                        size_t nvr,
+                                        const fmi2Integer order[],
+                                        const fmi2Real value[])
 {
     TRACEFUNC
-    return fmu->fmi2.setRealInputDerivatives(fmu->fmi2.component, vr, nvr, order, value);
+    return fmu->fmi2.setRealInputDerivatives(comp, vr, nvr, order, value);
 }
 
 fmi2Status fmi2_getRealOutputDerivatives (fmiHandle* fmu,
-                                         const fmi2ValueReference vr[],
-                                         size_t nvr,
-                                         const fmi2Integer order[],
-                                         fmi2Real value[])
+                                          fmi2Component comp,
+                                          const fmi2ValueReference vr[],
+                                          size_t nvr,
+                                          const fmi2Integer order[],
+                                          fmi2Real value[])
 {
     TRACEFUNC
-    return fmu->fmi2.getRealOutputDerivatives(fmu->fmi2.component, vr, nvr, order, value);
+    return fmu->fmi2.getRealOutputDerivatives(comp, vr, nvr, order, value);
 }
 
-fmi2Status fmi2_doStep(fmiHandle *fmu, fmi2Real currentCommunicationPoint, fmi2Real communicationStepSize, fmi2Boolean noSetFMUStatePriorToCurrentPoint)
+fmi2Status fmi2_doStep(fmiHandle *fmu, fmi2Component comp, fmi2Real currentCommunicationPoint, fmi2Real communicationStepSize, fmi2Boolean noSetFMUStatePriorToCurrentPoint)
 {
     TRACEFUNC
-    return fmu->fmi2.doStep(fmu->fmi2.component,
-                              currentCommunicationPoint,
-                              communicationStepSize,
-                              noSetFMUStatePriorToCurrentPoint);
+    return fmu->fmi2.doStep(comp,
+                            currentCommunicationPoint,
+                            communicationStepSize,
+                            noSetFMUStatePriorToCurrentPoint);
 }
 
 fmi2Status fmi2_cancelStep(fmiHandle* fmu)

--- a/src/fmi4c.c
+++ b/src/fmi4c.c
@@ -2523,7 +2523,7 @@ fmi3Status fmi3_setDebugLogging(fmi3InstanceHandle *instance,
                                 const fmi3String categories[])
 {
 
-    return instance->fmu->fmi3.setDebugLogging(instance, loggingOn, nCategories, categories);
+    return instance->fmu->fmi3.setDebugLogging(instance->component, loggingOn, nCategories, categories);
 }
 
 fmi3Status fmi3_getFloat64(fmi3InstanceHandle *instance,
@@ -2532,7 +2532,7 @@ fmi3Status fmi3_getFloat64(fmi3InstanceHandle *instance,
                            fmi3Float64 values[],
                            size_t nValues) {
 
-    return instance->fmu->fmi3.getFloat64(instance,
+    return instance->fmu->fmi3.getFloat64(instance->component,
                                 valueReferences,
                                 nValueReferences,
                                 values,
@@ -2546,7 +2546,7 @@ fmi3Status fmi3_setFloat64(fmi3InstanceHandle *instance,
                            const fmi3Float64 values[],
                            size_t nValues) {
 
-    return instance->fmu->fmi3.setFloat64(instance,
+    return instance->fmu->fmi3.setFloat64(instance->component,
                                 valueReferences,
                                 nValueReferences,
                                 values,
@@ -2560,7 +2560,7 @@ fmi3Status fmi3_enterInitializationMode(fmi3InstanceHandle *instance,
                                        fmi3Boolean stopTimeDefined,
                                        fmi3Float64 stopTime)
 {
-    return instance->fmu->fmi3.enterInitializationMode(instance,
+    return instance->fmu->fmi3.enterInitializationMode(instance->component,
                                             toleranceDefined,
                                             tolerance,
                                             startTime,
@@ -2572,14 +2572,14 @@ fmi3Status fmi3_exitInitializationMode(fmi3InstanceHandle *instance)
 {
     TRACEFUNC
 
-    return instance->fmu->fmi3.exitInitializationMode(instance);
+    return instance->fmu->fmi3.exitInitializationMode(instance->component);
 }
 
 fmi3Status fmi3_terminate(fmi3InstanceHandle *instance)
 {
     TRACEFUNC
 
-    return instance->fmu->fmi3.terminate(instance);
+    return instance->fmu->fmi3.terminate(instance->component);
 }
 
 void fmi3_freeInstance(fmi3InstanceHandle *instance)
@@ -2600,7 +2600,7 @@ fmi3Status fmi3_doStep(fmi3InstanceHandle *instance,
                        fmi3Float64 *lastSuccessfulTime)
 {
 
-    return instance->fmu->fmi3.doStep(instance,
+    return instance->fmu->fmi3.doStep(instance->component,
                             currentCommunicationPoint,
                             communicationStepSize,
                             noSetFMUStatePriorToCurrentPoint,
@@ -3036,368 +3036,368 @@ fmi3ValueReference fmi3_getVariableValueReference(fmi3VariableHandle *var)
 
 fmi3Status fmi3_enterEventMode(fmi3InstanceHandle *instance)
 {
-    return instance->fmu->fmi3.enterEventMode(instance);
+    return instance->fmu->fmi3.enterEventMode(instance->component);
 }
 
 fmi3Status fmi3_reset(fmi3InstanceHandle *instance)
 {
     TRACEFUNC
 
-    return instance->fmu->fmi3.reset(instance);
+    return instance->fmu->fmi3.reset(instance->component);
 }
 
 fmi3Status fmi3_getFloat32(fmi3InstanceHandle *instance, const fmi3ValueReference valueReferences[], size_t nValueReferences, fmi3Float32 values[], size_t nValues)
 {
 
-    return instance->fmu->fmi3.getFloat32(instance, valueReferences, nValueReferences, values, nValues);
+    return instance->fmu->fmi3.getFloat32(instance->component, valueReferences, nValueReferences, values, nValues);
 }
 
 fmi3Status fmi3_getInt8(fmi3InstanceHandle *instance, const fmi3ValueReference valueReferences[], size_t nValueReferences, fmi3Int8 values[], size_t nValues)
 {
 
-    return instance->fmu->fmi3.getInt8(instance, valueReferences, nValueReferences, values, nValues);
+    return instance->fmu->fmi3.getInt8(instance->component, valueReferences, nValueReferences, values, nValues);
 }
 
 fmi3Status fmi3_getUInt8(fmi3InstanceHandle *instance, const fmi3ValueReference valueReferences[], size_t nValueReferences, fmi3UInt8 values[], size_t nValues)
 {
 
-    return instance->fmu->fmi3.getUInt8(instance, valueReferences, nValueReferences, values, nValues);
+    return instance->fmu->fmi3.getUInt8(instance->component, valueReferences, nValueReferences, values, nValues);
 }
 
 fmi3Status fmi3_getInt16(fmi3InstanceHandle *instance, const fmi3ValueReference valueReferences[], size_t nValueReferences, fmi3Int16 values[], size_t nValues)
 {
 
-    return instance->fmu->fmi3.getInt16(instance, valueReferences, nValueReferences, values, nValues);
+    return instance->fmu->fmi3.getInt16(instance->component, valueReferences, nValueReferences, values, nValues);
 }
 
 fmi3Status fmi3_getUInt16(fmi3InstanceHandle *instance, const fmi3ValueReference valueReferences[], size_t nValueReferences, fmi3UInt16 values[], size_t nValues)
 {
 
-    return instance->fmu->fmi3.getUInt16(instance, valueReferences, nValueReferences, values, nValues);
+    return instance->fmu->fmi3.getUInt16(instance->component, valueReferences, nValueReferences, values, nValues);
 }
 
 fmi3Status fmi3_getInt32(fmi3InstanceHandle *instance, const fmi3ValueReference valueReferences[], size_t nValueReferences, fmi3Int32 values[], size_t nValues)
 {
 
-    return instance->fmu->fmi3.getInt32(instance, valueReferences, nValueReferences, values, nValues);
+    return instance->fmu->fmi3.getInt32(instance->component, valueReferences, nValueReferences, values, nValues);
 }
 
 fmi3Status fmi3_getUInt32(fmi3InstanceHandle *instance, const fmi3ValueReference valueReferences[], size_t nValueReferences, fmi3UInt32 values[], size_t nValues)
 {
 
-    return instance->fmu->fmi3.getUInt32(instance, valueReferences, nValueReferences, values, nValues);
+    return instance->fmu->fmi3.getUInt32(instance->component, valueReferences, nValueReferences, values, nValues);
 }
 
 fmi3Status fmi3_getInt64(fmi3InstanceHandle *instance, const fmi3ValueReference valueReferences[], size_t nValueReferences, fmi3Int64 values[], size_t nValues)
 {
 
-    return instance->fmu->fmi3.getInt64(instance, valueReferences, nValueReferences, values, nValues);
+    return instance->fmu->fmi3.getInt64(instance->component, valueReferences, nValueReferences, values, nValues);
 }
 
 fmi3Status fmi3_getUInt64(fmi3InstanceHandle *instance, const fmi3ValueReference valueReferences[], size_t nValueReferences, fmi3UInt64 values[], size_t nValues)
 {
 
-    return instance->fmu->fmi3.getUInt64(instance, valueReferences, nValueReferences, values, nValues);
+    return instance->fmu->fmi3.getUInt64(instance->component, valueReferences, nValueReferences, values, nValues);
 }
 
 fmi3Status fmi3_getBoolean(fmi3InstanceHandle *instance, const fmi3ValueReference valueReferences[], size_t nValueReferences, fmi3Boolean values[], size_t nValues)
 {
 
-    return instance->fmu->fmi3.getBoolean(instance, valueReferences, nValueReferences, values, nValues);
+    return instance->fmu->fmi3.getBoolean(instance->component, valueReferences, nValueReferences, values, nValues);
 }
 
 fmi3Status fmi3_getString(fmi3InstanceHandle *instance, const fmi3ValueReference valueReferences[], size_t nValueReferences, fmi3String values[], size_t nValues)
 {
 
-    return instance->fmu->fmi3.getString(instance, valueReferences, nValueReferences, values, nValues);
+    return instance->fmu->fmi3.getString(instance->component, valueReferences, nValueReferences, values, nValues);
 }
 
 fmi3Status fmi3_getBinary(fmi3InstanceHandle *instance, const fmi3ValueReference valueReferences[], size_t nValueReferences, size_t valueSizes[], fmi3Binary values[], size_t nValues)
 {
 
-    return instance->fmu->fmi3.getBinary(instance, valueReferences, nValueReferences, valueSizes, values, nValues);
+    return instance->fmu->fmi3.getBinary(instance->component, valueReferences, nValueReferences, valueSizes, values, nValues);
 }
 
 fmi3Status fmi3_getClock(fmi3InstanceHandle *instance, const fmi3ValueReference valueReferences[], size_t nValueReferences, fmi3Clock values[])
 {
 
-    return instance->fmu->fmi3.getClock(instance, valueReferences, nValueReferences, values);
+    return instance->fmu->fmi3.getClock(instance->component, valueReferences, nValueReferences, values);
 }
 
 fmi3Status fmi3_setFloat32(fmi3InstanceHandle *instance, const fmi3ValueReference valueReferences[], size_t nValueReferences, const fmi3Float32 values[], size_t nValues)
 {
 
-    return instance->fmu->fmi3.setFloat32(instance, valueReferences, nValueReferences, values, nValues);
+    return instance->fmu->fmi3.setFloat32(instance->component, valueReferences, nValueReferences, values, nValues);
 }
 
 fmi3Status fmi3_setInt8(fmi3InstanceHandle *instance, const fmi3ValueReference valueReferences[], size_t nValueReferences, const fmi3Int8 values[], size_t nValues)
 {
 
-    return instance->fmu->fmi3.setInt8(instance, valueReferences, nValueReferences, values, nValues);
+    return instance->fmu->fmi3.setInt8(instance->component, valueReferences, nValueReferences, values, nValues);
 }
 
 fmi3Status fmi3_setUInt8(fmi3InstanceHandle *instance, const fmi3ValueReference valueReferences[], size_t nValueReferences, const fmi3UInt8 values[], size_t nValues)
 {
 
-    return instance->fmu->fmi3.setUInt8(instance, valueReferences, nValueReferences, values, nValues);
+    return instance->fmu->fmi3.setUInt8(instance->component, valueReferences, nValueReferences, values, nValues);
 }
 
 fmi3Status fmi3_setInt16(fmi3InstanceHandle *instance, const fmi3ValueReference valueReferences[], size_t nValueReferences, const fmi3Int16 values[], size_t nValues)
 {
 
-    return instance->fmu->fmi3.setInt16(instance, valueReferences, nValueReferences, values, nValues);
+    return instance->fmu->fmi3.setInt16(instance->component, valueReferences, nValueReferences, values, nValues);
 }
 
 fmi3Status fmi3_setUInt16(fmi3InstanceHandle *instance, const fmi3ValueReference valueReferences[], size_t nValueReferences, const fmi3UInt16 values[], size_t nValues)
 {
 
-    return instance->fmu->fmi3.setUInt16(instance, valueReferences, nValueReferences, values, nValues);
+    return instance->fmu->fmi3.setUInt16(instance->component, valueReferences, nValueReferences, values, nValues);
 }
 
 fmi3Status fmi3_setInt32(fmi3InstanceHandle *instance, const fmi3ValueReference valueReferences[], size_t nValueReferences, const fmi3Int32 values[], size_t nValues)
 {
 
-    return instance->fmu->fmi3.setInt32(instance, valueReferences, nValueReferences, values, nValues);
+    return instance->fmu->fmi3.setInt32(instance->component, valueReferences, nValueReferences, values, nValues);
 }
 
 fmi3Status fmi3_setUInt32(fmi3InstanceHandle *instance, const fmi3ValueReference valueReferences[], size_t nValueReferences, const fmi3UInt32 values[], size_t nValues)
 {
 
-    return instance->fmu->fmi3.setUInt32(instance, valueReferences, nValueReferences, values, nValues);
+    return instance->fmu->fmi3.setUInt32(instance->component, valueReferences, nValueReferences, values, nValues);
 }
 
 fmi3Status fmi3_setInt64(fmi3InstanceHandle *instance, const fmi3ValueReference valueReferences[], size_t nValueReferences, const fmi3Int64 values[], size_t nValues)
 {
 
-    return instance->fmu->fmi3.setInt64(instance, valueReferences, nValueReferences, values, nValues);
+    return instance->fmu->fmi3.setInt64(instance->component, valueReferences, nValueReferences, values, nValues);
 }
 
 fmi3Status fmi3_setUInt64(fmi3InstanceHandle *instance, const fmi3ValueReference valueReferences[], size_t nValueReferences, const fmi3UInt64 values[], size_t nValues)
 {
 
-    return instance->fmu->fmi3.setUInt64(instance, valueReferences, nValueReferences, values, nValues);
+    return instance->fmu->fmi3.setUInt64(instance->component, valueReferences, nValueReferences, values, nValues);
 }
 
 fmi3Status fmi3_setBoolean(fmi3InstanceHandle *instance, const fmi3ValueReference valueReferences[], size_t nValueReferences, const fmi3Boolean values[], size_t nValues)
 {
 
-    return instance->fmu->fmi3.setBoolean(instance, valueReferences, nValueReferences, values, nValues);
+    return instance->fmu->fmi3.setBoolean(instance->component, valueReferences, nValueReferences, values, nValues);
 }
 
 fmi3Status fmi3_setString(fmi3InstanceHandle *instance, const fmi3ValueReference valueReferences[], size_t nValueReferences, const fmi3String values[], size_t nValues)
 {
 
-    return instance->fmu->fmi3.setString(instance, valueReferences, nValueReferences, values, nValues);
+    return instance->fmu->fmi3.setString(instance->component, valueReferences, nValueReferences, values, nValues);
 }
 
 fmi3Status fmi3_setBinary(fmi3InstanceHandle *instance, const fmi3ValueReference valueReferences[], size_t nValueReferences, const size_t valueSizes[], const fmi3Binary values[], size_t nValues)
 {
 
-    return instance->fmu->fmi3.setBinary(instance, valueReferences, nValueReferences, valueSizes, values, nValues);
+    return instance->fmu->fmi3.setBinary(instance->component, valueReferences, nValueReferences, valueSizes, values, nValues);
 }
 
 fmi3Status fmi3_setClock(fmi3InstanceHandle *instance, const fmi3ValueReference valueReferences[], size_t nValueReferences, const fmi3Clock values[])
 {
 
-    return instance->fmu->fmi3.setClock(instance, valueReferences, nValueReferences, values);
+    return instance->fmu->fmi3.setClock(instance->component, valueReferences, nValueReferences, values);
 }
 
 fmi3Status fmi3_getNumberOfVariableDependencies(fmi3InstanceHandle *instance, fmi3ValueReference valueReference, size_t *nDependencies)
 {
 
-    return instance->fmu->fmi3.getNumberOfVariableDependencies(instance, valueReference, nDependencies);
+    return instance->fmu->fmi3.getNumberOfVariableDependencies(instance->component, valueReference, nDependencies);
 }
 
 fmi3Status fmi3_getVariableDependencies(fmi3InstanceHandle *instance, fmi3ValueReference dependent, size_t elementIndicesOfDependent[], fmi3ValueReference independents[], size_t elementIndicesOfIndependents[], fmi3DependencyKind dependencyKinds[], size_t nDependencies)
 {
 
-    return instance->fmu->fmi3.getVariableDependencies(instance, dependent, elementIndicesOfDependent, independents, elementIndicesOfIndependents, dependencyKinds, nDependencies);
+    return instance->fmu->fmi3.getVariableDependencies(instance->component, dependent, elementIndicesOfDependent, independents, elementIndicesOfIndependents, dependencyKinds, nDependencies);
 }
 
 fmi3Status fmi3_getFMUState(fmi3InstanceHandle *instance, fmi3FMUState *FMUState)
 {
 
-    return instance->fmu->fmi3.getFMUState(instance, FMUState);
+    return instance->fmu->fmi3.getFMUState(instance->component, FMUState);
 }
 
 fmi3Status fmi3_setFMUState(fmi3InstanceHandle *instance, fmi3FMUState FMUState)
 {
 
-    return instance->fmu->fmi3.setFMUState(instance, FMUState);
+    return instance->fmu->fmi3.setFMUState(instance->component, FMUState);
 }
 
 fmi3Status fmi3_freeFMUState(fmi3InstanceHandle *instance, fmi3FMUState *FMUState)
 {
 
-    return instance->fmu->fmi3.freeFMUState(instance, FMUState);
+    return instance->fmu->fmi3.freeFMUState(instance->component, FMUState);
 }
 
 fmi3Status fmi3_serializedFMUStateSize(fmi3InstanceHandle *instance, fmi3FMUState FMUState, size_t *size)
 {
 
-    return instance->fmu->fmi3.serializedFMUStateSize(instance, FMUState, size);
+    return instance->fmu->fmi3.serializedFMUStateSize(instance->component, FMUState, size);
 }
 
 fmi3Status fmi3_serializeFMUState(fmi3InstanceHandle *instance, fmi3FMUState FMUState, fmi3Byte serializedState[], size_t size)
 {
 
-    return instance->fmu->fmi3.serializeFMUState(instance, FMUState, serializedState, size);
+    return instance->fmu->fmi3.serializeFMUState(instance->component, FMUState, serializedState, size);
 }
 
 fmi3Status fmi3_deserializeFMUState(fmi3InstanceHandle *instance, const fmi3Byte serializedState[], size_t size, fmi3FMUState *FMUState)
 {
 
-    return instance->fmu->fmi3.deserializeFMUState(instance, serializedState, size, FMUState);
+    return instance->fmu->fmi3.deserializeFMUState(instance->component, serializedState, size, FMUState);
 }
 
 fmi3Status fmi3_getDirectionalDerivative(fmi3InstanceHandle *instance, const fmi3ValueReference unknowns[], size_t nUnknowns, const fmi3ValueReference knowns[], size_t nKnowns, const fmi3Float64 seed[], size_t nSeed, fmi3Float64 sensitivity[], size_t nSensitivity)
 {
 
-    return instance->fmu->fmi3.getDirectionalDerivative(instance, unknowns, nUnknowns, knowns, nKnowns, seed, nSeed, sensitivity, nSensitivity);
+    return instance->fmu->fmi3.getDirectionalDerivative(instance->component, unknowns, nUnknowns, knowns, nKnowns, seed, nSeed, sensitivity, nSensitivity);
 }
 
 fmi3Status fmi3_getAdjointDerivative(fmi3InstanceHandle *instance, const fmi3ValueReference unknowns[], size_t nUnknowns, const fmi3ValueReference knowns[], size_t nKnowns, const fmi3Float64 seed[], size_t nSeed, fmi3Float64 sensitivity[], size_t nSensitivity)
 {
 
-    return instance->fmu->fmi3.getAdjointDerivative(instance, unknowns, nUnknowns, knowns, nKnowns, seed, nSeed, sensitivity, nSensitivity);
+    return instance->fmu->fmi3.getAdjointDerivative(instance->component, unknowns, nUnknowns, knowns, nKnowns, seed, nSeed, sensitivity, nSensitivity);
 }
 
 fmi3Status fmi3_enterConfigurationMode(fmi3InstanceHandle *instance)
 {
 
-    return instance->fmu->fmi3.enterConfigurationMode(instance);
+    return instance->fmu->fmi3.enterConfigurationMode(instance->component);
 }
 
 fmi3Status fmi3_exitConfigurationMode(fmi3InstanceHandle *instance)
 {
 
-    return instance->fmu->fmi3.exitConfigurationMode(instance);
+    return instance->fmu->fmi3.exitConfigurationMode(instance->component);
 }
 
 fmi3Status fmi3_getIntervalDecimal(fmi3InstanceHandle *instance, const fmi3ValueReference valueReferences[], size_t nValueReferences, fmi3Float64 intervals[], fmi3IntervalQualifier qualifiers[])
 {
 
-    return instance->fmu->fmi3.getIntervalDecimal(instance, valueReferences, nValueReferences, intervals, qualifiers);
+    return instance->fmu->fmi3.getIntervalDecimal(instance->component, valueReferences, nValueReferences, intervals, qualifiers);
 }
 
 fmi3Status fmi3_getIntervalFraction(fmi3InstanceHandle *instance, const fmi3ValueReference valueReferences[], size_t nValueReferences, fmi3UInt64 intervalCounters[], fmi3UInt64 resolutions[], fmi3IntervalQualifier qualifiers[])
 {
 
-    return instance->fmu->fmi3.getIntervalFraction(instance, valueReferences, nValueReferences, intervalCounters, resolutions, qualifiers);
+    return instance->fmu->fmi3.getIntervalFraction(instance->component, valueReferences, nValueReferences, intervalCounters, resolutions, qualifiers);
 }
 
 fmi3Status fmi3_getShiftDecimal(fmi3InstanceHandle *instance, const fmi3ValueReference valueReferences[], size_t nValueReferences, fmi3Float64 shifts[])
 {
 
-    return instance->fmu->fmi3.getShiftDecimal(instance, valueReferences, nValueReferences, shifts);
+    return instance->fmu->fmi3.getShiftDecimal(instance->component, valueReferences, nValueReferences, shifts);
 }
 
 fmi3Status fmi3_getShiftFraction(fmi3InstanceHandle *instance, const fmi3ValueReference valueReferences[], size_t nValueReferences, fmi3UInt64 shiftCounters[], fmi3UInt64 resolutions[])
 {
 
-    return instance->fmu->fmi3.getShiftFraction(instance, valueReferences, nValueReferences, shiftCounters, resolutions);
+    return instance->fmu->fmi3.getShiftFraction(instance->component, valueReferences, nValueReferences, shiftCounters, resolutions);
 }
 
 fmi3Status fmi3_setIntervalDecimal(fmi3InstanceHandle *instance, const fmi3ValueReference valueReferences[], size_t nValueReferences, const fmi3Float64 intervals[])
 {
 
-    return instance->fmu->fmi3.setIntervalDecimal(instance, valueReferences, nValueReferences, intervals);
+    return instance->fmu->fmi3.setIntervalDecimal(instance->component, valueReferences, nValueReferences, intervals);
 }
 
 fmi3Status fmi3_setIntervalFraction(fmi3InstanceHandle *instance, const fmi3ValueReference valueReferences[], size_t nValueReferences, const fmi3UInt64 intervalCounters[], const fmi3UInt64 resolutions[])
 {
 
-    return instance->fmu->fmi3.setIntervalFraction(instance, valueReferences, nValueReferences, intervalCounters, resolutions);
+    return instance->fmu->fmi3.setIntervalFraction(instance->component, valueReferences, nValueReferences, intervalCounters, resolutions);
 }
 
 fmi3Status fmi3_evaluateDiscreteStates(fmi3InstanceHandle *instance)
 {
 
-    return instance->fmu->fmi3.evaluateDiscreteStates(instance);
+    return instance->fmu->fmi3.evaluateDiscreteStates(instance->component);
 }
 
 fmi3Status fmi3_updateDiscreteStates(fmi3InstanceHandle *instance, fmi3Boolean *discreteStatesNeedUpdate, fmi3Boolean *terminateSimulation, fmi3Boolean *nominalsOfContinuousStatesChanged, fmi3Boolean *valuesOfContinuousStatesChanged, fmi3Boolean *nextEventTimeDefined, fmi3Float64 *nextEventTime)
 {
 
-    return instance->fmu->fmi3.updateDiscreteStates(instance, discreteStatesNeedUpdate, terminateSimulation, nominalsOfContinuousStatesChanged, valuesOfContinuousStatesChanged, nextEventTimeDefined, nextEventTime);
+    return instance->fmu->fmi3.updateDiscreteStates(instance->component, discreteStatesNeedUpdate, terminateSimulation, nominalsOfContinuousStatesChanged, valuesOfContinuousStatesChanged, nextEventTimeDefined, nextEventTime);
 }
 
 fmi3Status fmi3_enterContinuousTimeMode(fmi3InstanceHandle *instance)
 {
 
-    return instance->fmu->fmi3.enterContinuousTimeMode(instance);
+    return instance->fmu->fmi3.enterContinuousTimeMode(instance->component);
 }
 
 fmi3Status fmi3_completedIntegratorStep(fmi3InstanceHandle *instance, fmi3Boolean noSetFMUStatePriorToCurrentPoint, fmi3Boolean *enterEventMode, fmi3Boolean *terminateSimulation)
 {
 
-    return instance->fmu->fmi3.completedIntegratorStep(instance, noSetFMUStatePriorToCurrentPoint, enterEventMode, terminateSimulation);
+    return instance->fmu->fmi3.completedIntegratorStep(instance->component, noSetFMUStatePriorToCurrentPoint, enterEventMode, terminateSimulation);
 }
 
 fmi3Status fmi3_setTime(fmi3InstanceHandle *instance, fmi3Float64 time)
 {
 
-    return instance->fmu->fmi3.setTime(instance, time);
+    return instance->fmu->fmi3.setTime(instance->component, time);
 }
 
 fmi3Status fmi3_setContinuousStates(fmi3InstanceHandle *instance, const fmi3Float64 continuousStates[], size_t nContinuousStates)
 {
 
-    return instance->fmu->fmi3.setContinuousStates(instance, continuousStates, nContinuousStates);
+    return instance->fmu->fmi3.setContinuousStates(instance->component, continuousStates, nContinuousStates);
 }
 
 fmi3Status fmi3_getContinuousStateDerivatives(fmi3InstanceHandle *instance, fmi3Float64 derivatives[], size_t nContinuousStates)
 {
 
-    return instance->fmu->fmi3.getContinuousStateDerivatives(instance, derivatives, nContinuousStates);
+    return instance->fmu->fmi3.getContinuousStateDerivatives(instance->component, derivatives, nContinuousStates);
 }
 
 fmi3Status fmi3_getEventIndicators(fmi3InstanceHandle *instance, fmi3Float64 eventIndicators[], size_t nEventIndicators)
 {
 
-    return instance->fmu->fmi3.getEventIndicators(instance, eventIndicators, nEventIndicators);
+    return instance->fmu->fmi3.getEventIndicators(instance->component, eventIndicators, nEventIndicators);
 }
 
 fmi3Status fmi3_getContinuousStates(fmi3InstanceHandle *instance, fmi3Float64 continuousStates[], size_t nContinuousStates)
 {
 
-    return instance->fmu->fmi3.getContinuousStates(instance, continuousStates, nContinuousStates);
+    return instance->fmu->fmi3.getContinuousStates(instance->component, continuousStates, nContinuousStates);
 }
 
 fmi3Status fmi3_getNominalsOfContinuousStates(fmi3InstanceHandle *instance, fmi3Float64 nominals[], size_t nContinuousStates)
 {
 
-    return instance->fmu->fmi3.getNominalsOfContinuousStates(instance, nominals, nContinuousStates);
+    return instance->fmu->fmi3.getNominalsOfContinuousStates(instance->component, nominals, nContinuousStates);
 }
 
 fmi3Status fmi3_getNumberOfEventIndicators(fmi3InstanceHandle *instance, size_t *nEventIndicators)
 {
 
-    return instance->fmu->fmi3.getNumberOfEventIndicators(instance, nEventIndicators);
+    return instance->fmu->fmi3.getNumberOfEventIndicators(instance->component, nEventIndicators);
 }
 
 fmi3Status fmi3_getNumberOfContinuousStates(fmi3InstanceHandle *instance, size_t *nContinuousStates)
 {
 
-    return instance->fmu->fmi3.getNumberOfContinuousStates(instance, nContinuousStates);
+    return instance->fmu->fmi3.getNumberOfContinuousStates(instance->component, nContinuousStates);
 }
 
 fmi3Status fmi3_enterStepMode(fmi3InstanceHandle *instance)
 {
 
-    return instance->fmu->fmi3.enterStepMode(instance);
+    return instance->fmu->fmi3.enterStepMode(instance->component);
 }
 
 fmi3Status fmi3_getOutputDerivatives(fmi3InstanceHandle *instance, const fmi3ValueReference valueReferences[], size_t nValueReferences, const fmi3Int32 orders[], fmi3Float64 values[], size_t nValues)
 {
 
-    return instance->fmu->fmi3.getOutputDerivatives(instance, valueReferences, nValueReferences, orders, values, nValues);
+    return instance->fmu->fmi3.getOutputDerivatives(instance->component, valueReferences, nValueReferences, orders, values, nValues);
 }
 
 fmi3Status fmi3_activateModelPartition(fmi3InstanceHandle *instance, fmi3ValueReference clockReference, fmi3Float64 activationTime)
 {
 
-    return instance->fmu->fmi3.activateModelPartition(instance, clockReference, activationTime);
+    return instance->fmu->fmi3.activateModelPartition(instance->component, clockReference, activationTime);
 }
 
 bool fmi3_defaultStartTimeDefined(fmuHandle *fmu)
@@ -4015,37 +4015,37 @@ fmi2Status fmi2_doStep(fmi2InstanceHandle *instance, fmi2Real currentCommunicati
 fmi2Status fmi2_cancelStep(fmi2InstanceHandle *instance)
 {
     TRACEFUNC
-    return instance->fmu->fmi2.cancelStep(instance);
+    return instance->fmu->fmi2.cancelStep(instance->component);
 }
 
 fmi2Status fmi2_getStatus(fmi2InstanceHandle *instance, const fmi2StatusKind s, fmi2Status* value)
 {
     TRACEFUNC
-    return instance->fmu->fmi2.getStatus(instance, s, value);
+    return instance->fmu->fmi2.getStatus(instance->component, s, value);
 }
 
 fmi2Status fmi2_getRealStatus(fmi2InstanceHandle *instance, const fmi2StatusKind s, fmi2Real* value)
 {
     TRACEFUNC
-    return instance->fmu->fmi2.getRealStatus(instance, s, value);
+    return instance->fmu->fmi2.getRealStatus(instance->component, s, value);
 }
 
 fmi2Status fmi2_getIntegerStatus(fmi2InstanceHandle *instance, const fmi2StatusKind s, fmi2Integer* value)
 {
     TRACEFUNC
-    return instance->fmu->fmi2.getIntegerStatus(instance, s, value);
+    return instance->fmu->fmi2.getIntegerStatus(instance->component, s, value);
 }
 
 fmi2Status fmi2_getBooleanStatus(fmi2InstanceHandle *instance, const fmi2StatusKind s, fmi2Boolean* value)
 {
     TRACEFUNC
-    return instance->fmu->fmi2.getBooleanStatus(instance, s, value);
+    return instance->fmu->fmi2.getBooleanStatus(instance->component, s, value);
 }
 
 fmi2Status fmi2_getStringStatus(fmi2InstanceHandle *instance, const fmi2StatusKind s, fmi2String* value)
 {
     TRACEFUNC
-    return instance->fmu->fmi2.getStringStatus(instance, s, value);
+    return instance->fmu->fmi2.getStringStatus(instance->component, s, value);
 }
 
 const char *fmi2_getGuid(fmuHandle *fmu)
@@ -5288,7 +5288,7 @@ fmi1InstanceHandle *fmi1_instantiateSlave(fmuHandle *fmu, fmi1String mimeType, f
     fmu->fmi1.callbacksCoSimulation.freeMemory = freeMemory;
     fmu->fmi1.callbacksCoSimulation.stepFinished = stepFinished;
 
-    fmi1Component_t comp = fmu->fmi1.instantiateSlave(fmu->instanceName, fmu->fmi1.guid, fmu->resourcesLocation, mimeType, timeOut, visible, interactive, fmu->fmi1.callbacksCoSimulation, loggingOn);
+    fmi1Component comp = fmu->fmi1.instantiateSlave(fmu->instanceName, fmu->fmi1.guid, fmu->resourcesLocation, mimeType, timeOut, visible, interactive, fmu->fmi1.callbacksCoSimulation, loggingOn);
     fmi1InstanceHandle *handle = calloc(1, sizeof(fmi1InstanceHandle));
     handle->component = comp;
     handle->fmu = (struct fmuHandle*)fmu;
@@ -5388,7 +5388,7 @@ fmi1InstanceHandle *fmi1_instantiateModel(fmuHandle *fmu, fmi1CallbackLogger_t l
     fmu->fmi1.callbacksModelExchange.logger = logger;
     fmu->fmi1.callbacksModelExchange.allocateMemory = allocateMemory;
     fmu->fmi1.callbacksModelExchange.freeMemory = freeMemory;
-    fmi1Component_t comp = fmu->fmi1.instantiateModel(fmu->instanceName, fmu->fmi1.guid, fmu->fmi1.callbacksModelExchange, loggingOn);
+    fmi1Component comp = fmu->fmi1.instantiateModel(fmu->instanceName, fmu->fmi1.guid, fmu->fmi1.callbacksModelExchange, loggingOn);
     fmi1InstanceHandle *handle = calloc(1, sizeof(fmi1InstanceHandle));
     handle->component = comp;
     handle->fmu = (struct fmuHandle*)fmu;

--- a/src/fmi4c.c
+++ b/src/fmi4c.c
@@ -2449,43 +2449,47 @@ fmiVersion_t fmi4c_getFmiVersion(fmuHandle *fmu)
 
 
 
-bool fmi3_instantiateCoSimulation(fmuHandle *fmu,
-                             fmi3Boolean                    visible,
-                             fmi3Boolean                    loggingOn,
-                             fmi3Boolean                    eventModeUsed,
-                             fmi3Boolean                    earlyReturnAllowed,
-                             const fmi3ValueReference       requiredIntermediateVariables[],
-                             size_t                         nRequiredIntermediateVariables,
-                             fmi3InstanceEnvironment        instanceEnvironment,
-                             fmi3LogMessageCallback         logMessage,
-                             fmi3IntermediateUpdateCallback intermediateUpdate)
+fmi3InstanceHandle *fmi3_instantiateCoSimulation(fmuHandle *fmu,
+                                                 fmi3Boolean                    visible,
+                                                 fmi3Boolean                    loggingOn,
+                                                 fmi3Boolean                    eventModeUsed,
+                                                 fmi3Boolean                    earlyReturnAllowed,
+                                                 const fmi3ValueReference       requiredIntermediateVariables[],
+                                                 size_t                         nRequiredIntermediateVariables,
+                                                 fmi3InstanceEnvironment        instanceEnvironment,
+                                                 fmi3LogMessageCallback         logMessage,
+                                                 fmi3IntermediateUpdateCallback intermediateUpdate)
 {
     if(!loadFunctionsFmi3(fmu, fmi3CoSimulation)) {
         printf("Failed to load functions for FMI 3 CS.");
         return false;
     }
 
-    fmu->fmi3.fmi3Instance = fmu->fmi3.instantiateCoSimulation(fmu->instanceName,
-                                                      fmu->fmi3.instantiationToken,
-                                                      fmu->resourcesLocation,
-                                                      visible,
-                                                      loggingOn,
-                                                      eventModeUsed,
-                                                      earlyReturnAllowed,
-                                                      requiredIntermediateVariables,
-                                                      nRequiredIntermediateVariables,
-                                                      instanceEnvironment,
-                                                      logMessage,
-                                                      intermediateUpdate);
+    fmi3Component* comp = fmu->fmi3.instantiateCoSimulation(fmu->instanceName,
+                                                            fmu->fmi3.instantiationToken,
+                                                            fmu->resourcesLocation,
+                                                            visible,
+                                                            loggingOn,
+                                                            eventModeUsed,
+                                                            earlyReturnAllowed,
+                                                            requiredIntermediateVariables,
+                                                            nRequiredIntermediateVariables,
+                                                            instanceEnvironment,
+                                                            logMessage,
+                                                            intermediateUpdate);
 
-    return (fmu->fmi3.fmi3Instance != NULL);
+    fmi3InstanceHandle *handle = calloc(1, sizeof(fmi3InstanceHandle));
+    handle->component = comp;
+    handle->fmu = (struct fmuHandle*)fmu;
+
+    return handle;
 }
 
-bool fmi3_instantiateModelExchange(fmuHandle *fmu,
-                                  fmi3Boolean               visible,
-                                  fmi3Boolean                loggingOn,
-                                  fmi3InstanceEnvironment    instanceEnvironment,
-                                  fmi3LogMessageCallback     logMessage)
+fmi3InstanceHandle *fmi3_instantiateModelExchange(fmuHandle *fmu,
+                                                  fmi3Boolean               visible,
+                                                  fmi3Boolean                loggingOn,
+                                                  fmi3InstanceEnvironment    instanceEnvironment,
+                                                  fmi3LogMessageCallback     logMessage)
 {
     if(!loadFunctionsFmi3(fmu, fmi3ModelExchange)) {
         printf("Failed to load functions for FMI 3 ME.");
@@ -2493,15 +2497,19 @@ bool fmi3_instantiateModelExchange(fmuHandle *fmu,
     }
 
 
-    fmu->fmi3.fmi3Instance = fmu->fmi3.instantiateModelExchange(fmu->instanceName,
-                                                           fmu->fmi3.instantiationToken,
-                                                           fmu->resourcesLocation,
-                                                           visible,
-                                                           loggingOn,
-                                                           instanceEnvironment,
-                                                           logMessage);
+    fmi3Component *comp = fmu->fmi3.instantiateModelExchange(fmu->instanceName,
+                                                             fmu->fmi3.instantiationToken,
+                                                             fmu->resourcesLocation,
+                                                             visible,
+                                                             loggingOn,
+                                                             instanceEnvironment,
+                                                             logMessage);
 
-    return (fmu->fmi3.fmi3Instance != NULL);
+    fmi3InstanceHandle *handle = calloc(1, sizeof(fmi3InstanceHandle));
+    handle->component = comp;
+    handle->fmu = (struct fmuHandle*)fmu;
+
+    return handle;
 }
 
 const char* fmi3_getVersion(fmuHandle *fmu) {
@@ -2509,22 +2517,22 @@ const char* fmi3_getVersion(fmuHandle *fmu) {
     return fmu->fmi3.getVersion();
 }
 
-fmi3Status fmi3_setDebugLogging(fmuHandle *fmu,
+fmi3Status fmi3_setDebugLogging(fmi3InstanceHandle *instance,
                                 fmi3Boolean loggingOn,
                                 size_t nCategories,
                                 const fmi3String categories[])
 {
 
-    return fmu->fmi3.setDebugLogging(fmu->fmi3.fmi3Instance, loggingOn, nCategories, categories);
+    return instance->fmu->fmi3.setDebugLogging(instance, loggingOn, nCategories, categories);
 }
 
-fmi3Status fmi3_getFloat64(fmuHandle *fmu,
+fmi3Status fmi3_getFloat64(fmi3InstanceHandle *instance,
                            const fmi3ValueReference valueReferences[],
                            size_t nValueReferences,
                            fmi3Float64 values[],
                            size_t nValues) {
 
-    return fmu->fmi3.getFloat64(fmu->fmi3.fmi3Instance,
+    return instance->fmu->fmi3.getFloat64(instance,
                                 valueReferences,
                                 nValueReferences,
                                 values,
@@ -2532,27 +2540,27 @@ fmi3Status fmi3_getFloat64(fmuHandle *fmu,
 }
 
 
-fmi3Status fmi3_setFloat64(fmuHandle *fmu,
+fmi3Status fmi3_setFloat64(fmi3InstanceHandle *instance,
                            const fmi3ValueReference valueReferences[],
                            size_t nValueReferences,
                            const fmi3Float64 values[],
                            size_t nValues) {
 
-    return fmu->fmi3.setFloat64(fmu->fmi3.fmi3Instance,
+    return instance->fmu->fmi3.setFloat64(instance,
                                 valueReferences,
                                 nValueReferences,
                                 values,
                                 nValues);
 }
 
-fmi3Status fmi3_enterInitializationMode(fmuHandle *fmu,
+fmi3Status fmi3_enterInitializationMode(fmi3InstanceHandle *instance,
                                        fmi3Boolean toleranceDefined,
                                        fmi3Float64 tolerance,
                                        fmi3Float64 startTime,
                                        fmi3Boolean stopTimeDefined,
                                        fmi3Float64 stopTime)
 {
-    return fmu->fmi3.enterInitializationMode(fmu->fmi3.fmi3Instance,
+    return instance->fmu->fmi3.enterInitializationMode(instance,
                                             toleranceDefined,
                                             tolerance,
                                             startTime,
@@ -2560,28 +2568,29 @@ fmi3Status fmi3_enterInitializationMode(fmuHandle *fmu,
                                             stopTime);
 }
 
-fmi3Status fmi3_exitInitializationMode(fmuHandle *fmu)
+fmi3Status fmi3_exitInitializationMode(fmi3InstanceHandle *instance)
 {
     TRACEFUNC
 
-    return fmu->fmi3.exitInitializationMode(fmu->fmi3.fmi3Instance);
+    return instance->fmu->fmi3.exitInitializationMode(instance);
 }
 
-fmi3Status fmi3_terminate(fmuHandle *fmu)
+fmi3Status fmi3_terminate(fmi3InstanceHandle *instance)
 {
     TRACEFUNC
 
-    return fmu->fmi3.terminate(fmu->fmi3.fmi3Instance);
+    return instance->fmu->fmi3.terminate(instance);
 }
 
-void fmi3_freeInstance(fmuHandle *fmu)
+void fmi3_freeInstance(fmi3InstanceHandle *instance)
 {
     TRACEFUNC
 
-    fmu->fmi3.freeInstance(fmu->fmi3.fmi3Instance);
+    instance->fmu->fmi3.freeInstance(instance->component);
+    free(instance);
 }
 
-fmi3Status fmi3_doStep(fmuHandle *fmu,
+fmi3Status fmi3_doStep(fmi3InstanceHandle *instance,
                        fmi3Float64 currentCommunicationPoint,
                        fmi3Float64 communicationStepSize,
                        fmi3Boolean noSetFMUStatePriorToCurrentPoint,
@@ -2591,7 +2600,7 @@ fmi3Status fmi3_doStep(fmuHandle *fmu,
                        fmi3Float64 *lastSuccessfulTime)
 {
 
-    return fmu->fmi3.doStep(fmu->fmi3.fmi3Instance,
+    return instance->fmu->fmi3.doStep(instance,
                             currentCommunicationPoint,
                             communicationStepSize,
                             noSetFMUStatePriorToCurrentPoint,
@@ -3025,370 +3034,370 @@ fmi3ValueReference fmi3_getVariableValueReference(fmi3VariableHandle *var)
     return var->valueReference;
 }
 
-fmi3Status fmi3_enterEventMode(fmuHandle *fmu)
+fmi3Status fmi3_enterEventMode(fmi3InstanceHandle *instance)
 {
-    return fmu->fmi3.enterEventMode(fmu->fmi3.fmi3Instance);
+    return instance->fmu->fmi3.enterEventMode(instance);
 }
 
-fmi3Status fmi3_reset(fmuHandle *fmu)
+fmi3Status fmi3_reset(fmi3InstanceHandle *instance)
 {
     TRACEFUNC
 
-    return fmu->fmi3.reset(fmu->fmi3.fmi3Instance);
+    return instance->fmu->fmi3.reset(instance);
 }
 
-fmi3Status fmi3_getFloat32(fmuHandle *fmu, const fmi3ValueReference valueReferences[], size_t nValueReferences, fmi3Float32 values[], size_t nValues)
+fmi3Status fmi3_getFloat32(fmi3InstanceHandle *instance, const fmi3ValueReference valueReferences[], size_t nValueReferences, fmi3Float32 values[], size_t nValues)
 {
 
-    return fmu->fmi3.getFloat32(fmu->fmi3.fmi3Instance, valueReferences, nValueReferences, values, nValues);
+    return instance->fmu->fmi3.getFloat32(instance, valueReferences, nValueReferences, values, nValues);
 }
 
-fmi3Status fmi3_getInt8(fmuHandle *fmu, const fmi3ValueReference valueReferences[], size_t nValueReferences, fmi3Int8 values[], size_t nValues)
+fmi3Status fmi3_getInt8(fmi3InstanceHandle *instance, const fmi3ValueReference valueReferences[], size_t nValueReferences, fmi3Int8 values[], size_t nValues)
 {
 
-    return fmu->fmi3.getInt8(fmu->fmi3.fmi3Instance, valueReferences, nValueReferences, values, nValues);
+    return instance->fmu->fmi3.getInt8(instance, valueReferences, nValueReferences, values, nValues);
 }
 
-fmi3Status fmi3_getUInt8(fmuHandle *fmu, const fmi3ValueReference valueReferences[], size_t nValueReferences, fmi3UInt8 values[], size_t nValues)
+fmi3Status fmi3_getUInt8(fmi3InstanceHandle *instance, const fmi3ValueReference valueReferences[], size_t nValueReferences, fmi3UInt8 values[], size_t nValues)
 {
 
-    return fmu->fmi3.getUInt8(fmu->fmi3.fmi3Instance, valueReferences, nValueReferences, values, nValues);
+    return instance->fmu->fmi3.getUInt8(instance, valueReferences, nValueReferences, values, nValues);
 }
 
-fmi3Status fmi3_getInt16(fmuHandle *fmu, const fmi3ValueReference valueReferences[], size_t nValueReferences, fmi3Int16 values[], size_t nValues)
+fmi3Status fmi3_getInt16(fmi3InstanceHandle *instance, const fmi3ValueReference valueReferences[], size_t nValueReferences, fmi3Int16 values[], size_t nValues)
 {
 
-    return fmu->fmi3.getInt16(fmu->fmi3.fmi3Instance, valueReferences, nValueReferences, values, nValues);
+    return instance->fmu->fmi3.getInt16(instance, valueReferences, nValueReferences, values, nValues);
 }
 
-fmi3Status fmi3_getUInt16(fmuHandle *fmu, const fmi3ValueReference valueReferences[], size_t nValueReferences, fmi3UInt16 values[], size_t nValues)
+fmi3Status fmi3_getUInt16(fmi3InstanceHandle *instance, const fmi3ValueReference valueReferences[], size_t nValueReferences, fmi3UInt16 values[], size_t nValues)
 {
 
-    return fmu->fmi3.getUInt16(fmu->fmi3.fmi3Instance, valueReferences, nValueReferences, values, nValues);
+    return instance->fmu->fmi3.getUInt16(instance, valueReferences, nValueReferences, values, nValues);
 }
 
-fmi3Status fmi3_getInt32(fmuHandle *fmu, const fmi3ValueReference valueReferences[], size_t nValueReferences, fmi3Int32 values[], size_t nValues)
+fmi3Status fmi3_getInt32(fmi3InstanceHandle *instance, const fmi3ValueReference valueReferences[], size_t nValueReferences, fmi3Int32 values[], size_t nValues)
 {
 
-    return fmu->fmi3.getInt32(fmu->fmi3.fmi3Instance, valueReferences, nValueReferences, values, nValues);
+    return instance->fmu->fmi3.getInt32(instance, valueReferences, nValueReferences, values, nValues);
 }
 
-fmi3Status fmi3_getUInt32(fmuHandle *fmu, const fmi3ValueReference valueReferences[], size_t nValueReferences, fmi3UInt32 values[], size_t nValues)
+fmi3Status fmi3_getUInt32(fmi3InstanceHandle *instance, const fmi3ValueReference valueReferences[], size_t nValueReferences, fmi3UInt32 values[], size_t nValues)
 {
 
-    return fmu->fmi3.getUInt32(fmu->fmi3.fmi3Instance, valueReferences, nValueReferences, values, nValues);
+    return instance->fmu->fmi3.getUInt32(instance, valueReferences, nValueReferences, values, nValues);
 }
 
-fmi3Status fmi3_getInt64(fmuHandle *fmu, const fmi3ValueReference valueReferences[], size_t nValueReferences, fmi3Int64 values[], size_t nValues)
+fmi3Status fmi3_getInt64(fmi3InstanceHandle *instance, const fmi3ValueReference valueReferences[], size_t nValueReferences, fmi3Int64 values[], size_t nValues)
 {
 
-    return fmu->fmi3.getInt64(fmu->fmi3.fmi3Instance, valueReferences, nValueReferences, values, nValues);
+    return instance->fmu->fmi3.getInt64(instance, valueReferences, nValueReferences, values, nValues);
 }
 
-fmi3Status fmi3_getUInt64(fmuHandle *fmu, const fmi3ValueReference valueReferences[], size_t nValueReferences, fmi3UInt64 values[], size_t nValues)
+fmi3Status fmi3_getUInt64(fmi3InstanceHandle *instance, const fmi3ValueReference valueReferences[], size_t nValueReferences, fmi3UInt64 values[], size_t nValues)
 {
 
-    return fmu->fmi3.getUInt64(fmu->fmi3.fmi3Instance, valueReferences, nValueReferences, values, nValues);
+    return instance->fmu->fmi3.getUInt64(instance, valueReferences, nValueReferences, values, nValues);
 }
 
-fmi3Status fmi3_getBoolean(fmuHandle *fmu, const fmi3ValueReference valueReferences[], size_t nValueReferences, fmi3Boolean values[], size_t nValues)
+fmi3Status fmi3_getBoolean(fmi3InstanceHandle *instance, const fmi3ValueReference valueReferences[], size_t nValueReferences, fmi3Boolean values[], size_t nValues)
 {
 
-    return fmu->fmi3.getBoolean(fmu->fmi3.fmi3Instance, valueReferences, nValueReferences, values, nValues);
+    return instance->fmu->fmi3.getBoolean(instance, valueReferences, nValueReferences, values, nValues);
 }
 
-fmi3Status fmi3_getString(fmuHandle *fmu, const fmi3ValueReference valueReferences[], size_t nValueReferences, fmi3String values[], size_t nValues)
+fmi3Status fmi3_getString(fmi3InstanceHandle *instance, const fmi3ValueReference valueReferences[], size_t nValueReferences, fmi3String values[], size_t nValues)
 {
 
-    return fmu->fmi3.getString(fmu->fmi3.fmi3Instance, valueReferences, nValueReferences, values, nValues);
+    return instance->fmu->fmi3.getString(instance, valueReferences, nValueReferences, values, nValues);
 }
 
-fmi3Status fmi3_getBinary(fmuHandle *fmu, const fmi3ValueReference valueReferences[], size_t nValueReferences, size_t valueSizes[], fmi3Binary values[], size_t nValues)
+fmi3Status fmi3_getBinary(fmi3InstanceHandle *instance, const fmi3ValueReference valueReferences[], size_t nValueReferences, size_t valueSizes[], fmi3Binary values[], size_t nValues)
 {
 
-    return fmu->fmi3.getBinary(fmu->fmi3.fmi3Instance, valueReferences, nValueReferences, valueSizes, values, nValues);
+    return instance->fmu->fmi3.getBinary(instance, valueReferences, nValueReferences, valueSizes, values, nValues);
 }
 
-fmi3Status fmi3_getClock(fmuHandle *fmu, const fmi3ValueReference valueReferences[], size_t nValueReferences, fmi3Clock values[])
+fmi3Status fmi3_getClock(fmi3InstanceHandle *instance, const fmi3ValueReference valueReferences[], size_t nValueReferences, fmi3Clock values[])
 {
 
-    return fmu->fmi3.getClock(fmu->fmi3.fmi3Instance, valueReferences, nValueReferences, values);
+    return instance->fmu->fmi3.getClock(instance, valueReferences, nValueReferences, values);
 }
 
-fmi3Status fmi3_setFloat32(fmuHandle *fmu, const fmi3ValueReference valueReferences[], size_t nValueReferences, const fmi3Float32 values[], size_t nValues)
+fmi3Status fmi3_setFloat32(fmi3InstanceHandle *instance, const fmi3ValueReference valueReferences[], size_t nValueReferences, const fmi3Float32 values[], size_t nValues)
 {
 
-    return fmu->fmi3.setFloat32(fmu->fmi3.fmi3Instance, valueReferences, nValueReferences, values, nValues);
+    return instance->fmu->fmi3.setFloat32(instance, valueReferences, nValueReferences, values, nValues);
 }
 
-fmi3Status fmi3_setInt8(fmuHandle *fmu, const fmi3ValueReference valueReferences[], size_t nValueReferences, const fmi3Int8 values[], size_t nValues)
+fmi3Status fmi3_setInt8(fmi3InstanceHandle *instance, const fmi3ValueReference valueReferences[], size_t nValueReferences, const fmi3Int8 values[], size_t nValues)
 {
 
-    return fmu->fmi3.setInt8(fmu->fmi3.fmi3Instance, valueReferences, nValueReferences, values, nValues);
+    return instance->fmu->fmi3.setInt8(instance, valueReferences, nValueReferences, values, nValues);
 }
 
-fmi3Status fmi3_setUInt8(fmuHandle *fmu, const fmi3ValueReference valueReferences[], size_t nValueReferences, const fmi3UInt8 values[], size_t nValues)
+fmi3Status fmi3_setUInt8(fmi3InstanceHandle *instance, const fmi3ValueReference valueReferences[], size_t nValueReferences, const fmi3UInt8 values[], size_t nValues)
 {
 
-    return fmu->fmi3.setUInt8(fmu->fmi3.fmi3Instance, valueReferences, nValueReferences, values, nValues);
+    return instance->fmu->fmi3.setUInt8(instance, valueReferences, nValueReferences, values, nValues);
 }
 
-fmi3Status fmi3_setInt16(fmuHandle *fmu, const fmi3ValueReference valueReferences[], size_t nValueReferences, const fmi3Int16 values[], size_t nValues)
+fmi3Status fmi3_setInt16(fmi3InstanceHandle *instance, const fmi3ValueReference valueReferences[], size_t nValueReferences, const fmi3Int16 values[], size_t nValues)
 {
 
-    return fmu->fmi3.setInt16(fmu->fmi3.fmi3Instance, valueReferences, nValueReferences, values, nValues);
+    return instance->fmu->fmi3.setInt16(instance, valueReferences, nValueReferences, values, nValues);
 }
 
-fmi3Status fmi3_setUInt16(fmuHandle *fmu, const fmi3ValueReference valueReferences[], size_t nValueReferences, const fmi3UInt16 values[], size_t nValues)
+fmi3Status fmi3_setUInt16(fmi3InstanceHandle *instance, const fmi3ValueReference valueReferences[], size_t nValueReferences, const fmi3UInt16 values[], size_t nValues)
 {
 
-    return fmu->fmi3.setUInt16(fmu->fmi3.fmi3Instance, valueReferences, nValueReferences, values, nValues);
+    return instance->fmu->fmi3.setUInt16(instance, valueReferences, nValueReferences, values, nValues);
 }
 
-fmi3Status fmi3_setInt32(fmuHandle *fmu, const fmi3ValueReference valueReferences[], size_t nValueReferences, const fmi3Int32 values[], size_t nValues)
+fmi3Status fmi3_setInt32(fmi3InstanceHandle *instance, const fmi3ValueReference valueReferences[], size_t nValueReferences, const fmi3Int32 values[], size_t nValues)
 {
 
-    return fmu->fmi3.setInt32(fmu->fmi3.fmi3Instance, valueReferences, nValueReferences, values, nValues);
+    return instance->fmu->fmi3.setInt32(instance, valueReferences, nValueReferences, values, nValues);
 }
 
-fmi3Status fmi3_setUInt32(fmuHandle *fmu, const fmi3ValueReference valueReferences[], size_t nValueReferences, const fmi3UInt32 values[], size_t nValues)
+fmi3Status fmi3_setUInt32(fmi3InstanceHandle *instance, const fmi3ValueReference valueReferences[], size_t nValueReferences, const fmi3UInt32 values[], size_t nValues)
 {
 
-    return fmu->fmi3.setUInt32(fmu->fmi3.fmi3Instance, valueReferences, nValueReferences, values, nValues);
+    return instance->fmu->fmi3.setUInt32(instance, valueReferences, nValueReferences, values, nValues);
 }
 
-fmi3Status fmi3_setInt64(fmuHandle *fmu, const fmi3ValueReference valueReferences[], size_t nValueReferences, const fmi3Int64 values[], size_t nValues)
+fmi3Status fmi3_setInt64(fmi3InstanceHandle *instance, const fmi3ValueReference valueReferences[], size_t nValueReferences, const fmi3Int64 values[], size_t nValues)
 {
 
-    return fmu->fmi3.setInt64(fmu->fmi3.fmi3Instance, valueReferences, nValueReferences, values, nValues);
+    return instance->fmu->fmi3.setInt64(instance, valueReferences, nValueReferences, values, nValues);
 }
 
-fmi3Status fmi3_setUInt64(fmuHandle *fmu, const fmi3ValueReference valueReferences[], size_t nValueReferences, const fmi3UInt64 values[], size_t nValues)
+fmi3Status fmi3_setUInt64(fmi3InstanceHandle *instance, const fmi3ValueReference valueReferences[], size_t nValueReferences, const fmi3UInt64 values[], size_t nValues)
 {
 
-    return fmu->fmi3.setUInt64(fmu->fmi3.fmi3Instance, valueReferences, nValueReferences, values, nValues);
+    return instance->fmu->fmi3.setUInt64(instance, valueReferences, nValueReferences, values, nValues);
 }
 
-fmi3Status fmi3_setBoolean(fmuHandle *fmu, const fmi3ValueReference valueReferences[], size_t nValueReferences, const fmi3Boolean values[], size_t nValues)
+fmi3Status fmi3_setBoolean(fmi3InstanceHandle *instance, const fmi3ValueReference valueReferences[], size_t nValueReferences, const fmi3Boolean values[], size_t nValues)
 {
 
-    return fmu->fmi3.setBoolean(fmu->fmi3.fmi3Instance, valueReferences, nValueReferences, values, nValues);
+    return instance->fmu->fmi3.setBoolean(instance, valueReferences, nValueReferences, values, nValues);
 }
 
-fmi3Status fmi3_setString(fmuHandle *fmu, const fmi3ValueReference valueReferences[], size_t nValueReferences, const fmi3String values[], size_t nValues)
+fmi3Status fmi3_setString(fmi3InstanceHandle *instance, const fmi3ValueReference valueReferences[], size_t nValueReferences, const fmi3String values[], size_t nValues)
 {
 
-    return fmu->fmi3.setString(fmu->fmi3.fmi3Instance, valueReferences, nValueReferences, values, nValues);
+    return instance->fmu->fmi3.setString(instance, valueReferences, nValueReferences, values, nValues);
 }
 
-fmi3Status fmi3_setBinary(fmuHandle *fmu, const fmi3ValueReference valueReferences[], size_t nValueReferences, const size_t valueSizes[], const fmi3Binary values[], size_t nValues)
+fmi3Status fmi3_setBinary(fmi3InstanceHandle *instance, const fmi3ValueReference valueReferences[], size_t nValueReferences, const size_t valueSizes[], const fmi3Binary values[], size_t nValues)
 {
 
-    return fmu->fmi3.setBinary(fmu->fmi3.fmi3Instance, valueReferences, nValueReferences, valueSizes, values, nValues);
+    return instance->fmu->fmi3.setBinary(instance, valueReferences, nValueReferences, valueSizes, values, nValues);
 }
 
-fmi3Status fmi3_setClock(fmuHandle *fmu, const fmi3ValueReference valueReferences[], size_t nValueReferences, const fmi3Clock values[])
+fmi3Status fmi3_setClock(fmi3InstanceHandle *instance, const fmi3ValueReference valueReferences[], size_t nValueReferences, const fmi3Clock values[])
 {
 
-    return fmu->fmi3.setClock(fmu->fmi3.fmi3Instance, valueReferences, nValueReferences, values);
+    return instance->fmu->fmi3.setClock(instance, valueReferences, nValueReferences, values);
 }
 
-fmi3Status fmi3_getNumberOfVariableDependencies(fmuHandle *fmu, fmi3ValueReference valueReference, size_t *nDependencies)
+fmi3Status fmi3_getNumberOfVariableDependencies(fmi3InstanceHandle *instance, fmi3ValueReference valueReference, size_t *nDependencies)
 {
 
-    return fmu->fmi3.getNumberOfVariableDependencies(fmu->fmi3.fmi3Instance, valueReference, nDependencies);
+    return instance->fmu->fmi3.getNumberOfVariableDependencies(instance, valueReference, nDependencies);
 }
 
-fmi3Status fmi3_getVariableDependencies(fmuHandle *fmu, fmi3ValueReference dependent, size_t elementIndicesOfDependent[], fmi3ValueReference independents[], size_t elementIndicesOfIndependents[], fmi3DependencyKind dependencyKinds[], size_t nDependencies)
+fmi3Status fmi3_getVariableDependencies(fmi3InstanceHandle *instance, fmi3ValueReference dependent, size_t elementIndicesOfDependent[], fmi3ValueReference independents[], size_t elementIndicesOfIndependents[], fmi3DependencyKind dependencyKinds[], size_t nDependencies)
 {
 
-    return fmu->fmi3.getVariableDependencies(fmu->fmi3.fmi3Instance, dependent, elementIndicesOfDependent, independents, elementIndicesOfIndependents, dependencyKinds, nDependencies);
+    return instance->fmu->fmi3.getVariableDependencies(instance, dependent, elementIndicesOfDependent, independents, elementIndicesOfIndependents, dependencyKinds, nDependencies);
 }
 
-fmi3Status fmi3_getFMUState(fmuHandle *fmu, fmi3FMUState *FMUState)
+fmi3Status fmi3_getFMUState(fmi3InstanceHandle *instance, fmi3FMUState *FMUState)
 {
 
-    return fmu->fmi3.getFMUState(fmu->fmi3.fmi3Instance, FMUState);
+    return instance->fmu->fmi3.getFMUState(instance, FMUState);
 }
 
-fmi3Status fmi3_setFMUState(fmuHandle *fmu, fmi3FMUState FMUState)
+fmi3Status fmi3_setFMUState(fmi3InstanceHandle *instance, fmi3FMUState FMUState)
 {
 
-    return fmu->fmi3.setFMUState(fmu->fmi3.fmi3Instance, FMUState);
+    return instance->fmu->fmi3.setFMUState(instance, FMUState);
 }
 
-fmi3Status fmi3_freeFMUState(fmuHandle *fmu, fmi3FMUState *FMUState)
+fmi3Status fmi3_freeFMUState(fmi3InstanceHandle *instance, fmi3FMUState *FMUState)
 {
 
-    return fmu->fmi3.freeFMUState(fmu->fmi3.fmi3Instance, FMUState);
+    return instance->fmu->fmi3.freeFMUState(instance, FMUState);
 }
 
-fmi3Status fmi3_serializedFMUStateSize(fmuHandle *fmu, fmi3FMUState FMUState, size_t *size)
+fmi3Status fmi3_serializedFMUStateSize(fmi3InstanceHandle *instance, fmi3FMUState FMUState, size_t *size)
 {
 
-    return fmu->fmi3.serializedFMUStateSize(fmu->fmi3.fmi3Instance, FMUState, size);
+    return instance->fmu->fmi3.serializedFMUStateSize(instance, FMUState, size);
 }
 
-fmi3Status fmi3_serializeFMUState(fmuHandle *fmu, fmi3FMUState FMUState, fmi3Byte serializedState[], size_t size)
+fmi3Status fmi3_serializeFMUState(fmi3InstanceHandle *instance, fmi3FMUState FMUState, fmi3Byte serializedState[], size_t size)
 {
 
-    return fmu->fmi3.serializeFMUState(fmu->fmi3.fmi3Instance, FMUState, serializedState, size);
+    return instance->fmu->fmi3.serializeFMUState(instance, FMUState, serializedState, size);
 }
 
-fmi3Status fmi3_deserializeFMUState(fmuHandle *fmu, const fmi3Byte serializedState[], size_t size, fmi3FMUState *FMUState)
+fmi3Status fmi3_deserializeFMUState(fmi3InstanceHandle *instance, const fmi3Byte serializedState[], size_t size, fmi3FMUState *FMUState)
 {
 
-    return fmu->fmi3.deserializeFMUState(fmu->fmi3.fmi3Instance, serializedState, size, FMUState);
+    return instance->fmu->fmi3.deserializeFMUState(instance, serializedState, size, FMUState);
 }
 
-fmi3Status fmi3_getDirectionalDerivative(fmuHandle *fmu, const fmi3ValueReference unknowns[], size_t nUnknowns, const fmi3ValueReference knowns[], size_t nKnowns, const fmi3Float64 seed[], size_t nSeed, fmi3Float64 sensitivity[], size_t nSensitivity)
+fmi3Status fmi3_getDirectionalDerivative(fmi3InstanceHandle *instance, const fmi3ValueReference unknowns[], size_t nUnknowns, const fmi3ValueReference knowns[], size_t nKnowns, const fmi3Float64 seed[], size_t nSeed, fmi3Float64 sensitivity[], size_t nSensitivity)
 {
 
-    return fmu->fmi3.getDirectionalDerivative(fmu->fmi3.fmi3Instance, unknowns, nUnknowns, knowns, nKnowns, seed, nSeed, sensitivity, nSensitivity);
+    return instance->fmu->fmi3.getDirectionalDerivative(instance, unknowns, nUnknowns, knowns, nKnowns, seed, nSeed, sensitivity, nSensitivity);
 }
 
-fmi3Status fmi3_getAdjointDerivative(fmuHandle *fmu, const fmi3ValueReference unknowns[], size_t nUnknowns, const fmi3ValueReference knowns[], size_t nKnowns, const fmi3Float64 seed[], size_t nSeed, fmi3Float64 sensitivity[], size_t nSensitivity)
+fmi3Status fmi3_getAdjointDerivative(fmi3InstanceHandle *instance, const fmi3ValueReference unknowns[], size_t nUnknowns, const fmi3ValueReference knowns[], size_t nKnowns, const fmi3Float64 seed[], size_t nSeed, fmi3Float64 sensitivity[], size_t nSensitivity)
 {
 
-    return fmu->fmi3.getAdjointDerivative(fmu->fmi3.fmi3Instance, unknowns, nUnknowns, knowns, nKnowns, seed, nSeed, sensitivity, nSensitivity);
+    return instance->fmu->fmi3.getAdjointDerivative(instance, unknowns, nUnknowns, knowns, nKnowns, seed, nSeed, sensitivity, nSensitivity);
 }
 
-fmi3Status fmi3_enterConfigurationMode(fmuHandle *fmu)
+fmi3Status fmi3_enterConfigurationMode(fmi3InstanceHandle *instance)
 {
 
-    return fmu->fmi3.enterConfigurationMode(fmu->fmi3.fmi3Instance);
+    return instance->fmu->fmi3.enterConfigurationMode(instance);
 }
 
-fmi3Status fmi3_exitConfigurationMode(fmuHandle *fmu)
+fmi3Status fmi3_exitConfigurationMode(fmi3InstanceHandle *instance)
 {
 
-    return fmu->fmi3.exitConfigurationMode(fmu->fmi3.fmi3Instance);
+    return instance->fmu->fmi3.exitConfigurationMode(instance);
 }
 
-fmi3Status fmi3_getIntervalDecimal(fmuHandle *fmu, const fmi3ValueReference valueReferences[], size_t nValueReferences, fmi3Float64 intervals[], fmi3IntervalQualifier qualifiers[])
+fmi3Status fmi3_getIntervalDecimal(fmi3InstanceHandle *instance, const fmi3ValueReference valueReferences[], size_t nValueReferences, fmi3Float64 intervals[], fmi3IntervalQualifier qualifiers[])
 {
 
-    return fmu->fmi3.getIntervalDecimal(fmu->fmi3.fmi3Instance, valueReferences, nValueReferences, intervals, qualifiers);
+    return instance->fmu->fmi3.getIntervalDecimal(instance, valueReferences, nValueReferences, intervals, qualifiers);
 }
 
-fmi3Status fmi3_getIntervalFraction(fmuHandle *fmu, const fmi3ValueReference valueReferences[], size_t nValueReferences, fmi3UInt64 intervalCounters[], fmi3UInt64 resolutions[], fmi3IntervalQualifier qualifiers[])
+fmi3Status fmi3_getIntervalFraction(fmi3InstanceHandle *instance, const fmi3ValueReference valueReferences[], size_t nValueReferences, fmi3UInt64 intervalCounters[], fmi3UInt64 resolutions[], fmi3IntervalQualifier qualifiers[])
 {
 
-    return fmu->fmi3.getIntervalFraction(fmu->fmi3.fmi3Instance, valueReferences, nValueReferences, intervalCounters, resolutions, qualifiers);
+    return instance->fmu->fmi3.getIntervalFraction(instance, valueReferences, nValueReferences, intervalCounters, resolutions, qualifiers);
 }
 
-fmi3Status fmi3_getShiftDecimal(fmuHandle *fmu, const fmi3ValueReference valueReferences[], size_t nValueReferences, fmi3Float64 shifts[])
+fmi3Status fmi3_getShiftDecimal(fmi3InstanceHandle *instance, const fmi3ValueReference valueReferences[], size_t nValueReferences, fmi3Float64 shifts[])
 {
 
-    return fmu->fmi3.getShiftDecimal(fmu->fmi3.fmi3Instance, valueReferences, nValueReferences, shifts);
+    return instance->fmu->fmi3.getShiftDecimal(instance, valueReferences, nValueReferences, shifts);
 }
 
-fmi3Status fmi3_getShiftFraction(fmuHandle *fmu, const fmi3ValueReference valueReferences[], size_t nValueReferences, fmi3UInt64 shiftCounters[], fmi3UInt64 resolutions[])
+fmi3Status fmi3_getShiftFraction(fmi3InstanceHandle *instance, const fmi3ValueReference valueReferences[], size_t nValueReferences, fmi3UInt64 shiftCounters[], fmi3UInt64 resolutions[])
 {
 
-    return fmu->fmi3.getShiftFraction(fmu->fmi3.fmi3Instance, valueReferences, nValueReferences, shiftCounters, resolutions);
+    return instance->fmu->fmi3.getShiftFraction(instance, valueReferences, nValueReferences, shiftCounters, resolutions);
 }
 
-fmi3Status fmi3_setIntervalDecimal(fmuHandle *fmu, const fmi3ValueReference valueReferences[], size_t nValueReferences, const fmi3Float64 intervals[])
+fmi3Status fmi3_setIntervalDecimal(fmi3InstanceHandle *instance, const fmi3ValueReference valueReferences[], size_t nValueReferences, const fmi3Float64 intervals[])
 {
 
-    return fmu->fmi3.setIntervalDecimal(fmu->fmi3.fmi3Instance, valueReferences, nValueReferences, intervals);
+    return instance->fmu->fmi3.setIntervalDecimal(instance, valueReferences, nValueReferences, intervals);
 }
 
-fmi3Status fmi3_setIntervalFraction(fmuHandle *fmu, const fmi3ValueReference valueReferences[], size_t nValueReferences, const fmi3UInt64 intervalCounters[], const fmi3UInt64 resolutions[])
+fmi3Status fmi3_setIntervalFraction(fmi3InstanceHandle *instance, const fmi3ValueReference valueReferences[], size_t nValueReferences, const fmi3UInt64 intervalCounters[], const fmi3UInt64 resolutions[])
 {
 
-    return fmu->fmi3.setIntervalFraction(fmu->fmi3.fmi3Instance, valueReferences, nValueReferences, intervalCounters, resolutions);
+    return instance->fmu->fmi3.setIntervalFraction(instance, valueReferences, nValueReferences, intervalCounters, resolutions);
 }
 
-fmi3Status fmi3_evaluateDiscreteStates(fmuHandle *fmu)
+fmi3Status fmi3_evaluateDiscreteStates(fmi3InstanceHandle *instance)
 {
 
-    return fmu->fmi3.evaluateDiscreteStates(fmu->fmi3.fmi3Instance);
+    return instance->fmu->fmi3.evaluateDiscreteStates(instance);
 }
 
-fmi3Status fmi3_updateDiscreteStates(fmuHandle *fmu, fmi3Boolean *discreteStatesNeedUpdate, fmi3Boolean *terminateSimulation, fmi3Boolean *nominalsOfContinuousStatesChanged, fmi3Boolean *valuesOfContinuousStatesChanged, fmi3Boolean *nextEventTimeDefined, fmi3Float64 *nextEventTime)
+fmi3Status fmi3_updateDiscreteStates(fmi3InstanceHandle *instance, fmi3Boolean *discreteStatesNeedUpdate, fmi3Boolean *terminateSimulation, fmi3Boolean *nominalsOfContinuousStatesChanged, fmi3Boolean *valuesOfContinuousStatesChanged, fmi3Boolean *nextEventTimeDefined, fmi3Float64 *nextEventTime)
 {
 
-    return fmu->fmi3.updateDiscreteStates(fmu->fmi3.fmi3Instance, discreteStatesNeedUpdate, terminateSimulation, nominalsOfContinuousStatesChanged, valuesOfContinuousStatesChanged, nextEventTimeDefined, nextEventTime);
+    return instance->fmu->fmi3.updateDiscreteStates(instance, discreteStatesNeedUpdate, terminateSimulation, nominalsOfContinuousStatesChanged, valuesOfContinuousStatesChanged, nextEventTimeDefined, nextEventTime);
 }
 
-fmi3Status fmi3_enterContinuousTimeMode(fmuHandle *fmu)
+fmi3Status fmi3_enterContinuousTimeMode(fmi3InstanceHandle *instance)
 {
 
-    return fmu->fmi3.enterContinuousTimeMode(fmu->fmi3.fmi3Instance);
+    return instance->fmu->fmi3.enterContinuousTimeMode(instance);
 }
 
-fmi3Status fmi3_completedIntegratorStep(fmuHandle *fmu, fmi3Boolean noSetFMUStatePriorToCurrentPoint, fmi3Boolean *enterEventMode, fmi3Boolean *terminateSimulation)
+fmi3Status fmi3_completedIntegratorStep(fmi3InstanceHandle *instance, fmi3Boolean noSetFMUStatePriorToCurrentPoint, fmi3Boolean *enterEventMode, fmi3Boolean *terminateSimulation)
 {
 
-    return fmu->fmi3.completedIntegratorStep(fmu->fmi3.fmi3Instance, noSetFMUStatePriorToCurrentPoint, enterEventMode, terminateSimulation);
+    return instance->fmu->fmi3.completedIntegratorStep(instance, noSetFMUStatePriorToCurrentPoint, enterEventMode, terminateSimulation);
 }
 
-fmi3Status fmi3_setTime(fmuHandle *fmu, fmi3Float64 time)
+fmi3Status fmi3_setTime(fmi3InstanceHandle *instance, fmi3Float64 time)
 {
 
-    return fmu->fmi3.setTime(fmu->fmi3.fmi3Instance, time);
+    return instance->fmu->fmi3.setTime(instance, time);
 }
 
-fmi3Status fmi3_setContinuousStates(fmuHandle *fmu, const fmi3Float64 continuousStates[], size_t nContinuousStates)
+fmi3Status fmi3_setContinuousStates(fmi3InstanceHandle *instance, const fmi3Float64 continuousStates[], size_t nContinuousStates)
 {
 
-    return fmu->fmi3.setContinuousStates(fmu->fmi3.fmi3Instance, continuousStates, nContinuousStates);
+    return instance->fmu->fmi3.setContinuousStates(instance, continuousStates, nContinuousStates);
 }
 
-fmi3Status fmi3_getContinuousStateDerivatives(fmuHandle *fmu, fmi3Float64 derivatives[], size_t nContinuousStates)
+fmi3Status fmi3_getContinuousStateDerivatives(fmi3InstanceHandle *instance, fmi3Float64 derivatives[], size_t nContinuousStates)
 {
 
-    return fmu->fmi3.getContinuousStateDerivatives(fmu->fmi3.fmi3Instance, derivatives, nContinuousStates);
+    return instance->fmu->fmi3.getContinuousStateDerivatives(instance, derivatives, nContinuousStates);
 }
 
-fmi3Status fmi3_getEventIndicators(fmuHandle *fmu, fmi3Float64 eventIndicators[], size_t nEventIndicators)
+fmi3Status fmi3_getEventIndicators(fmi3InstanceHandle *instance, fmi3Float64 eventIndicators[], size_t nEventIndicators)
 {
 
-    return fmu->fmi3.getEventIndicators(fmu->fmi3.fmi3Instance, eventIndicators, nEventIndicators);
+    return instance->fmu->fmi3.getEventIndicators(instance, eventIndicators, nEventIndicators);
 }
 
-fmi3Status fmi3_getContinuousStates(fmuHandle *fmu, fmi3Float64 continuousStates[], size_t nContinuousStates)
+fmi3Status fmi3_getContinuousStates(fmi3InstanceHandle *instance, fmi3Float64 continuousStates[], size_t nContinuousStates)
 {
 
-    return fmu->fmi3.getContinuousStates(fmu->fmi3.fmi3Instance, continuousStates, nContinuousStates);
+    return instance->fmu->fmi3.getContinuousStates(instance, continuousStates, nContinuousStates);
 }
 
-fmi3Status fmi3_getNominalsOfContinuousStates(fmuHandle *fmu, fmi3Float64 nominals[], size_t nContinuousStates)
+fmi3Status fmi3_getNominalsOfContinuousStates(fmi3InstanceHandle *instance, fmi3Float64 nominals[], size_t nContinuousStates)
 {
 
-    return fmu->fmi3.getNominalsOfContinuousStates(fmu->fmi3.fmi3Instance, nominals, nContinuousStates);
+    return instance->fmu->fmi3.getNominalsOfContinuousStates(instance, nominals, nContinuousStates);
 }
 
-fmi3Status fmi3_getNumberOfEventIndicators(fmuHandle *fmu, size_t *nEventIndicators)
+fmi3Status fmi3_getNumberOfEventIndicators(fmi3InstanceHandle *instance, size_t *nEventIndicators)
 {
 
-    return fmu->fmi3.getNumberOfEventIndicators(fmu->fmi3.fmi3Instance, nEventIndicators);
+    return instance->fmu->fmi3.getNumberOfEventIndicators(instance, nEventIndicators);
 }
 
-fmi3Status fmi3_getNumberOfContinuousStates(fmuHandle *fmu, size_t *nContinuousStates)
+fmi3Status fmi3_getNumberOfContinuousStates(fmi3InstanceHandle *instance, size_t *nContinuousStates)
 {
 
-    return fmu->fmi3.getNumberOfContinuousStates(fmu->fmi3.fmi3Instance, nContinuousStates);
+    return instance->fmu->fmi3.getNumberOfContinuousStates(instance, nContinuousStates);
 }
 
-fmi3Status fmi3_enterStepMode(fmuHandle *fmu)
+fmi3Status fmi3_enterStepMode(fmi3InstanceHandle *instance)
 {
 
-    return fmu->fmi3.enterStepMode(fmu->fmi3.fmi3Instance);
+    return instance->fmu->fmi3.enterStepMode(instance);
 }
 
-fmi3Status fmi3_getOutputDerivatives(fmuHandle *fmu, const fmi3ValueReference valueReferences[], size_t nValueReferences, const fmi3Int32 orders[], fmi3Float64 values[], size_t nValues)
+fmi3Status fmi3_getOutputDerivatives(fmi3InstanceHandle *instance, const fmi3ValueReference valueReferences[], size_t nValueReferences, const fmi3Int32 orders[], fmi3Float64 values[], size_t nValues)
 {
 
-    return fmu->fmi3.getOutputDerivatives(fmu->fmi3.fmi3Instance, valueReferences, nValueReferences, orders, values, nValues);
+    return instance->fmu->fmi3.getOutputDerivatives(instance, valueReferences, nValueReferences, orders, values, nValues);
 }
 
-fmi3Status fmi3_activateModelPartition(fmuHandle *fmu, fmi3ValueReference clockReference, fmi3Float64 activationTime)
+fmi3Status fmi3_activateModelPartition(fmi3InstanceHandle *instance, fmi3ValueReference clockReference, fmi3Float64 activationTime)
 {
 
-    return fmu->fmi3.activateModelPartition(fmu->fmi3.fmi3Instance, clockReference, activationTime);
+    return instance->fmu->fmi3.activateModelPartition(instance, clockReference, activationTime);
 }
 
 bool fmi3_defaultStartTimeDefined(fmuHandle *fmu)

--- a/src/fmi4c.c
+++ b/src/fmi4c.c
@@ -95,7 +95,7 @@ void freeDuplicatedConstChar(const char* ptr) {
 //! @brief Parses modelDescription.xml for FMI 1
 //! @param fmu FMU handle
 //! @returns True if parsing was successful
-bool parseModelDescriptionFmi1(fmiHandle *fmu)
+bool parseModelDescriptionFmi1(fmuHandle *fmu)
 {
     fmu->fmi1.modelName = NULL;
     fmu->fmi1.modelIdentifier = NULL;
@@ -402,7 +402,7 @@ fmi2Initial initialDefaultTableFmi2[5][6] = {
 //! @brief Parses modelDescription.xml for FMI 2
 //! @param fmu FMU handle
 //! @returns True if parsing was successful
-bool parseModelDescriptionFmi2(fmiHandle *fmu)
+bool parseModelDescriptionFmi2(fmuHandle *fmu)
 {
     fmu->fmi2.fmiVersion_ = NULL;
     fmu->fmi2.modelName = NULL;
@@ -864,7 +864,7 @@ fmi3Initial initialDefaultTableFmi3[5][7] = {
 //! @brief Parses modelDescription.xml for FMI 3
 //! @param fmu FMU handle
 //! @returns True if parsing was successful
-bool parseModelDescriptionFmi3(fmiHandle *fmu)
+bool parseModelDescriptionFmi3(fmuHandle *fmu)
 {
     fmu->fmi3.modelName = NULL;
     fmu->fmi3.instantiationToken = NULL;
@@ -1969,7 +1969,7 @@ bool parseModelDescriptionFmi3(fmiHandle *fmu)
 //! @brief Loads all DLL functions for FMI 1
 //! @param fmu FMU handle
 //! @returns True if load was successful
-bool loadFunctionsFmi1(fmiHandle *fmu)
+bool loadFunctionsFmi1(fmuHandle *fmu)
 {
     TRACEFUNC
 
@@ -2102,7 +2102,7 @@ bool loadFunctionsFmi1(fmiHandle *fmu)
 //! @brief Loads all DLL functions for FMI 2
 //! @param fmu FMU handle
 //! @returns True if load was successful
-bool loadFunctionsFmi2(fmiHandle *fmu, fmi2Type fmuType)
+bool loadFunctionsFmi2(fmuHandle *fmu, fmi2Type fmuType)
 {
     TRACEFUNC
 
@@ -2243,7 +2243,7 @@ bool loadFunctionsFmi2(fmiHandle *fmu, fmi2Type fmuType)
 //! @brief Loads all DLL functions for FMI 3
 //! @param fmu FMU handle
 //! @returns True if load was successful
-bool loadFunctionsFmi3(fmiHandle *fmu, fmi3Type fmuType)
+bool loadFunctionsFmi3(fmuHandle *fmu, fmi3Type fmuType)
 {
     TRACEFUNC
 
@@ -2441,7 +2441,7 @@ bool loadFunctionsFmi3(fmiHandle *fmu, fmi3Type fmuType)
 //! @brief Returns FMI version of FMU
 //! @param fmu FMU handle
 //! @returns Version of the FMU
-fmiVersion_t fmi4c_getFmiVersion(fmiHandle *fmu)
+fmiVersion_t fmi4c_getFmiVersion(fmuHandle *fmu)
 {
     return fmu->version;
 }
@@ -2449,7 +2449,7 @@ fmiVersion_t fmi4c_getFmiVersion(fmiHandle *fmu)
 
 
 
-bool fmi3_instantiateCoSimulation(fmiHandle *fmu,
+bool fmi3_instantiateCoSimulation(fmuHandle *fmu,
                              fmi3Boolean                    visible,
                              fmi3Boolean                    loggingOn,
                              fmi3Boolean                    eventModeUsed,
@@ -2481,7 +2481,7 @@ bool fmi3_instantiateCoSimulation(fmiHandle *fmu,
     return (fmu->fmi3.fmi3Instance != NULL);
 }
 
-bool fmi3_instantiateModelExchange(fmiHandle *fmu,
+bool fmi3_instantiateModelExchange(fmuHandle *fmu,
                                   fmi3Boolean               visible,
                                   fmi3Boolean                loggingOn,
                                   fmi3InstanceEnvironment    instanceEnvironment,
@@ -2504,12 +2504,12 @@ bool fmi3_instantiateModelExchange(fmiHandle *fmu,
     return (fmu->fmi3.fmi3Instance != NULL);
 }
 
-const char* fmi3_getVersion(fmiHandle *fmu) {
+const char* fmi3_getVersion(fmuHandle *fmu) {
 
     return fmu->fmi3.getVersion();
 }
 
-fmi3Status fmi3_setDebugLogging(fmiHandle *fmu,
+fmi3Status fmi3_setDebugLogging(fmuHandle *fmu,
                                 fmi3Boolean loggingOn,
                                 size_t nCategories,
                                 const fmi3String categories[])
@@ -2518,7 +2518,7 @@ fmi3Status fmi3_setDebugLogging(fmiHandle *fmu,
     return fmu->fmi3.setDebugLogging(fmu->fmi3.fmi3Instance, loggingOn, nCategories, categories);
 }
 
-fmi3Status fmi3_getFloat64(fmiHandle *fmu,
+fmi3Status fmi3_getFloat64(fmuHandle *fmu,
                            const fmi3ValueReference valueReferences[],
                            size_t nValueReferences,
                            fmi3Float64 values[],
@@ -2532,7 +2532,7 @@ fmi3Status fmi3_getFloat64(fmiHandle *fmu,
 }
 
 
-fmi3Status fmi3_setFloat64(fmiHandle *fmu,
+fmi3Status fmi3_setFloat64(fmuHandle *fmu,
                            const fmi3ValueReference valueReferences[],
                            size_t nValueReferences,
                            const fmi3Float64 values[],
@@ -2545,7 +2545,7 @@ fmi3Status fmi3_setFloat64(fmiHandle *fmu,
                                 nValues);
 }
 
-fmi3Status fmi3_enterInitializationMode(fmiHandle *fmu,
+fmi3Status fmi3_enterInitializationMode(fmuHandle *fmu,
                                        fmi3Boolean toleranceDefined,
                                        fmi3Float64 tolerance,
                                        fmi3Float64 startTime,
@@ -2560,28 +2560,28 @@ fmi3Status fmi3_enterInitializationMode(fmiHandle *fmu,
                                             stopTime);
 }
 
-fmi3Status fmi3_exitInitializationMode(fmiHandle *fmu)
+fmi3Status fmi3_exitInitializationMode(fmuHandle *fmu)
 {
     TRACEFUNC
 
     return fmu->fmi3.exitInitializationMode(fmu->fmi3.fmi3Instance);
 }
 
-fmi3Status fmi3_terminate(fmiHandle *fmu)
+fmi3Status fmi3_terminate(fmuHandle *fmu)
 {
     TRACEFUNC
 
     return fmu->fmi3.terminate(fmu->fmi3.fmi3Instance);
 }
 
-void fmi3_freeInstance(fmiHandle *fmu)
+void fmi3_freeInstance(fmuHandle *fmu)
 {
     TRACEFUNC
 
     fmu->fmi3.freeInstance(fmu->fmi3.fmi3Instance);
 }
 
-fmi3Status fmi3_doStep(fmiHandle *fmu,
+fmi3Status fmi3_doStep(fmuHandle *fmu,
                        fmi3Float64 currentCommunicationPoint,
                        fmi3Float64 communicationStepSize,
                        fmi3Boolean noSetFMUStatePriorToCurrentPoint,
@@ -2601,89 +2601,89 @@ fmi3Status fmi3_doStep(fmiHandle *fmu,
                             lastSuccessfulTime);
 }
 
-const char *fmi3_modelName(fmiHandle *fmu)
+const char *fmi3_modelName(fmuHandle *fmu)
 {
     return fmu->fmi3.modelName;
 }
 
-const char* fmi3_instantiationToken(fmiHandle *fmu)
+const char* fmi3_instantiationToken(fmuHandle *fmu)
 {
 
     return fmu->fmi3.instantiationToken;
 }
 
-const char* fmi3_description(fmiHandle *fmu)
+const char* fmi3_description(fmuHandle *fmu)
 {
 
     return fmu->fmi3.description;
 }
 
-const char* fmi3_author(fmiHandle *fmu)
+const char* fmi3_author(fmuHandle *fmu)
 {
 
     return fmu->fmi3.author;
 }
 
-const char* fmi3_version(fmiHandle *fmu)
+const char* fmi3_version(fmuHandle *fmu)
 {
     return fmu->fmi3.version;
 }
 
-const char* fmi3_copyright(fmiHandle *fmu)
+const char* fmi3_copyright(fmuHandle *fmu)
 {
 
     return fmu->fmi3.copyright;
 }
 
-const char* fmi3_license(fmiHandle *fmu)
+const char* fmi3_license(fmuHandle *fmu)
 {
 
     return fmu->fmi3.license;
 }
 
-const char* fmi3_generationTool(fmiHandle *fmu)
+const char* fmi3_generationTool(fmuHandle *fmu)
 {
     TRACEFUNC
 
     return fmu->fmi3.generationTool;
 }
 
-const char* fmi3_generationDateAndTime(fmiHandle *fmu)
+const char* fmi3_generationDateAndTime(fmuHandle *fmu)
 {
     TRACEFUNC
 
     return fmu->fmi3.generationDateAndTime;
 }
 
-const char* fmi3_variableNamingConvention(fmiHandle *fmu)
+const char* fmi3_variableNamingConvention(fmuHandle *fmu)
 {
     TRACEFUNC
 
     return fmu->fmi3.variableNamingConvention;
 }
 
-bool fmi3_supportsCoSimulation(fmiHandle *fmu)
+bool fmi3_supportsCoSimulation(fmuHandle *fmu)
 {
     TRACEFUNC
 
     return fmu->fmi3.supportsCoSimulation;
 }
 
-bool fmi3_supportsModelExchange(fmiHandle *fmu)
+bool fmi3_supportsModelExchange(fmuHandle *fmu)
 {
     TRACEFUNC
 
     return fmu->fmi3.supportsModelExchange;
 }
 
-bool fmi3_supportsScheduledExecution(fmiHandle *fmu)
+bool fmi3_supportsScheduledExecution(fmuHandle *fmu)
 {
     TRACEFUNC
 
     return fmu->fmi3.supportsScheduledExecution;
 }
 
-const char *fmi2_getTypesPlatform(fmiHandle *fmu)
+const char *fmi2_getTypesPlatform(fmuHandle *fmu)
 {
     TRACEFUNC
 
@@ -2691,41 +2691,40 @@ const char *fmi2_getTypesPlatform(fmiHandle *fmu)
 }
 
 // this function returns the fmiVersion (e.g) fmiVersion = 2.0
-const char *fmi2_getFmiVersion(fmiHandle *fmu)
+const char *fmi2_getFmiVersion(fmuHandle *fmu)
 {
     TRACEFUNC
     return fmu->fmi2.fmiVersion_;
 }
 
 // this function returns the optional model version from the <fmiModeldescription>
-const char *fmi2_getVersion(fmiHandle *fmu)
+const char *fmi2_getVersion(fmuHandle *fmu)
 {
     TRACEFUNC
     return fmu->fmi2.version;
 }
 
-fmi2Status fmi2_setDebugLogging(fmiHandle *fmu, fmi2Component comp, fmi2Boolean loggingOn, size_t nCategories, const fmi2String categories[])
+fmi2Status fmi2_setDebugLogging(fmi2InstanceHandle *instance, fmi2Boolean loggingOn, size_t nCategories, const fmi2String categories[])
 {
     TRACEFUNC
-
-    return fmu->fmi2.setDebugLogging(comp, loggingOn, nCategories, categories);
+    return instance->fmu->fmi2.setDebugLogging(instance, loggingOn, nCategories, categories);
 }
 
-fmi2Component fmi2_instantiate(fmiHandle *fmu, fmi2Type type, fmi2CallbackLogger logger, fmi2CallbackAllocateMemory allocateMemory, fmi2CallbackFreeMemory freeMemory, fmi2StepFinished stepFinished, fmi2ComponentEnvironment componentEnvironment, fmi2Boolean visible, fmi2Boolean loggingOn)
+fmi2InstanceHandle *fmi2_instantiate(fmuHandle *fmu, fmi2Type type, fmi2CallbackLogger logger, fmi2CallbackAllocateMemory allocateMemory, fmi2CallbackFreeMemory freeMemory, fmi2StepFinished stepFinished, fmi2ComponentEnvironment componentEnvironment, fmi2Boolean visible, fmi2Boolean loggingOn)
 {
     TRACEFUNC
     if(type == fmi2CoSimulation && !fmu->fmi2.supportsCoSimulation) {
         fmi4c_printMessage("FMI for co-simulation is not supported by this FMU.");
-        return false;
+        return NULL;
     }
     else if(type == fmi2ModelExchange && !fmu->fmi2.supportsModelExchange) {
         fmi4c_printMessage("FMI for model exchange is not supported by this FMU.");
-        return false;
+        return NULL;
     }
 
     if(!loadFunctionsFmi2(fmu, type)) {
         fmi4c_printMessage("Failed to load functions for FMI 2.");
-        return false;
+        return NULL;
     }
 
     fmu->fmi2.callbacks.logger = logger;
@@ -2734,64 +2733,68 @@ fmi2Component fmi2_instantiate(fmiHandle *fmu, fmi2Type type, fmi2CallbackLogger
     fmu->fmi2.callbacks.stepFinished = stepFinished;
     fmu->fmi2.callbacks.componentEnvironment = componentEnvironment;
 
-    // printf("  FMIVersion:         %s\n", fmu->fmi2.fmiVersion_);
+    // printf("  FMIVersion:         %s\n", instance->fmu->fmi2.fmiVersion_);
     // printf("  instanceName:       %s\n", fmu->instanceName);
-    // printf("  GUID:               %s\n", fmu->fmi2.guid);
+    // printf("  GUID:               %s\n", instance->fmu->fmi2.guid);
     // printf("  unzipped location:  %s\n", fmu->unzippedLocation);
     // printf("  resources location: %s\n", fmu->resourcesLocation);
 
     fmi2Component comp = fmu->fmi2.instantiate(fmu->instanceName, type, fmu->fmi2.guid, fmu->resourcesLocation, &fmu->fmi2.callbacks, visible, loggingOn);
-    return comp;
+    fmi2InstanceHandle *handle = calloc(1, sizeof(fmi2InstanceHandle));
+    handle->component = comp;
+    handle->fmu = (struct fmuHandle*)fmu;
+
+    return handle;
 }
 
-void fmi2_freeInstance(fmiHandle *fmu, fmi2Component comp)
+void fmi2_freeInstance(fmi2InstanceHandle *instance)
 {
     TRACEFUNC
 
-    fmu->fmi2.freeInstance(comp);
+    instance->fmu->fmi2.freeInstance(instance->component);
 }
 
-fmi2Status fmi2_setupExperiment(fmiHandle *fmu, fmi2Component comp, fmi2Boolean toleranceDefined, fmi2Real tolerance, fmi2Real startTime, fmi2Boolean stopTimeDefined, fmi2Real stopTime)
+fmi2Status fmi2_setupExperiment(fmi2InstanceHandle *instance, fmi2Boolean toleranceDefined, fmi2Real tolerance, fmi2Real startTime, fmi2Boolean stopTimeDefined, fmi2Real stopTime)
 {
     TRACEFUNC
 
-    return fmu->fmi2.setupExperiment(comp, toleranceDefined, tolerance, startTime, stopTimeDefined, stopTime);
+    return instance->fmu->fmi2.setupExperiment(instance->component, toleranceDefined, tolerance, startTime, stopTimeDefined, stopTime);
 }
 
-fmi2Status fmi2_enterInitializationMode(fmiHandle *fmu, fmi2Component comp)
+fmi2Status fmi2_enterInitializationMode(fmi2InstanceHandle *instance)
 {
     TRACEFUNC
 
-    return fmu->fmi2.enterInitializationMode(comp);
+    return instance->fmu->fmi2.enterInitializationMode(instance->component);
 }
 
-fmi2Status fmi2_exitInitializationMode(fmiHandle *fmu, fmi2Component comp)
+fmi2Status fmi2_exitInitializationMode(fmi2InstanceHandle *instance)
 {
     TRACEFUNC
 
-    return fmu->fmi2.exitInitializationMode(comp);
+    return instance->fmu->fmi2.exitInitializationMode(instance->component);
 }
 
-fmi2Status fmi2_terminate(fmiHandle *fmu, fmi2Component comp)
+fmi2Status fmi2_terminate(fmi2InstanceHandle *instance)
 {
     TRACEFUNC
 
-    return fmu->fmi2.terminate(comp);
+    return instance->fmu->fmi2.terminate(instance->component);
 }
 
-fmi2Status fmi2_reset(fmiHandle *fmu, fmi2Component comp)
+fmi2Status fmi2_reset(fmi2InstanceHandle *instance)
 {
     TRACEFUNC
 
-    return fmu->fmi2.reset(comp);
+    return instance->fmu->fmi2.reset(instance->component);
 }
 
-int fmi2_getNumberOfUnits(fmiHandle *fmu)
+int fmi2_getNumberOfUnits(fmuHandle *fmu)
 {
     return fmu->fmi2.numberOfUnits;
 }
 
-fmi2UnitHandle *fmi2_getUnitByIndex(fmiHandle *fmu, int i)
+fmi2UnitHandle *fmi2_getUnitByIndex(fmuHandle *fmu, int i)
 {
     return &fmu->fmi2.units[i];
 }
@@ -2850,7 +2853,7 @@ void fmi2_getDisplayUnitByIndex(fmi2UnitHandle *unit, int id, const char **name,
     *offset = unit->displayUnits[id].offset;
 }
 
-int fmi3_getNumberOfVariables(fmiHandle *fmu)
+int fmi3_getNumberOfVariables(fmuHandle *fmu)
 {
     TRACEFUNC
 
@@ -3020,477 +3023,477 @@ fmi3ValueReference fmi3_getVariableValueReference(fmi3VariableHandle *var)
     return var->valueReference;
 }
 
-fmi3Status fmi3_enterEventMode(fmiHandle *fmu)
+fmi3Status fmi3_enterEventMode(fmuHandle *fmu)
 {
     return fmu->fmi3.enterEventMode(fmu->fmi3.fmi3Instance);
 }
 
-fmi3Status fmi3_reset(fmiHandle *fmu)
+fmi3Status fmi3_reset(fmuHandle *fmu)
 {
     TRACEFUNC
 
     return fmu->fmi3.reset(fmu->fmi3.fmi3Instance);
 }
 
-fmi3Status fmi3_getFloat32(fmiHandle *fmu, const fmi3ValueReference valueReferences[], size_t nValueReferences, fmi3Float32 values[], size_t nValues)
+fmi3Status fmi3_getFloat32(fmuHandle *fmu, const fmi3ValueReference valueReferences[], size_t nValueReferences, fmi3Float32 values[], size_t nValues)
 {
 
     return fmu->fmi3.getFloat32(fmu->fmi3.fmi3Instance, valueReferences, nValueReferences, values, nValues);
 }
 
-fmi3Status fmi3_getInt8(fmiHandle *fmu, const fmi3ValueReference valueReferences[], size_t nValueReferences, fmi3Int8 values[], size_t nValues)
+fmi3Status fmi3_getInt8(fmuHandle *fmu, const fmi3ValueReference valueReferences[], size_t nValueReferences, fmi3Int8 values[], size_t nValues)
 {
 
     return fmu->fmi3.getInt8(fmu->fmi3.fmi3Instance, valueReferences, nValueReferences, values, nValues);
 }
 
-fmi3Status fmi3_getUInt8(fmiHandle *fmu, const fmi3ValueReference valueReferences[], size_t nValueReferences, fmi3UInt8 values[], size_t nValues)
+fmi3Status fmi3_getUInt8(fmuHandle *fmu, const fmi3ValueReference valueReferences[], size_t nValueReferences, fmi3UInt8 values[], size_t nValues)
 {
 
     return fmu->fmi3.getUInt8(fmu->fmi3.fmi3Instance, valueReferences, nValueReferences, values, nValues);
 }
 
-fmi3Status fmi3_getInt16(fmiHandle *fmu, const fmi3ValueReference valueReferences[], size_t nValueReferences, fmi3Int16 values[], size_t nValues)
+fmi3Status fmi3_getInt16(fmuHandle *fmu, const fmi3ValueReference valueReferences[], size_t nValueReferences, fmi3Int16 values[], size_t nValues)
 {
 
     return fmu->fmi3.getInt16(fmu->fmi3.fmi3Instance, valueReferences, nValueReferences, values, nValues);
 }
 
-fmi3Status fmi3_getUInt16(fmiHandle *fmu, const fmi3ValueReference valueReferences[], size_t nValueReferences, fmi3UInt16 values[], size_t nValues)
+fmi3Status fmi3_getUInt16(fmuHandle *fmu, const fmi3ValueReference valueReferences[], size_t nValueReferences, fmi3UInt16 values[], size_t nValues)
 {
 
     return fmu->fmi3.getUInt16(fmu->fmi3.fmi3Instance, valueReferences, nValueReferences, values, nValues);
 }
 
-fmi3Status fmi3_getInt32(fmiHandle *fmu, const fmi3ValueReference valueReferences[], size_t nValueReferences, fmi3Int32 values[], size_t nValues)
+fmi3Status fmi3_getInt32(fmuHandle *fmu, const fmi3ValueReference valueReferences[], size_t nValueReferences, fmi3Int32 values[], size_t nValues)
 {
 
     return fmu->fmi3.getInt32(fmu->fmi3.fmi3Instance, valueReferences, nValueReferences, values, nValues);
 }
 
-fmi3Status fmi3_getUInt32(fmiHandle *fmu, const fmi3ValueReference valueReferences[], size_t nValueReferences, fmi3UInt32 values[], size_t nValues)
+fmi3Status fmi3_getUInt32(fmuHandle *fmu, const fmi3ValueReference valueReferences[], size_t nValueReferences, fmi3UInt32 values[], size_t nValues)
 {
 
     return fmu->fmi3.getUInt32(fmu->fmi3.fmi3Instance, valueReferences, nValueReferences, values, nValues);
 }
 
-fmi3Status fmi3_getInt64(fmiHandle *fmu, const fmi3ValueReference valueReferences[], size_t nValueReferences, fmi3Int64 values[], size_t nValues)
+fmi3Status fmi3_getInt64(fmuHandle *fmu, const fmi3ValueReference valueReferences[], size_t nValueReferences, fmi3Int64 values[], size_t nValues)
 {
 
     return fmu->fmi3.getInt64(fmu->fmi3.fmi3Instance, valueReferences, nValueReferences, values, nValues);
 }
 
-fmi3Status fmi3_getUInt64(fmiHandle *fmu, const fmi3ValueReference valueReferences[], size_t nValueReferences, fmi3UInt64 values[], size_t nValues)
+fmi3Status fmi3_getUInt64(fmuHandle *fmu, const fmi3ValueReference valueReferences[], size_t nValueReferences, fmi3UInt64 values[], size_t nValues)
 {
 
     return fmu->fmi3.getUInt64(fmu->fmi3.fmi3Instance, valueReferences, nValueReferences, values, nValues);
 }
 
-fmi3Status fmi3_getBoolean(fmiHandle *fmu, const fmi3ValueReference valueReferences[], size_t nValueReferences, fmi3Boolean values[], size_t nValues)
+fmi3Status fmi3_getBoolean(fmuHandle *fmu, const fmi3ValueReference valueReferences[], size_t nValueReferences, fmi3Boolean values[], size_t nValues)
 {
 
     return fmu->fmi3.getBoolean(fmu->fmi3.fmi3Instance, valueReferences, nValueReferences, values, nValues);
 }
 
-fmi3Status fmi3_getString(fmiHandle *fmu, const fmi3ValueReference valueReferences[], size_t nValueReferences, fmi3String values[], size_t nValues)
+fmi3Status fmi3_getString(fmuHandle *fmu, const fmi3ValueReference valueReferences[], size_t nValueReferences, fmi3String values[], size_t nValues)
 {
 
     return fmu->fmi3.getString(fmu->fmi3.fmi3Instance, valueReferences, nValueReferences, values, nValues);
 }
 
-fmi3Status fmi3_getBinary(fmiHandle *fmu, const fmi3ValueReference valueReferences[], size_t nValueReferences, size_t valueSizes[], fmi3Binary values[], size_t nValues)
+fmi3Status fmi3_getBinary(fmuHandle *fmu, const fmi3ValueReference valueReferences[], size_t nValueReferences, size_t valueSizes[], fmi3Binary values[], size_t nValues)
 {
 
     return fmu->fmi3.getBinary(fmu->fmi3.fmi3Instance, valueReferences, nValueReferences, valueSizes, values, nValues);
 }
 
-fmi3Status fmi3_getClock(fmiHandle *fmu, const fmi3ValueReference valueReferences[], size_t nValueReferences, fmi3Clock values[])
+fmi3Status fmi3_getClock(fmuHandle *fmu, const fmi3ValueReference valueReferences[], size_t nValueReferences, fmi3Clock values[])
 {
 
     return fmu->fmi3.getClock(fmu->fmi3.fmi3Instance, valueReferences, nValueReferences, values);
 }
 
-fmi3Status fmi3_setFloat32(fmiHandle *fmu, const fmi3ValueReference valueReferences[], size_t nValueReferences, const fmi3Float32 values[], size_t nValues)
+fmi3Status fmi3_setFloat32(fmuHandle *fmu, const fmi3ValueReference valueReferences[], size_t nValueReferences, const fmi3Float32 values[], size_t nValues)
 {
 
     return fmu->fmi3.setFloat32(fmu->fmi3.fmi3Instance, valueReferences, nValueReferences, values, nValues);
 }
 
-fmi3Status fmi3_setInt8(fmiHandle *fmu, const fmi3ValueReference valueReferences[], size_t nValueReferences, const fmi3Int8 values[], size_t nValues)
+fmi3Status fmi3_setInt8(fmuHandle *fmu, const fmi3ValueReference valueReferences[], size_t nValueReferences, const fmi3Int8 values[], size_t nValues)
 {
 
     return fmu->fmi3.setInt8(fmu->fmi3.fmi3Instance, valueReferences, nValueReferences, values, nValues);
 }
 
-fmi3Status fmi3_setUInt8(fmiHandle *fmu, const fmi3ValueReference valueReferences[], size_t nValueReferences, const fmi3UInt8 values[], size_t nValues)
+fmi3Status fmi3_setUInt8(fmuHandle *fmu, const fmi3ValueReference valueReferences[], size_t nValueReferences, const fmi3UInt8 values[], size_t nValues)
 {
 
     return fmu->fmi3.setUInt8(fmu->fmi3.fmi3Instance, valueReferences, nValueReferences, values, nValues);
 }
 
-fmi3Status fmi3_setInt16(fmiHandle *fmu, const fmi3ValueReference valueReferences[], size_t nValueReferences, const fmi3Int16 values[], size_t nValues)
+fmi3Status fmi3_setInt16(fmuHandle *fmu, const fmi3ValueReference valueReferences[], size_t nValueReferences, const fmi3Int16 values[], size_t nValues)
 {
 
     return fmu->fmi3.setInt16(fmu->fmi3.fmi3Instance, valueReferences, nValueReferences, values, nValues);
 }
 
-fmi3Status fmi3_setUInt16(fmiHandle *fmu, const fmi3ValueReference valueReferences[], size_t nValueReferences, const fmi3UInt16 values[], size_t nValues)
+fmi3Status fmi3_setUInt16(fmuHandle *fmu, const fmi3ValueReference valueReferences[], size_t nValueReferences, const fmi3UInt16 values[], size_t nValues)
 {
 
     return fmu->fmi3.setUInt16(fmu->fmi3.fmi3Instance, valueReferences, nValueReferences, values, nValues);
 }
 
-fmi3Status fmi3_setInt32(fmiHandle *fmu, const fmi3ValueReference valueReferences[], size_t nValueReferences, const fmi3Int32 values[], size_t nValues)
+fmi3Status fmi3_setInt32(fmuHandle *fmu, const fmi3ValueReference valueReferences[], size_t nValueReferences, const fmi3Int32 values[], size_t nValues)
 {
 
     return fmu->fmi3.setInt32(fmu->fmi3.fmi3Instance, valueReferences, nValueReferences, values, nValues);
 }
 
-fmi3Status fmi3_setUInt32(fmiHandle *fmu, const fmi3ValueReference valueReferences[], size_t nValueReferences, const fmi3UInt32 values[], size_t nValues)
+fmi3Status fmi3_setUInt32(fmuHandle *fmu, const fmi3ValueReference valueReferences[], size_t nValueReferences, const fmi3UInt32 values[], size_t nValues)
 {
 
     return fmu->fmi3.setUInt32(fmu->fmi3.fmi3Instance, valueReferences, nValueReferences, values, nValues);
 }
 
-fmi3Status fmi3_setInt64(fmiHandle *fmu, const fmi3ValueReference valueReferences[], size_t nValueReferences, const fmi3Int64 values[], size_t nValues)
+fmi3Status fmi3_setInt64(fmuHandle *fmu, const fmi3ValueReference valueReferences[], size_t nValueReferences, const fmi3Int64 values[], size_t nValues)
 {
 
     return fmu->fmi3.setInt64(fmu->fmi3.fmi3Instance, valueReferences, nValueReferences, values, nValues);
 }
 
-fmi3Status fmi3_setUInt64(fmiHandle *fmu, const fmi3ValueReference valueReferences[], size_t nValueReferences, const fmi3UInt64 values[], size_t nValues)
+fmi3Status fmi3_setUInt64(fmuHandle *fmu, const fmi3ValueReference valueReferences[], size_t nValueReferences, const fmi3UInt64 values[], size_t nValues)
 {
 
     return fmu->fmi3.setUInt64(fmu->fmi3.fmi3Instance, valueReferences, nValueReferences, values, nValues);
 }
 
-fmi3Status fmi3_setBoolean(fmiHandle *fmu, const fmi3ValueReference valueReferences[], size_t nValueReferences, const fmi3Boolean values[], size_t nValues)
+fmi3Status fmi3_setBoolean(fmuHandle *fmu, const fmi3ValueReference valueReferences[], size_t nValueReferences, const fmi3Boolean values[], size_t nValues)
 {
 
     return fmu->fmi3.setBoolean(fmu->fmi3.fmi3Instance, valueReferences, nValueReferences, values, nValues);
 }
 
-fmi3Status fmi3_setString(fmiHandle *fmu, const fmi3ValueReference valueReferences[], size_t nValueReferences, const fmi3String values[], size_t nValues)
+fmi3Status fmi3_setString(fmuHandle *fmu, const fmi3ValueReference valueReferences[], size_t nValueReferences, const fmi3String values[], size_t nValues)
 {
 
     return fmu->fmi3.setString(fmu->fmi3.fmi3Instance, valueReferences, nValueReferences, values, nValues);
 }
 
-fmi3Status fmi3_setBinary(fmiHandle *fmu, const fmi3ValueReference valueReferences[], size_t nValueReferences, const size_t valueSizes[], const fmi3Binary values[], size_t nValues)
+fmi3Status fmi3_setBinary(fmuHandle *fmu, const fmi3ValueReference valueReferences[], size_t nValueReferences, const size_t valueSizes[], const fmi3Binary values[], size_t nValues)
 {
 
     return fmu->fmi3.setBinary(fmu->fmi3.fmi3Instance, valueReferences, nValueReferences, valueSizes, values, nValues);
 }
 
-fmi3Status fmi3_setClock(fmiHandle *fmu, const fmi3ValueReference valueReferences[], size_t nValueReferences, const fmi3Clock values[])
+fmi3Status fmi3_setClock(fmuHandle *fmu, const fmi3ValueReference valueReferences[], size_t nValueReferences, const fmi3Clock values[])
 {
 
     return fmu->fmi3.setClock(fmu->fmi3.fmi3Instance, valueReferences, nValueReferences, values);
 }
 
-fmi3Status fmi3_getNumberOfVariableDependencies(fmiHandle *fmu, fmi3ValueReference valueReference, size_t *nDependencies)
+fmi3Status fmi3_getNumberOfVariableDependencies(fmuHandle *fmu, fmi3ValueReference valueReference, size_t *nDependencies)
 {
 
     return fmu->fmi3.getNumberOfVariableDependencies(fmu->fmi3.fmi3Instance, valueReference, nDependencies);
 }
 
-fmi3Status fmi3_getVariableDependencies(fmiHandle *fmu, fmi3ValueReference dependent, size_t elementIndicesOfDependent[], fmi3ValueReference independents[], size_t elementIndicesOfIndependents[], fmi3DependencyKind dependencyKinds[], size_t nDependencies)
+fmi3Status fmi3_getVariableDependencies(fmuHandle *fmu, fmi3ValueReference dependent, size_t elementIndicesOfDependent[], fmi3ValueReference independents[], size_t elementIndicesOfIndependents[], fmi3DependencyKind dependencyKinds[], size_t nDependencies)
 {
 
     return fmu->fmi3.getVariableDependencies(fmu->fmi3.fmi3Instance, dependent, elementIndicesOfDependent, independents, elementIndicesOfIndependents, dependencyKinds, nDependencies);
 }
 
-fmi3Status fmi3_getFMUState(fmiHandle *fmu, fmi3FMUState *FMUState)
+fmi3Status fmi3_getFMUState(fmuHandle *fmu, fmi3FMUState *FMUState)
 {
 
     return fmu->fmi3.getFMUState(fmu->fmi3.fmi3Instance, FMUState);
 }
 
-fmi3Status fmi3_setFMUState(fmiHandle *fmu, fmi3FMUState FMUState)
+fmi3Status fmi3_setFMUState(fmuHandle *fmu, fmi3FMUState FMUState)
 {
 
     return fmu->fmi3.setFMUState(fmu->fmi3.fmi3Instance, FMUState);
 }
 
-fmi3Status fmi3_freeFMUState(fmiHandle *fmu, fmi3FMUState *FMUState)
+fmi3Status fmi3_freeFMUState(fmuHandle *fmu, fmi3FMUState *FMUState)
 {
 
     return fmu->fmi3.freeFMUState(fmu->fmi3.fmi3Instance, FMUState);
 }
 
-fmi3Status fmi3_serializedFMUStateSize(fmiHandle *fmu, fmi3FMUState FMUState, size_t *size)
+fmi3Status fmi3_serializedFMUStateSize(fmuHandle *fmu, fmi3FMUState FMUState, size_t *size)
 {
 
     return fmu->fmi3.serializedFMUStateSize(fmu->fmi3.fmi3Instance, FMUState, size);
 }
 
-fmi3Status fmi3_serializeFMUState(fmiHandle *fmu, fmi3FMUState FMUState, fmi3Byte serializedState[], size_t size)
+fmi3Status fmi3_serializeFMUState(fmuHandle *fmu, fmi3FMUState FMUState, fmi3Byte serializedState[], size_t size)
 {
 
     return fmu->fmi3.serializeFMUState(fmu->fmi3.fmi3Instance, FMUState, serializedState, size);
 }
 
-fmi3Status fmi3_deserializeFMUState(fmiHandle *fmu, const fmi3Byte serializedState[], size_t size, fmi3FMUState *FMUState)
+fmi3Status fmi3_deserializeFMUState(fmuHandle *fmu, const fmi3Byte serializedState[], size_t size, fmi3FMUState *FMUState)
 {
 
     return fmu->fmi3.deserializeFMUState(fmu->fmi3.fmi3Instance, serializedState, size, FMUState);
 }
 
-fmi3Status fmi3_getDirectionalDerivative(fmiHandle *fmu, const fmi3ValueReference unknowns[], size_t nUnknowns, const fmi3ValueReference knowns[], size_t nKnowns, const fmi3Float64 seed[], size_t nSeed, fmi3Float64 sensitivity[], size_t nSensitivity)
+fmi3Status fmi3_getDirectionalDerivative(fmuHandle *fmu, const fmi3ValueReference unknowns[], size_t nUnknowns, const fmi3ValueReference knowns[], size_t nKnowns, const fmi3Float64 seed[], size_t nSeed, fmi3Float64 sensitivity[], size_t nSensitivity)
 {
 
     return fmu->fmi3.getDirectionalDerivative(fmu->fmi3.fmi3Instance, unknowns, nUnknowns, knowns, nKnowns, seed, nSeed, sensitivity, nSensitivity);
 }
 
-fmi3Status fmi3_getAdjointDerivative(fmiHandle *fmu, const fmi3ValueReference unknowns[], size_t nUnknowns, const fmi3ValueReference knowns[], size_t nKnowns, const fmi3Float64 seed[], size_t nSeed, fmi3Float64 sensitivity[], size_t nSensitivity)
+fmi3Status fmi3_getAdjointDerivative(fmuHandle *fmu, const fmi3ValueReference unknowns[], size_t nUnknowns, const fmi3ValueReference knowns[], size_t nKnowns, const fmi3Float64 seed[], size_t nSeed, fmi3Float64 sensitivity[], size_t nSensitivity)
 {
 
     return fmu->fmi3.getAdjointDerivative(fmu->fmi3.fmi3Instance, unknowns, nUnknowns, knowns, nKnowns, seed, nSeed, sensitivity, nSensitivity);
 }
 
-fmi3Status fmi3_enterConfigurationMode(fmiHandle *fmu)
+fmi3Status fmi3_enterConfigurationMode(fmuHandle *fmu)
 {
 
     return fmu->fmi3.enterConfigurationMode(fmu->fmi3.fmi3Instance);
 }
 
-fmi3Status fmi3_exitConfigurationMode(fmiHandle *fmu)
+fmi3Status fmi3_exitConfigurationMode(fmuHandle *fmu)
 {
 
     return fmu->fmi3.exitConfigurationMode(fmu->fmi3.fmi3Instance);
 }
 
-fmi3Status fmi3_getIntervalDecimal(fmiHandle *fmu, const fmi3ValueReference valueReferences[], size_t nValueReferences, fmi3Float64 intervals[], fmi3IntervalQualifier qualifiers[])
+fmi3Status fmi3_getIntervalDecimal(fmuHandle *fmu, const fmi3ValueReference valueReferences[], size_t nValueReferences, fmi3Float64 intervals[], fmi3IntervalQualifier qualifiers[])
 {
 
     return fmu->fmi3.getIntervalDecimal(fmu->fmi3.fmi3Instance, valueReferences, nValueReferences, intervals, qualifiers);
 }
 
-fmi3Status fmi3_getIntervalFraction(fmiHandle *fmu, const fmi3ValueReference valueReferences[], size_t nValueReferences, fmi3UInt64 intervalCounters[], fmi3UInt64 resolutions[], fmi3IntervalQualifier qualifiers[])
+fmi3Status fmi3_getIntervalFraction(fmuHandle *fmu, const fmi3ValueReference valueReferences[], size_t nValueReferences, fmi3UInt64 intervalCounters[], fmi3UInt64 resolutions[], fmi3IntervalQualifier qualifiers[])
 {
 
     return fmu->fmi3.getIntervalFraction(fmu->fmi3.fmi3Instance, valueReferences, nValueReferences, intervalCounters, resolutions, qualifiers);
 }
 
-fmi3Status fmi3_getShiftDecimal(fmiHandle *fmu, const fmi3ValueReference valueReferences[], size_t nValueReferences, fmi3Float64 shifts[])
+fmi3Status fmi3_getShiftDecimal(fmuHandle *fmu, const fmi3ValueReference valueReferences[], size_t nValueReferences, fmi3Float64 shifts[])
 {
 
     return fmu->fmi3.getShiftDecimal(fmu->fmi3.fmi3Instance, valueReferences, nValueReferences, shifts);
 }
 
-fmi3Status fmi3_getShiftFraction(fmiHandle *fmu, const fmi3ValueReference valueReferences[], size_t nValueReferences, fmi3UInt64 shiftCounters[], fmi3UInt64 resolutions[])
+fmi3Status fmi3_getShiftFraction(fmuHandle *fmu, const fmi3ValueReference valueReferences[], size_t nValueReferences, fmi3UInt64 shiftCounters[], fmi3UInt64 resolutions[])
 {
 
     return fmu->fmi3.getShiftFraction(fmu->fmi3.fmi3Instance, valueReferences, nValueReferences, shiftCounters, resolutions);
 }
 
-fmi3Status fmi3_setIntervalDecimal(fmiHandle *fmu, const fmi3ValueReference valueReferences[], size_t nValueReferences, const fmi3Float64 intervals[])
+fmi3Status fmi3_setIntervalDecimal(fmuHandle *fmu, const fmi3ValueReference valueReferences[], size_t nValueReferences, const fmi3Float64 intervals[])
 {
 
     return fmu->fmi3.setIntervalDecimal(fmu->fmi3.fmi3Instance, valueReferences, nValueReferences, intervals);
 }
 
-fmi3Status fmi3_setIntervalFraction(fmiHandle *fmu, const fmi3ValueReference valueReferences[], size_t nValueReferences, const fmi3UInt64 intervalCounters[], const fmi3UInt64 resolutions[])
+fmi3Status fmi3_setIntervalFraction(fmuHandle *fmu, const fmi3ValueReference valueReferences[], size_t nValueReferences, const fmi3UInt64 intervalCounters[], const fmi3UInt64 resolutions[])
 {
 
     return fmu->fmi3.setIntervalFraction(fmu->fmi3.fmi3Instance, valueReferences, nValueReferences, intervalCounters, resolutions);
 }
 
-fmi3Status fmi3_evaluateDiscreteStates(fmiHandle *fmu)
+fmi3Status fmi3_evaluateDiscreteStates(fmuHandle *fmu)
 {
 
     return fmu->fmi3.evaluateDiscreteStates(fmu->fmi3.fmi3Instance);
 }
 
-fmi3Status fmi3_updateDiscreteStates(fmiHandle *fmu, fmi3Boolean *discreteStatesNeedUpdate, fmi3Boolean *terminateSimulation, fmi3Boolean *nominalsOfContinuousStatesChanged, fmi3Boolean *valuesOfContinuousStatesChanged, fmi3Boolean *nextEventTimeDefined, fmi3Float64 *nextEventTime)
+fmi3Status fmi3_updateDiscreteStates(fmuHandle *fmu, fmi3Boolean *discreteStatesNeedUpdate, fmi3Boolean *terminateSimulation, fmi3Boolean *nominalsOfContinuousStatesChanged, fmi3Boolean *valuesOfContinuousStatesChanged, fmi3Boolean *nextEventTimeDefined, fmi3Float64 *nextEventTime)
 {
 
     return fmu->fmi3.updateDiscreteStates(fmu->fmi3.fmi3Instance, discreteStatesNeedUpdate, terminateSimulation, nominalsOfContinuousStatesChanged, valuesOfContinuousStatesChanged, nextEventTimeDefined, nextEventTime);
 }
 
-fmi3Status fmi3_enterContinuousTimeMode(fmiHandle *fmu)
+fmi3Status fmi3_enterContinuousTimeMode(fmuHandle *fmu)
 {
 
     return fmu->fmi3.enterContinuousTimeMode(fmu->fmi3.fmi3Instance);
 }
 
-fmi3Status fmi3_completedIntegratorStep(fmiHandle *fmu, fmi3Boolean noSetFMUStatePriorToCurrentPoint, fmi3Boolean *enterEventMode, fmi3Boolean *terminateSimulation)
+fmi3Status fmi3_completedIntegratorStep(fmuHandle *fmu, fmi3Boolean noSetFMUStatePriorToCurrentPoint, fmi3Boolean *enterEventMode, fmi3Boolean *terminateSimulation)
 {
 
     return fmu->fmi3.completedIntegratorStep(fmu->fmi3.fmi3Instance, noSetFMUStatePriorToCurrentPoint, enterEventMode, terminateSimulation);
 }
 
-fmi3Status fmi3_setTime(fmiHandle *fmu, fmi3Float64 time)
+fmi3Status fmi3_setTime(fmuHandle *fmu, fmi3Float64 time)
 {
 
     return fmu->fmi3.setTime(fmu->fmi3.fmi3Instance, time);
 }
 
-fmi3Status fmi3_setContinuousStates(fmiHandle *fmu, const fmi3Float64 continuousStates[], size_t nContinuousStates)
+fmi3Status fmi3_setContinuousStates(fmuHandle *fmu, const fmi3Float64 continuousStates[], size_t nContinuousStates)
 {
 
     return fmu->fmi3.setContinuousStates(fmu->fmi3.fmi3Instance, continuousStates, nContinuousStates);
 }
 
-fmi3Status fmi3_getContinuousStateDerivatives(fmiHandle *fmu, fmi3Float64 derivatives[], size_t nContinuousStates)
+fmi3Status fmi3_getContinuousStateDerivatives(fmuHandle *fmu, fmi3Float64 derivatives[], size_t nContinuousStates)
 {
 
     return fmu->fmi3.getContinuousStateDerivatives(fmu->fmi3.fmi3Instance, derivatives, nContinuousStates);
 }
 
-fmi3Status fmi3_getEventIndicators(fmiHandle *fmu, fmi3Float64 eventIndicators[], size_t nEventIndicators)
+fmi3Status fmi3_getEventIndicators(fmuHandle *fmu, fmi3Float64 eventIndicators[], size_t nEventIndicators)
 {
 
     return fmu->fmi3.getEventIndicators(fmu->fmi3.fmi3Instance, eventIndicators, nEventIndicators);
 }
 
-fmi3Status fmi3_getContinuousStates(fmiHandle *fmu, fmi3Float64 continuousStates[], size_t nContinuousStates)
+fmi3Status fmi3_getContinuousStates(fmuHandle *fmu, fmi3Float64 continuousStates[], size_t nContinuousStates)
 {
 
     return fmu->fmi3.getContinuousStates(fmu->fmi3.fmi3Instance, continuousStates, nContinuousStates);
 }
 
-fmi3Status fmi3_getNominalsOfContinuousStates(fmiHandle *fmu, fmi3Float64 nominals[], size_t nContinuousStates)
+fmi3Status fmi3_getNominalsOfContinuousStates(fmuHandle *fmu, fmi3Float64 nominals[], size_t nContinuousStates)
 {
 
     return fmu->fmi3.getNominalsOfContinuousStates(fmu->fmi3.fmi3Instance, nominals, nContinuousStates);
 }
 
-fmi3Status fmi3_getNumberOfEventIndicators(fmiHandle *fmu, size_t *nEventIndicators)
+fmi3Status fmi3_getNumberOfEventIndicators(fmuHandle *fmu, size_t *nEventIndicators)
 {
 
     return fmu->fmi3.getNumberOfEventIndicators(fmu->fmi3.fmi3Instance, nEventIndicators);
 }
 
-fmi3Status fmi3_getNumberOfContinuousStates(fmiHandle *fmu, size_t *nContinuousStates)
+fmi3Status fmi3_getNumberOfContinuousStates(fmuHandle *fmu, size_t *nContinuousStates)
 {
 
     return fmu->fmi3.getNumberOfContinuousStates(fmu->fmi3.fmi3Instance, nContinuousStates);
 }
 
-fmi3Status fmi3_enterStepMode(fmiHandle *fmu)
+fmi3Status fmi3_enterStepMode(fmuHandle *fmu)
 {
 
     return fmu->fmi3.enterStepMode(fmu->fmi3.fmi3Instance);
 }
 
-fmi3Status fmi3_getOutputDerivatives(fmiHandle *fmu, const fmi3ValueReference valueReferences[], size_t nValueReferences, const fmi3Int32 orders[], fmi3Float64 values[], size_t nValues)
+fmi3Status fmi3_getOutputDerivatives(fmuHandle *fmu, const fmi3ValueReference valueReferences[], size_t nValueReferences, const fmi3Int32 orders[], fmi3Float64 values[], size_t nValues)
 {
 
     return fmu->fmi3.getOutputDerivatives(fmu->fmi3.fmi3Instance, valueReferences, nValueReferences, orders, values, nValues);
 }
 
-fmi3Status fmi3_activateModelPartition(fmiHandle *fmu, fmi3ValueReference clockReference, fmi3Float64 activationTime)
+fmi3Status fmi3_activateModelPartition(fmuHandle *fmu, fmi3ValueReference clockReference, fmi3Float64 activationTime)
 {
 
     return fmu->fmi3.activateModelPartition(fmu->fmi3.fmi3Instance, clockReference, activationTime);
 }
 
-bool fmi3_defaultStartTimeDefined(fmiHandle *fmu)
+bool fmi3_defaultStartTimeDefined(fmuHandle *fmu)
 {
 
     return fmu->fmi3.defaultStartTimeDefined;
 }
 
-bool fmi3_defaultStopTimeDefined(fmiHandle *fmu)
+bool fmi3_defaultStopTimeDefined(fmuHandle *fmu)
 {
 
     return fmu->fmi3.defaultStopTimeDefined;
 }
 
-bool fmi3_defaultToleranceDefined(fmiHandle *fmu)
+bool fmi3_defaultToleranceDefined(fmuHandle *fmu)
 {
 
     return fmu->fmi3.defaultToleranceDefined;
 }
 
-bool fmi3_defaultStepSizeDefined(fmiHandle *fmu)
+bool fmi3_defaultStepSizeDefined(fmuHandle *fmu)
 {
 
     return fmu->fmi3.defaultStepSizeDefined;
 }
 
-double fmi3_getDefaultStartTime(fmiHandle *fmu)
+double fmi3_getDefaultStartTime(fmuHandle *fmu)
 {
 
     return fmu->fmi3.defaultStartTime;
 }
 
-double fmi3_getDefaultStopTime(fmiHandle *fmu)
+double fmi3_getDefaultStopTime(fmuHandle *fmu)
 {
 
     return fmu->fmi3.defaultStopTime;
 }
 
-double fmi3_getDefaultTolerance(fmiHandle *fmu)
+double fmi3_getDefaultTolerance(fmuHandle *fmu)
 {
 
     return fmu->fmi3.defaultTolerance;
 }
 
-double fmi3_getDefaultStepSize(fmiHandle *fmu)
+double fmi3_getDefaultStepSize(fmuHandle *fmu)
 {
 
     return fmu->fmi3.defaultStepSize;
 }
 
-bool fmi2_defaultStartTimeDefined(fmiHandle *fmu)
+bool fmi2_defaultStartTimeDefined(fmuHandle *fmu)
 {
     TRACEFUNC
 
     return fmu->fmi2.defaultStartTimeDefined;
 }
 
-bool fmi2_defaultStopTimeDefined(fmiHandle *fmu)
+bool fmi2_defaultStopTimeDefined(fmuHandle *fmu)
 {
     TRACEFUNC
 
     return fmu->fmi2.defaultStopTimeDefined;
 }
 
-bool fmi2_defaultToleranceDefined(fmiHandle *fmu)
+bool fmi2_defaultToleranceDefined(fmuHandle *fmu)
 {
     TRACEFUNC
 
     return fmu->fmi2.defaultToleranceDefined;
 }
 
-bool fmi2_defaultStepSizeDefined(fmiHandle *fmu)
+bool fmi2_defaultStepSizeDefined(fmuHandle *fmu)
 {
     TRACEFUNC
 
     return fmu->fmi2.defaultStepSizeDefined;
 }
 
-double fmi2_getDefaultStartTime(fmiHandle *fmu)
+double fmi2_getDefaultStartTime(fmuHandle *fmu)
 {
     TRACEFUNC
 
     return fmu->fmi2.defaultStartTime;
 }
 
-double fmi2_getDefaultStopTime(fmiHandle *fmu)
+double fmi2_getDefaultStopTime(fmuHandle *fmu)
 {
     TRACEFUNC
 
     return fmu->fmi2.defaultStopTime;
 }
 
-double fmi2_getDefaultTolerance(fmiHandle *fmu)
+double fmi2_getDefaultTolerance(fmuHandle *fmu)
 {
     TRACEFUNC
 
     return fmu->fmi2.defaultTolerance;
 }
 
-double fmi2_getDefaultStepSize(fmiHandle *fmu)
+double fmi2_getDefaultStepSize(fmuHandle *fmu)
 {
     TRACEFUNC
 
     return fmu->fmi2.defaultStepSize;
 }
 
-fmi3VariableHandle *fmi3_getVariableByName(fmiHandle *fmu, fmi3String name)
+fmi3VariableHandle *fmi3_getVariableByName(fmuHandle *fmu, fmi3String name)
 {
     for(int i=0; i<fmu->fmi3.numberOfVariables; ++i) {
         if(!strcmp(fmu->fmi3.variables[i].name, name)) {
@@ -3501,7 +3504,7 @@ fmi3VariableHandle *fmi3_getVariableByName(fmiHandle *fmu, fmi3String name)
     return NULL;
 }
 
-fmi3VariableHandle *fmi3_getVariableByIndex(fmiHandle *fmu, int i)
+fmi3VariableHandle *fmi3_getVariableByIndex(fmuHandle *fmu, int i)
 {
 
     if(i-1 >= fmu->fmi3.numberOfVariables || i<1) {
@@ -3511,7 +3514,7 @@ fmi3VariableHandle *fmi3_getVariableByIndex(fmiHandle *fmu, int i)
     return &fmu->fmi3.variables[i-1];
 }
 
-fmi3VariableHandle *fmi3_getVariableByValueReference(fmiHandle *fmu, fmi3ValueReference vr)
+fmi3VariableHandle *fmi3_getVariableByValueReference(fmuHandle *fmu, fmi3ValueReference vr)
 {
 
     for(int i=0; i<fmu->fmi3.numberOfVariables; ++i) {
@@ -3523,14 +3526,14 @@ fmi3VariableHandle *fmi3_getVariableByValueReference(fmiHandle *fmu, fmi3ValueRe
     return NULL;
 }
 
-int fmi2_getNumberOfVariables(fmiHandle *fmu)
+int fmi2_getNumberOfVariables(fmuHandle *fmu)
 {
     TRACEFUNC
 
     return fmu->fmi2.numberOfVariables;
 }
 
-fmi2VariableHandle *fmi2_getVariableByIndex(fmiHandle *fmu, int i)
+fmi2VariableHandle *fmi2_getVariableByIndex(fmuHandle *fmu, int i)
 {
     TRACEFUNC
 
@@ -3541,7 +3544,7 @@ fmi2VariableHandle *fmi2_getVariableByIndex(fmiHandle *fmu, int i)
     return &fmu->fmi2.variables[i-1];
 }
 
-fmi2VariableHandle *fmi2_getVariableByValueReference(fmiHandle *fmu, fmi2ValueReference vr)
+fmi2VariableHandle *fmi2_getVariableByValueReference(fmuHandle *fmu, fmi2ValueReference vr)
 {
     TRACEFUNC
 
@@ -3554,7 +3557,7 @@ fmi2VariableHandle *fmi2_getVariableByValueReference(fmiHandle *fmu, fmi2ValueRe
     return NULL;
 }
 
-fmi2VariableHandle *fmi2_getVariableByName(fmiHandle *fmu, fmi2String name)
+fmi2VariableHandle *fmi2_getVariableByName(fmuHandle *fmu, fmi2String name)
 {
     for(int i=0; i<fmu->fmi2.numberOfVariables; ++i) {
         if(!strcmp(fmu->fmi2.variables[i].name, name)) {
@@ -3583,49 +3586,49 @@ int fmi2_getVariableDerivativeIndex(fmi2VariableHandle *var)
     return var->derivative;
 }
 
-const char* fmi2_getAuthor(fmiHandle *fmu)
+const char* fmi2_getAuthor(fmuHandle *fmu)
 {
     TRACEFUNC
     return fmu->fmi2.author;
 }
 
-const char* fmi2_getModelName(fmiHandle *fmu)
+const char* fmi2_getModelName(fmuHandle *fmu)
 {
     TRACEFUNC
     return fmu->fmi2.modelName;
 }
 
-const char* fmi2_getModelDescription(fmiHandle *fmu)
+const char* fmi2_getModelDescription(fmuHandle *fmu)
 {
     TRACEFUNC
     return fmu->fmi2.description;
 }
 
-const char* fmi2_getCopyright(fmiHandle *fmu)
+const char* fmi2_getCopyright(fmuHandle *fmu)
 {
     TRACEFUNC
     return fmu->fmi2.copyright;
 }
 
-const char* fmi2_getLicense(fmiHandle *fmu)
+const char* fmi2_getLicense(fmuHandle *fmu)
 {
     TRACEFUNC
     return fmu->fmi2.license;
 }
 
-const char* fmi2_getGenerationTool(fmiHandle *fmu)
+const char* fmi2_getGenerationTool(fmuHandle *fmu)
 {
     TRACEFUNC
     return fmu->fmi2.generationTool;
 }
 
-const char* fmi2_getGenerationDateAndTime(fmiHandle *fmu)
+const char* fmi2_getGenerationDateAndTime(fmuHandle *fmu)
 {
     TRACEFUNC
     return fmu->fmi2.generationDateAndTime;
 }
 
-const char* fmi2_getVariableNamingConvention(fmiHandle *fmu)
+const char* fmi2_getVariableNamingConvention(fmuHandle *fmu)
 {
     TRACEFUNC
     return fmu->fmi2.variableNamingConvention;
@@ -3746,152 +3749,143 @@ fmi2DataType fmi2_getVariableDataType(fmi2VariableHandle *var)
     return var->datatype;
 }
 
-fmi2Status fmi2_getReal(fmiHandle *fmu,
-                        fmi2Component comp,
+fmi2Status fmi2_getReal(fmi2InstanceHandle *instance,
                         const fmi2ValueReference valueReferences[],
                         size_t nValueReferences,
                         fmi2Real values[])
 {
-    return fmu->fmi2.getReal(comp,
+    return instance->fmu->fmi2.getReal(instance->component,
                              valueReferences,
                              nValueReferences,
                              values);
 }
 
-fmi2Status fmi2_getInteger(fmiHandle *fmu,
-                           fmi2Component comp,
+fmi2Status fmi2_getInteger(fmi2InstanceHandle *instance,
                            const fmi2ValueReference valueReferences[],
                            size_t nValueReferences,
                            fmi2Integer values[])
 {
     TRACEFUNC
 
-            return fmu->fmi2.getInteger(comp,
-                                        valueReferences,
-                                        nValueReferences,
-                                        values);
+    return instance->fmu->fmi2.getInteger(instance->component,
+                                valueReferences,
+                                nValueReferences,
+                                values);
 }
 
-fmi2Status fmi2_getBoolean(fmiHandle *fmu,
-                           fmi2Component comp,
+fmi2Status fmi2_getBoolean(fmi2InstanceHandle *instance,
                            const fmi2ValueReference valueReferences[],
                            size_t nValueReferences,
                            fmi2Boolean values[])
 {
     TRACEFUNC
 
-            return fmu->fmi2.getBoolean(comp,
-                                        valueReferences,
-                                        nValueReferences,
-                                        values);
+    return instance->fmu->fmi2.getBoolean(instance->component,
+                                valueReferences,
+                                nValueReferences,
+                                values);
 }
 
-fmi2Status fmi2_getString(fmiHandle *fmu,
-                          fmi2Component comp,
+fmi2Status fmi2_getString(fmi2InstanceHandle *instance,
                           const fmi2ValueReference valueReferences[],
                           size_t nValueReferences,
                           fmi2String values[])
 {
     TRACEFUNC
 
-            return fmu->fmi2.getString(comp,
-                                       valueReferences,
-                                       nValueReferences,
-                                       values);
+    return instance->fmu->fmi2.getString(instance->component,
+                               valueReferences,
+                               nValueReferences,
+                               values);
 }
 
-fmi2Status fmi2_setReal(fmiHandle *fmu,
-                        fmi2Component comp,
+fmi2Status fmi2_setReal(fmi2InstanceHandle *instance,
                         const fmi2ValueReference valueReferences[],
                         size_t nValueReferences,
                         const fmi2Real values[])
 {
-    return fmu->fmi2.setReal(comp,
+    return instance->fmu->fmi2.setReal(instance->component,
                                valueReferences,
                                nValueReferences,
                              values);
 }
 
-fmi2Status fmi2_setInteger(fmiHandle *fmu,
-                           fmi2Component comp,
+fmi2Status fmi2_setInteger(fmi2InstanceHandle *instance,
                            const fmi2ValueReference valueReferences[],
                            size_t nValueReferences,
                            const fmi2Integer values[])
 {
     TRACEFUNC
 
-    return fmu->fmi2.setInteger(comp,
+    return instance->fmu->fmi2.setInteger(instance->component,
                                valueReferences,
                                nValueReferences,
                                values);
 }
 
-fmi2Status fmi2_setBoolean(fmiHandle *fmu,
-                           fmi2Component comp,
+fmi2Status fmi2_setBoolean(fmi2InstanceHandle *instance,
                            const fmi2ValueReference valueReferences[],
                            size_t nValueReferences,
                            const fmi2Boolean values[])
 {
     TRACEFUNC
 
-    return fmu->fmi2.setBoolean(comp,
+    return instance->fmu->fmi2.setBoolean(instance->component,
                                valueReferences,
                                nValueReferences,
                                values);
 }
 
-fmi2Status fmi2_setString(fmiHandle *fmu,
-                          fmi2Component comp,
+fmi2Status fmi2_setString(fmi2InstanceHandle *instance,
                           const fmi2ValueReference valueReferences[],
                           size_t nValueReferences,
                           const fmi2String values[])
 {
     TRACEFUNC
 
-    return fmu->fmi2.setString(comp,
+    return instance->fmu->fmi2.setString(instance->component,
                                valueReferences,
                                nValueReferences,
                                values);
 }
 
-fmi2Status fmi2_getFMUstate(fmiHandle* fmu, fmi2Component comp, fmi2FMUstate* FMUstate)
+fmi2Status fmi2_getFMUstate(fmi2InstanceHandle *instance, fmi2FMUstate* FMUstate)
 {
     TRACEFUNC
-    return fmu->fmi2.getFMUstate(comp, FMUstate);
+    return instance->fmu->fmi2.getFMUstate(instance->component, FMUstate);
 }
 
-fmi2Status fmi2_setFMUstate(fmiHandle* fmu, fmi2Component comp, fmi2FMUstate FMUstate)
+fmi2Status fmi2_setFMUstate(fmi2InstanceHandle *instance, fmi2FMUstate FMUstate)
 {
     TRACEFUNC
-    return fmu->fmi2.setFMUstate(comp, FMUstate);
+    return instance->fmu->fmi2.setFMUstate(instance->component, FMUstate);
 }
 
-fmi2Status fmi2_freeFMUstate(fmiHandle* fmu, fmi2Component comp, fmi2FMUstate* FMUstate)
+fmi2Status fmi2_freeFMUstate(fmi2InstanceHandle *instance, fmi2FMUstate* FMUstate)
 {
     TRACEFUNC
-    return fmu->fmi2.freeFMUstate(comp, FMUstate);
+    return instance->fmu->fmi2.freeFMUstate(instance->component, FMUstate);
 }
 
-fmi2Status fmi2_serializedFMUstateSize(fmiHandle* fmu, fmi2Component comp, fmi2FMUstate FMUstate, size_t* size)
+fmi2Status fmi2_serializedFMUstateSize(fmi2InstanceHandle *instance, fmi2FMUstate FMUstate, size_t* size)
 {
     TRACEFUNC
-    return fmu->fmi2.serializedFMUstateSize(comp, FMUstate, size);
+    return instance->fmu->fmi2.serializedFMUstateSize(instance->component, FMUstate, size);
 }
 
-fmi2Status fmi2_serializeFMUstate(fmiHandle* fmu, fmi2Component comp, fmi2FMUstate FMUstate, fmi2Byte serializedState[], size_t size)
+fmi2Status fmi2_serializeFMUstate(fmi2InstanceHandle *instance, fmi2FMUstate FMUstate, fmi2Byte serializedState[], size_t size)
 {
     TRACEFUNC
-    return fmu->fmi2.serializeFMUstate(comp, FMUstate, serializedState, size);
+    return instance->fmu->fmi2.serializeFMUstate(instance->component, FMUstate, serializedState, size);
 }
 
-fmi2Status fmi2_deSerializeFMUstate(fmiHandle* fmu, fmi2Component comp, const fmi2Byte serializedState[], size_t size, fmi2FMUstate* FMUstate)
+fmi2Status fmi2_deSerializeFMUstate(fmi2InstanceHandle *instance, const fmi2Byte serializedState[], size_t size, fmi2FMUstate* FMUstate)
 {
     TRACEFUNC
-    return fmu->fmi2.deSerializeFMUstate(comp, serializedState, size, FMUstate);
+    return instance->fmu->fmi2.deSerializeFMUstate(instance->component, serializedState, size, FMUstate);
 }
 
-fmi2Status fmi2_getDirectionalDerivative(fmiHandle* fmu,
-                                         fmi2Component comp,
+fmi2Status fmi2_getDirectionalDerivative(fmi2InstanceHandle *instance,
                                          const fmi2ValueReference unknownReferences[],
                                          size_t nUnknown,
                                          const fmi2ValueReference knownReferences[],
@@ -3900,7 +3894,7 @@ fmi2Status fmi2_getDirectionalDerivative(fmiHandle* fmu,
                                          fmi2Real dvUnknown[])
 {
     TRACEFUNC
-        return fmu->fmi2.getDirectionalDerivative(comp,
+        return instance->fmu->fmi2.getDirectionalDerivative(instance->component,
                                                   unknownReferences,
                                                   nUnknown,
                                                   knownReferences,
@@ -3909,314 +3903,310 @@ fmi2Status fmi2_getDirectionalDerivative(fmiHandle* fmu,
                                                   dvUnknown);
 }
 
-fmi2Status fmi2_enterEventMode(fmiHandle* fmu, fmi2Component comp)
+fmi2Status fmi2_enterEventMode(fmi2InstanceHandle *instance)
 {
     TRACEFUNC
-    return fmu->fmi2.enterEventMode(comp);
+    return instance->fmu->fmi2.enterEventMode(instance->component);
 }
 
-fmi2Status fmi2_newDiscreteStates(fmiHandle* fmu, fmi2Component comp, fmi2EventInfo* eventInfo)
+fmi2Status fmi2_newDiscreteStates(fmi2InstanceHandle *instance, fmi2EventInfo* eventInfo)
 {
     TRACEFUNC
-            return fmu->fmi2.newDiscreteStates(comp, eventInfo);
+            return instance->fmu->fmi2.newDiscreteStates(instance->component, eventInfo);
 }
 
-fmi2Status fmi2_enterContinuousTimeMode(fmiHandle* fmu, fmi2Component comp)
+fmi2Status fmi2_enterContinuousTimeMode(fmi2InstanceHandle *instance)
 {
     TRACEFUNC
-    return fmu->fmi2.enterContinuousTimeMode(comp);
+    return instance->fmu->fmi2.enterContinuousTimeMode(instance->component);
 }
 
-fmi2Status fmi2_completedIntegratorStep(fmiHandle* fmu,
-                                        fmi2Component comp,
+fmi2Status fmi2_completedIntegratorStep(fmi2InstanceHandle *instance,
                                         fmi2Boolean noSetFMUStatePriorToCurrentPoint,
                                         fmi2Boolean* enterEventMode,
                                         fmi2Boolean* terminateSimulation)
 {
     TRACEFUNC
-    return fmu->fmi2.completedIntegratorStep(comp,
+    return instance->fmu->fmi2.completedIntegratorStep(instance->component,
                                              noSetFMUStatePriorToCurrentPoint,
                                              enterEventMode,
                                              terminateSimulation);
 }
 
-fmi2Status fmi2_setTime(fmiHandle* fmu, fmi2Component comp, fmi2Real time)
+fmi2Status fmi2_setTime(fmi2InstanceHandle *instance, fmi2Real time)
 {
     TRACEFUNC
-    return fmu->fmi2.setTime(comp, time);
+    return instance->fmu->fmi2.setTime(instance->component, time);
 }
 
-fmi2Status fmi2_setContinuousStates(fmiHandle* fmu,
-                                    fmi2Component comp,
+fmi2Status fmi2_setContinuousStates(fmi2InstanceHandle *instance,
                                     const fmi2Real x[],
                                     size_t nx)
 {
     TRACEFUNC
-    return fmu->fmi2.setContinuousStates(comp, x, nx);
+    return instance->fmu->fmi2.setContinuousStates(instance->component, x, nx);
 }
 
-fmi2Status fmi2_getDerivatives(fmiHandle* fmu, fmi2Component comp, fmi2Real derivatives[], size_t nx)
+fmi2Status fmi2_getDerivatives(fmi2InstanceHandle *instance, fmi2Real derivatives[], size_t nx)
 {
     TRACEFUNC
-    return fmu->fmi2.getDerivatives(comp, derivatives, nx);
+    return instance->fmu->fmi2.getDerivatives(instance->component, derivatives, nx);
 }
 
-fmi2Status fmi2_getEventIndicators(fmiHandle* fmu, fmi2Component comp, fmi2Real eventIndicators[], size_t ni)
+fmi2Status fmi2_getEventIndicators(fmi2InstanceHandle *instance, fmi2Real eventIndicators[], size_t ni)
 {
     TRACEFUNC
-    return fmu->fmi2.getEventIndicators(comp, eventIndicators, ni);
+    return instance->fmu->fmi2.getEventIndicators(instance->component, eventIndicators, ni);
 }
 
-fmi2Status fmi2_getContinuousStates(fmiHandle* fmu, fmi2Component comp, fmi2Real x[], size_t nx)
+fmi2Status fmi2_getContinuousStates(fmi2InstanceHandle *instance, fmi2Real x[], size_t nx)
 {
     TRACEFUNC
-    return fmu->fmi2.getContinuousStates(comp, x, nx);
+    return instance->fmu->fmi2.getContinuousStates(instance->component, x, nx);
 }
 
-fmi2Status fmi2_getNominalsOfContinuousStates(fmiHandle* fmu, fmi2Component comp, fmi2Real x_nominal[], size_t nx)
+fmi2Status fmi2_getNominalsOfContinuousStates(fmi2InstanceHandle *instance, fmi2Real x_nominal[], size_t nx)
 {
     TRACEFUNC
-    return fmu->fmi2.getNominalsOfContinuousStates(comp, x_nominal, nx);
+    return instance->fmu->fmi2.getNominalsOfContinuousStates(instance->component, x_nominal, nx);
 }
 
 
-fmi2Status fmi2_setRealInputDerivatives(fmiHandle* fmu,
-                                        fmi2Component comp,
+fmi2Status fmi2_setRealInputDerivatives(fmi2InstanceHandle *instance,
                                         const fmi2ValueReference vr[],
                                         size_t nvr,
                                         const fmi2Integer order[],
                                         const fmi2Real value[])
 {
     TRACEFUNC
-    return fmu->fmi2.setRealInputDerivatives(comp, vr, nvr, order, value);
+    return instance->fmu->fmi2.setRealInputDerivatives(instance->component, vr, nvr, order, value);
 }
 
-fmi2Status fmi2_getRealOutputDerivatives (fmiHandle* fmu,
-                                          fmi2Component comp,
+fmi2Status fmi2_getRealOutputDerivatives (fmi2InstanceHandle *instance,
                                           const fmi2ValueReference vr[],
                                           size_t nvr,
                                           const fmi2Integer order[],
                                           fmi2Real value[])
 {
     TRACEFUNC
-    return fmu->fmi2.getRealOutputDerivatives(comp, vr, nvr, order, value);
+    return instance->fmu->fmi2.getRealOutputDerivatives(instance->component, vr, nvr, order, value);
 }
 
-fmi2Status fmi2_doStep(fmiHandle *fmu, fmi2Component comp, fmi2Real currentCommunicationPoint, fmi2Real communicationStepSize, fmi2Boolean noSetFMUStatePriorToCurrentPoint)
+fmi2Status fmi2_doStep(fmi2InstanceHandle *instance, fmi2Real currentCommunicationPoint, fmi2Real communicationStepSize, fmi2Boolean noSetFMUStatePriorToCurrentPoint)
 {
     TRACEFUNC
-    return fmu->fmi2.doStep(comp,
-                            currentCommunicationPoint,
-                            communicationStepSize,
-                            noSetFMUStatePriorToCurrentPoint);
+    return instance->fmu->fmi2.doStep(instance->component,
+                                      currentCommunicationPoint,
+                                      communicationStepSize,
+                                      noSetFMUStatePriorToCurrentPoint);
 }
 
-fmi2Status fmi2_cancelStep(fmiHandle* fmu)
+fmi2Status fmi2_cancelStep(fmi2InstanceHandle *instance)
 {
     TRACEFUNC
-    return fmu->fmi2.cancelStep(fmu);
+    return instance->fmu->fmi2.cancelStep(instance->fmu);
 }
 
-fmi2Status fmi2_getStatus(fmiHandle* fmu, const fmi2StatusKind s, fmi2Status* value)
+fmi2Status fmi2_getStatus(fmi2InstanceHandle *instance, const fmi2StatusKind s, fmi2Status* value)
 {
     TRACEFUNC
-    return fmu->fmi2.getStatus(fmu, s, value);
+    return instance->fmu->fmi2.getStatus(instance, s, value);
 }
 
-fmi2Status fmi2_getRealStatus(fmiHandle* fmu, const fmi2StatusKind s, fmi2Real* value)
+fmi2Status fmi2_getRealStatus(fmi2InstanceHandle *instance, const fmi2StatusKind s, fmi2Real* value)
 {
     TRACEFUNC
-    return fmu->fmi2.getRealStatus(fmu, s, value);
+    return instance->fmu->fmi2.getRealStatus(instance, s, value);
 }
 
-fmi2Status fmi2_getIntegerStatus(fmiHandle* fmu, const fmi2StatusKind s, fmi2Integer* value)
+fmi2Status fmi2_getIntegerStatus(fmi2InstanceHandle *instance, const fmi2StatusKind s, fmi2Integer* value)
 {
     TRACEFUNC
-    return fmu->fmi2.getIntegerStatus(fmu, s, value);
+    return instance->fmu->fmi2.getIntegerStatus(instance, s, value);
 }
 
-fmi2Status fmi2_getBooleanStatus(fmiHandle* fmu, const fmi2StatusKind s, fmi2Boolean* value)
+fmi2Status fmi2_getBooleanStatus(fmi2InstanceHandle *instance, const fmi2StatusKind s, fmi2Boolean* value)
 {
     TRACEFUNC
-    return fmu->fmi2.getBooleanStatus(fmu, s, value);
+    return instance->fmu->fmi2.getBooleanStatus(instance, s, value);
 }
 
-fmi2Status fmi2_getStringStatus(fmiHandle* fmu, const fmi2StatusKind s, fmi2String* value)
+fmi2Status fmi2_getStringStatus(fmi2InstanceHandle *instance, const fmi2StatusKind s, fmi2String* value)
 {
     TRACEFUNC
-    return fmu->fmi2.getStringStatus(fmu, s, value);
+    return instance->fmu->fmi2.getStringStatus(instance, s, value);
 }
 
-const char *fmi2_getGuid(fmiHandle *fmu)
+const char *fmi2_getGuid(fmuHandle *fmu)
 {
     TRACEFUNC
     return fmu->fmi2.guid;
 }
 
-const char *fmi2cs_getModelIdentifier(fmiHandle *fmu)
+const char *fmi2cs_getModelIdentifier(fmuHandle *fmu)
 {
     TRACEFUNC
     return fmu->fmi2.cs.modelIdentifier;
 }
 
-const char *fmi2me_getModelIdentifier(fmiHandle *fmu)
+const char *fmi2me_getModelIdentifier(fmuHandle *fmu)
 {
     TRACEFUNC
     return fmu->fmi2.me.modelIdentifier;
 }
 
-bool fmi2me_getCompletedIntegratorStepNotNeeded(fmiHandle *fmu)
+bool fmi2me_getCompletedIntegratorStepNotNeeded(fmuHandle *fmu)
 {
     TRACEFUNC
     return fmu->fmi2.me.completedIntegratorStepNotNeeded;
 }
 
-bool fmi2cs_getNeedsExecutionTool(fmiHandle *fmu)
+bool fmi2cs_getNeedsExecutionTool(fmuHandle *fmu)
 {
     TRACEFUNC
     return fmu->fmi2.cs.needsExecutionTool;
 }
 
-bool fmi2me_getNeedsExecutionTool(fmiHandle *fmu)
+bool fmi2me_getNeedsExecutionTool(fmuHandle *fmu)
 {
     TRACEFUNC
     return fmu->fmi2.me.needsExecutionTool;
 }
 
-bool fmi2cs_getCanHandleVariableCommunicationStepSize(fmiHandle *fmu)
+bool fmi2cs_getCanHandleVariableCommunicationStepSize(fmuHandle *fmu)
 {
     TRACEFUNC
     return fmu->fmi2.cs.canHandleVariableCommunicationStepSize;
 }
 
-bool fmi2cs_getCanInterpolateInputs(fmiHandle *fmu)
+bool fmi2cs_getCanInterpolateInputs(fmuHandle *fmu)
 {
     TRACEFUNC
     return fmu->fmi2.cs.canInterpolateInputs;
 }
 
-int fmi2cs_getMaxOutputDerivativeOrder(fmiHandle *fmu)
+int fmi2cs_getMaxOutputDerivativeOrder(fmuHandle *fmu)
 {
     TRACEFUNC
     return fmu->fmi2.cs.maxOutputDerivativeOrder;
 }
 
-bool fmi2cs_getCanRunAsynchronuously(fmiHandle *fmu)
+bool fmi2cs_getCanRunAsynchronuously(fmuHandle *fmu)
 {
     TRACEFUNC
     return fmu->fmi2.cs.canRunAsynchronuously;
 }
 
-bool fmi2cs_getCanBeInstantiatedOnlyOncePerProcess(fmiHandle *fmu)
+bool fmi2cs_getCanBeInstantiatedOnlyOncePerProcess(fmuHandle *fmu)
 {
     TRACEFUNC
     return fmu->fmi2.cs.canBeInstantiatedOnlyOncePerProcess;
 }
 
-bool fmi2cs_getCanNotUseMemoryManagementFunctions(fmiHandle *fmu)
+bool fmi2cs_getCanNotUseMemoryManagementFunctions(fmuHandle *fmu)
 {
     TRACEFUNC
     return fmu->fmi2.cs.canNotUseMemoryManagementFunctions;
 }
 
-bool fmi2cs_getCanGetAndSetFMUState(fmiHandle *fmu)
+bool fmi2cs_getCanGetAndSetFMUState(fmuHandle *fmu)
 {
     TRACEFUNC
     return fmu->fmi2.cs.canGetAndSetFMUState;
 }
 
-bool fmi2cs_getCanSerializeFMUState(fmiHandle *fmu)
+bool fmi2cs_getCanSerializeFMUState(fmuHandle *fmu)
 {
     TRACEFUNC
     return fmu->fmi2.cs.canSerializeFMUState;
 }
 
-bool fmi2cs_getProvidesDirectionalDerivative(fmiHandle *fmu)
+bool fmi2cs_getProvidesDirectionalDerivative(fmuHandle *fmu)
 {
     TRACEFUNC
     return fmu->fmi2.cs.providesDirectionalDerivative;
 }
 
-bool fmi2me_getCanBeInstantiatedOnlyOncePerProcess(fmiHandle *fmu)
+bool fmi2me_getCanBeInstantiatedOnlyOncePerProcess(fmuHandle *fmu)
 {
     TRACEFUNC
         return fmu->fmi2.me.canBeInstantiatedOnlyOncePerProcess;
 }
 
-bool fmi2me_getCanNotUseMemoryManagementFunctions(fmiHandle *fmu)
+bool fmi2me_getCanNotUseMemoryManagementFunctions(fmuHandle *fmu)
 {
     TRACEFUNC
         return fmu->fmi2.me.canNotUseMemoryManagementFunctions;
 }
 
-bool fmi2me_getCanGetAndSetFMUState(fmiHandle *fmu)
+bool fmi2me_getCanGetAndSetFMUState(fmuHandle *fmu)
 {
     TRACEFUNC
         return fmu->fmi2.me.canGetAndSetFMUState;
 }
 
-bool fmi2me_getCanSerializeFMUState(fmiHandle *fmu)
+bool fmi2me_getCanSerializeFMUState(fmuHandle *fmu)
 {
     TRACEFUNC
         return fmu->fmi2.me.canSerializeFMUState;
 }
 
-bool fmi2me_getProvidesDirectionalDerivative(fmiHandle *fmu)
+bool fmi2me_getProvidesDirectionalDerivative(fmuHandle *fmu)
 {
     TRACEFUNC
         return fmu->fmi2.me.providesDirectionalDerivative;
 }
 
-int fmi2_getNumberOfContinuousStates(fmiHandle *fmu)
+int fmi2_getNumberOfContinuousStates(fmuHandle *fmu)
 {
     TRACEFUNC
     return fmu->fmi2.numberOfContinuousStates;
 }
 
-int fmi2_getNumberOfEventIndicators(fmiHandle *fmu)
+int fmi2_getNumberOfEventIndicators(fmuHandle *fmu)
 {
     TRACEFUNC
     return fmu->fmi2.numberOfEventIndicators;
 }
 
-bool fmi2_getSupportsCoSimulation(fmiHandle *fmu)
+bool fmi2_getSupportsCoSimulation(fmuHandle *fmu)
 {
     TRACEFUNC
     return fmu->fmi2.supportsCoSimulation;
 }
 
-bool fmi2_getSupportsModelExchange(fmiHandle *fmu)
+bool fmi2_getSupportsModelExchange(fmuHandle *fmu)
 {
     TRACEFUNC
     return fmu->fmi2.supportsModelExchange;
 }
 
-int fmi2_getNumberOfModelStructureOutputs(fmiHandle *fmu)
+int fmi2_getNumberOfModelStructureOutputs(fmuHandle *fmu)
 {
     return fmu->fmi2.modelStructure.numberOfOutputs;
 }
 
-int fmi2_getNumberOfModelStructureDerivatives(fmiHandle *fmu)
+int fmi2_getNumberOfModelStructureDerivatives(fmuHandle *fmu)
 {
     return fmu->fmi2.modelStructure.numberOfDerivatives;
 }
 
-int fmi2_getNumberOfModelStructureInitialUnknowns(fmiHandle *fmu)
+int fmi2_getNumberOfModelStructureInitialUnknowns(fmuHandle *fmu)
 {
     return fmu->fmi2.modelStructure.numberOfInitialUnknowns;
 }
 
-fmi2ModelStructureHandle *fmi2_getModelStructureOutput(fmiHandle *fmu, size_t i)
+fmi2ModelStructureHandle *fmi2_getModelStructureOutput(fmuHandle *fmu, size_t i)
 {
     return &fmu->fmi2.modelStructure.outputs[i];
 }
 
-fmi2ModelStructureHandle *fmi2_getModelStructureDerivative(fmiHandle *fmu, size_t i)
+fmi2ModelStructureHandle *fmi2_getModelStructureDerivative(fmuHandle *fmu, size_t i)
 {
     return &fmu->fmi2.modelStructure.derivatives[i];
 }
 
-fmi2ModelStructureHandle *fmi2_getModelStructureInitialUnknown(fmiHandle *fmu, size_t i)
+fmi2ModelStructureHandle *fmi2_getModelStructureInitialUnknown(fmuHandle *fmu, size_t i)
 {
     return &fmu->fmi2.modelStructure.initialUnknowns[i];
 }
@@ -4250,205 +4240,205 @@ void fmi2_getModelStructureDependencyKinds(fmi2ModelStructureHandle *handle, int
     }
 }
 
-const char *fmi3cs_getModelIdentifier(fmiHandle *fmu)
+const char *fmi3cs_getModelIdentifier(fmuHandle *fmu)
 {
     TRACEFUNC
     return fmu->fmi3.cs.modelIdentifier;
 }
 
-const char *fmi3me_getModelIdentifier(fmiHandle *fmu)
+const char *fmi3me_getModelIdentifier(fmuHandle *fmu)
 {
     TRACEFUNC
         return fmu->fmi3.me.modelIdentifier;
 }
 
-const char *fmi3se_getModelIdentifier(fmiHandle *fmu)
+const char *fmi3se_getModelIdentifier(fmuHandle *fmu)
 {
     TRACEFUNC
         return fmu->fmi3.se.modelIdentifier;
 }
 
-bool fmi3cs_getCanHandleVariableCommunicationStepSize(fmiHandle *fmu)
+bool fmi3cs_getCanHandleVariableCommunicationStepSize(fmuHandle *fmu)
 {
     TRACEFUNC
     return fmu->fmi3.cs.canHandleVariableCommunicationStepSize;
 }
 
-bool fmi3cs_getCanReturnEarlyAfterIntermediateUpdate(fmiHandle *fmu)
+bool fmi3cs_getCanReturnEarlyAfterIntermediateUpdate(fmuHandle *fmu)
 {
     TRACEFUNC
     return fmu->fmi3.cs.canReturnEarlyAfterIntermediateUpdate;
 }
 
-double fmi3cs_getFixedInternalStepSize(fmiHandle *fmu)
+double fmi3cs_getFixedInternalStepSize(fmuHandle *fmu)
 {
     TRACEFUNC
     return fmu->fmi3.cs.fixedInternalStepSize;
 }
 
-bool fmi3cs_getHasEventMode(fmiHandle *fmu)
+bool fmi3cs_getHasEventMode(fmuHandle *fmu)
 {
     TRACEFUNC
     return fmu->fmi3.cs.hasEventMode;
 }
 
-bool fmi3cs_getNeedsExecutionTool(fmiHandle *fmu)
+bool fmi3cs_getNeedsExecutionTool(fmuHandle *fmu)
 {
     TRACEFUNC
     return fmu->fmi3.cs.needsExecutionTool;
 }
 
-bool fmi3cs_getCanBeInstantiatedOnlyOncePerProcess(fmiHandle *fmu)
+bool fmi3cs_getCanBeInstantiatedOnlyOncePerProcess(fmuHandle *fmu)
 {
     TRACEFUNC
     return fmu->fmi3.cs.canBeInstantiatedOnlyOncePerProcess;
 }
 
-bool fmi3cs_getCanGetAndSetFMUState(fmiHandle *fmu)
+bool fmi3cs_getCanGetAndSetFMUState(fmuHandle *fmu)
 {
     TRACEFUNC
     return fmu->fmi3.cs.canGetAndSetFMUState;
 }
 
-bool fmi3cs_getCanSerializeFMUState(fmiHandle *fmu)
+bool fmi3cs_getCanSerializeFMUState(fmuHandle *fmu)
 {
     TRACEFUNC
     return fmu->fmi3.cs.canSerializeFMUState;
 }
 
-bool fmi3cs_getProvidesDirectionalDerivative(fmiHandle *fmu)
+bool fmi3cs_getProvidesDirectionalDerivative(fmuHandle *fmu)
 {
     TRACEFUNC
     return fmu->fmi3.cs.providesDirectionalDerivative;
 }
 
-bool fmi3cs_getProvidesAdjointDerivatives(fmiHandle *fmu)
+bool fmi3cs_getProvidesAdjointDerivatives(fmuHandle *fmu)
 {
     TRACEFUNC
     return fmu->fmi3.cs.providesAdjointDerivatives;
 }
 
-bool fmi3cs_getProvidesPerElementDependencies(fmiHandle *fmu)
+bool fmi3cs_getProvidesPerElementDependencies(fmuHandle *fmu)
 {
     TRACEFUNC
     return fmu->fmi3.cs.providesPerElementDependencies;
 }
 
-bool fmi3me_getNeedsExecutionTool(fmiHandle *fmu)
+bool fmi3me_getNeedsExecutionTool(fmuHandle *fmu)
 {
     TRACEFUNC
         return fmu->fmi3.me.needsExecutionTool;
 }
 
-bool fmi3me_getCanBeInstantiatedOnlyOncePerProcess(fmiHandle *fmu)
+bool fmi3me_getCanBeInstantiatedOnlyOncePerProcess(fmuHandle *fmu)
 {
     TRACEFUNC
         return fmu->fmi3.me.canBeInstantiatedOnlyOncePerProcess;
 }
 
-bool fmi3me_getCanGetAndSetFMUState(fmiHandle *fmu)
+bool fmi3me_getCanGetAndSetFMUState(fmuHandle *fmu)
 {
     TRACEFUNC
         return fmu->fmi3.me.canGetAndSetFMUState;
 }
 
-bool fmi3me_getCanSerializeFMUState(fmiHandle *fmu)
+bool fmi3me_getCanSerializeFMUState(fmuHandle *fmu)
 {
     TRACEFUNC
         return fmu->fmi3.me.canSerializeFMUState;
 }
 
-bool fmi3me_getProvidesDirectionalDerivative(fmiHandle *fmu)
+bool fmi3me_getProvidesDirectionalDerivative(fmuHandle *fmu)
 {
     TRACEFUNC
         return fmu->fmi3.me.providesDirectionalDerivative;
 }
 
-bool fmi3me_getProvidesAdjointDerivatives(fmiHandle *fmu)
+bool fmi3me_getProvidesAdjointDerivatives(fmuHandle *fmu)
 {
     TRACEFUNC
         return fmu->fmi3.me.providesAdjointDerivatives;
 }
 
-bool fmi3me_getProvidesPerElementDependencies(fmiHandle *fmu)
+bool fmi3me_getProvidesPerElementDependencies(fmuHandle *fmu)
 {
     TRACEFUNC
         return fmu->fmi3.me.providesPerElementDependencies;
 }
 
-bool fmi3se_getNeedsExecutionTool(fmiHandle *fmu)
+bool fmi3se_getNeedsExecutionTool(fmuHandle *fmu)
 {
     TRACEFUNC
         return fmu->fmi3.se.needsExecutionTool;
 }
 
-bool fmi3se_getCanBeInstantiatedOnlyOncePerProcess(fmiHandle *fmu)
+bool fmi3se_getCanBeInstantiatedOnlyOncePerProcess(fmuHandle *fmu)
 {
     TRACEFUNC
         return fmu->fmi3.se.canBeInstantiatedOnlyOncePerProcess;
 }
 
-bool fmi3se_getCanGetAndSetFMUState(fmiHandle *fmu)
+bool fmi3se_getCanGetAndSetFMUState(fmuHandle *fmu)
 {
     TRACEFUNC
         return fmu->fmi3.se.canGetAndSetFMUState;
 }
 
-bool fmi3se_getCanSerializeFMUState(fmiHandle *fmu)
+bool fmi3se_getCanSerializeFMUState(fmuHandle *fmu)
 {
     TRACEFUNC
         return fmu->fmi3.se.canSerializeFMUState;
 }
 
-bool fmi3se_getProvidesDirectionalDerivative(fmiHandle *fmu)
+bool fmi3se_getProvidesDirectionalDerivative(fmuHandle *fmu)
 {
     TRACEFUNC
         return fmu->fmi3.se.providesDirectionalDerivative;
 }
 
-bool fmi3se_getProvidesAdjointDerivatives(fmiHandle *fmu)
+bool fmi3se_getProvidesAdjointDerivatives(fmuHandle *fmu)
 {
     TRACEFUNC
         return fmu->fmi3.se.providesAdjointDerivatives;
 }
 
-bool fmi3se_getProvidesPerElementDependencies(fmiHandle *fmu)
+bool fmi3se_getProvidesPerElementDependencies(fmuHandle *fmu)
 {
     TRACEFUNC
         return fmu->fmi3.se.providesPerElementDependencies;
 }
 
-int fmi3cs_getMaxOutputDerivativeOrder(fmiHandle *fmu)
+int fmi3cs_getMaxOutputDerivativeOrder(fmuHandle *fmu)
 {
     TRACEFUNC
     return fmu->fmi3.cs.maxOutputDerivativeOrder;
 }
 
-bool fmi3cs_getProvidesIntermediateUpdate(fmiHandle *fmu)
+bool fmi3cs_getProvidesIntermediateUpdate(fmuHandle *fmu)
 {
     TRACEFUNC
     return fmu->fmi3.cs.providesIntermediateUpdate;
 }
 
-bool fmi3cs_getProvidesEvaluateDiscreteStates(fmiHandle *fmu)
+bool fmi3cs_getProvidesEvaluateDiscreteStates(fmuHandle *fmu)
 {
     TRACEFUNC
     return fmu->fmi3.cs.providesEvaluateDiscreteStates;
 }
 
-bool fmi3me_getProvidesEvaluateDiscreteStates(fmiHandle *fmu)
+bool fmi3me_getProvidesEvaluateDiscreteStates(fmuHandle *fmu)
 {
     TRACEFUNC
     return fmu->fmi3.me.providesEvaluateDiscreteStates;
 }
 
-bool fmi3cs_getRecommendedIntermediateInputSmoothness(fmiHandle *fmu)
+bool fmi3cs_getRecommendedIntermediateInputSmoothness(fmuHandle *fmu)
 {
     TRACEFUNC
     return fmu->fmi3.cs.recommendedIntermediateInputSmoothness;
 }
 
-bool fmi3me_getNeedsCompletedIntegratorStep(fmiHandle *fmu)
+bool fmi3me_getNeedsCompletedIntegratorStep(fmuHandle *fmu)
 {
     TRACEFUNC
     return fmu->fmi3.me.needsCompletedIntegratorStep;
@@ -4597,9 +4587,9 @@ bool unzipFmu(const char* fmufile, const char* instanceName, const char* unzipLo
     return true;
 }
 
-fmiHandle *fmi4c_loadUnzippedFmu_internal(const char *instanceName, const char *unzipLocation, bool unzippedLocationIsTemporary)
+fmuHandle *fmi4c_loadUnzippedFmu_internal(const char *instanceName, const char *unzipLocation, bool unzippedLocationIsTemporary)
 {
-    fmiHandle *fmu = calloc(1, sizeof(fmiHandle)); // Using calloc to ensure all member pointers (and data) are initialized to NULL (0)
+    fmuHandle *fmu = calloc(1, sizeof(fmuHandle)); // Using calloc to ensure all member pointers (and data) are initialized to NULL (0)
     fmu->dll = NULL;
     fmu->numAllocatedPointers = 0;
     fmu->allocatedPointers = NULL;
@@ -4893,7 +4883,7 @@ fmiHandle *fmi4c_loadUnzippedFmu(const char *instanceName, const char *unzipLoca
 //! First unzips the FMU, then parses modelDescription.xml, and then loads all required FMI functions.
 //! @param fmu FMU handle
 //! @returns Handle to FMU
-fmiHandle *fmi4c_loadFmu(const char *fmufile, const char* instanceName)
+fmuHandle *fmi4c_loadFmu(const char *fmufile, const char* instanceName)
 {
     const char* unzipLocation = generateTempPath(instanceName);
 
@@ -4901,7 +4891,7 @@ fmiHandle *fmi4c_loadFmu(const char *fmufile, const char* instanceName)
         return NULL;
     }
 
-    fmiHandle *fmu = fmi4c_loadUnzippedFmu_internal(instanceName, unzipLocation, true);
+    fmuHandle *fmu = fmi4c_loadUnzippedFmu_internal(instanceName, unzipLocation, true);
     fmu->unzippedLocationIsTemporary = true;
     return fmu;
 }
@@ -4909,7 +4899,7 @@ fmiHandle *fmi4c_loadFmu(const char *fmufile, const char* instanceName)
 
 //! @brief Free FMU dll
 //! @param fmu FMU handle
-void fmi4c_freeFmu(fmiHandle *fmu)
+void fmi4c_freeFmu(fmuHandle *fmu)
 {
     TRACEFUNC
 
@@ -4933,107 +4923,107 @@ void fmi4c_freeFmu(fmiHandle *fmu)
     free(fmu);
 }
 
-fmi1Type fmi1_getType(fmiHandle *fmu)
+fmi1Type fmi1_getType(fmuHandle *fmu)
 {
     TRACEFUNC
     return fmu->fmi1.type;
 }
 
-const char* fmi1_getModelName(fmiHandle *fmu)
+const char* fmi1_getModelName(fmuHandle *fmu)
 {
     TRACEFUNC
     return fmu->fmi1.modelName;
 }
 
-const char* fmi1_getModelIdentifier(fmiHandle *fmu)
+const char* fmi1_getModelIdentifier(fmuHandle *fmu)
 {
     TRACEFUNC
     return fmu->fmi1.modelIdentifier;
 }
 
-const char* fmi1_getGuid(fmiHandle *fmu)
+const char* fmi1_getGuid(fmuHandle *fmu)
 {
     TRACEFUNC
     return fmu->fmi1.guid;
 }
 
-const char* fmi1_getDescription(fmiHandle *fmu)
+const char* fmi1_getDescription(fmuHandle *fmu)
 {
     TRACEFUNC
     return fmu->fmi1.description;
 }
 
-const char* fmi1_getAuthor(fmiHandle *fmu)
+const char* fmi1_getAuthor(fmuHandle *fmu)
 {
     TRACEFUNC
     return fmu->fmi1.author;
 }
 
-const char* fmi1_getGenerationTool(fmiHandle *fmu)
+const char* fmi1_getGenerationTool(fmuHandle *fmu)
 {
     TRACEFUNC
     return fmu->fmi1.generationTool;
 }
 
-const char* fmi1_getGenerationDateAndTime(fmiHandle *fmu)
+const char* fmi1_getGenerationDateAndTime(fmuHandle *fmu)
 {
     TRACEFUNC
     return fmu->fmi1.generationDateAndTime;
 }
 
-int fmi1_getNumberOfContinuousStates(fmiHandle *fmu)
+int fmi1_getNumberOfContinuousStates(fmuHandle *fmu)
 {
     return fmu->fmi1.numberOfContinuousStates;
 }
 
-int fmi1_getNumberOfEventIndicators(fmiHandle *fmu)
+int fmi1_getNumberOfEventIndicators(fmuHandle *fmu)
 {
     return fmu->fmi1.numberOfEventIndicators;
 }
 
-bool fmi1_defaultStartTimeDefined(fmiHandle *fmu)
+bool fmi1_defaultStartTimeDefined(fmuHandle *fmu)
 {
     TRACEFUNC
     return fmu->fmi1.defaultStartTimeDefined;
 }
 
-bool fmi1_defaultStopTimeDefined(fmiHandle *fmu)
+bool fmi1_defaultStopTimeDefined(fmuHandle *fmu)
 {
     TRACEFUNC
     return fmu->fmi1.defaultStopTimeDefined;
 }
 
-bool fmi1_defaultToleranceDefined(fmiHandle *fmu)
+bool fmi1_defaultToleranceDefined(fmuHandle *fmu)
 {
     TRACEFUNC
     return fmu->fmi1.defaultToleranceDefined;
 }
 
-double fmi1_getDefaultStartTime(fmiHandle *fmu)
+double fmi1_getDefaultStartTime(fmuHandle *fmu)
 {
     TRACEFUNC
     return fmu->fmi1.defaultStartTime;
 }
 
-double fmi1_getDefaultStopTime(fmiHandle *fmu)
+double fmi1_getDefaultStopTime(fmuHandle *fmu)
 {
     TRACEFUNC
     return fmu->fmi1.defaultStopTime;
 }
 
-double fmi1_getDefaultTolerance(fmiHandle *fmu)
+double fmi1_getDefaultTolerance(fmuHandle *fmu)
 {
     TRACEFUNC
     return fmu->fmi1.defaultTolerance;
 }
 
-int fmi1_getNumberOfVariables(fmiHandle *fmu)
+int fmi1_getNumberOfVariables(fmuHandle *fmu)
 {
     TRACEFUNC
     return fmu->fmi1.numberOfVariables;
 }
 
-fmi1VariableHandle *fmi1_getVariableByIndex(fmiHandle *fmu, int i)
+fmi1VariableHandle *fmi1_getVariableByIndex(fmuHandle *fmu, int i)
 {
     TRACEFUNC
 
@@ -5044,7 +5034,7 @@ fmi1VariableHandle *fmi1_getVariableByIndex(fmiHandle *fmu, int i)
     return &fmu->fmi1.variables[i-1];
 }
 
-fmi1VariableHandle *fmi1_getVariableByValueReference(fmiHandle *fmu, fmi1ValueReference vr)
+fmi1VariableHandle *fmi1_getVariableByValueReference(fmuHandle *fmu, fmi1ValueReference vr)
 {
     TRACEFUNC
 
@@ -5057,7 +5047,7 @@ fmi1VariableHandle *fmi1_getVariableByValueReference(fmiHandle *fmu, fmi1ValueRe
     return NULL;
 }
 
-fmi1VariableHandle *fmi1_getVariableByName(fmiHandle *fmu, fmi1String name)
+fmi1VariableHandle *fmi1_getVariableByName(fmuHandle *fmu, fmi1String name)
 {
     for(int i=0; i<fmu->fmi1.numberOfVariables; ++i) {
         if(!strcmp(fmu->fmi1.variables[i].name, name)) {
@@ -5182,31 +5172,31 @@ bool fmi1_getVariableIsFixed(fmi1VariableHandle *var)
     return var->fixed;
 }
 
-const char *fmi1_getTypesPlatform(fmiHandle *fmu)
+const char *fmi1_getTypesPlatform(fmuHandle *fmu)
 {
     TRACEFUNC
     return fmu->fmi1.getTypesPlatform();
 }
 
-const char *fmi1_getVersion(fmiHandle *fmu)
+const char *fmi1_getVersion(fmuHandle *fmu)
 {
     TRACEFUNC
     return fmu->fmi1.getVersion();
 }
 
-fmi1Status fmi1_setDebugLogging(fmiHandle *fmu, fmi1Boolean loggingOn)
+fmi1Status fmi1_setDebugLogging(fmuHandle *fmu, fmi1Boolean loggingOn)
 {
     TRACEFUNC
     return fmu->fmi1.setDebugLogging(fmu->fmi1.component, loggingOn);
 }
 
-int fmi1_getNumberOfBaseUnits(fmiHandle *fmu)
+int fmi1_getNumberOfBaseUnits(fmuHandle *fmu)
 {
     TRACEFUNC
     return fmu->fmi1.numberOfBaseUnits;
 }
 
-fmi1BaseUnitHandle *fmi1_getBaseUnitByIndex(fmiHandle *fmu, int i)
+fmi1BaseUnitHandle *fmi1_getBaseUnitByIndex(fmuHandle *fmu, int i)
 {
     TRACEFUNC
     return &fmu->fmi1.baseUnits[i];
@@ -5231,55 +5221,55 @@ void fmi1_getDisplayUnitByIndex(fmi1BaseUnitHandle *baseUnit, int id, const char
     *offset = baseUnit->displayUnits[id].offset;
 }
 
-fmi1Status fmi1_getReal(fmiHandle *fmu, const fmi1ValueReference valueReferences[], size_t nValueReferences, fmi1Real values[])
+fmi1Status fmi1_getReal(fmuHandle *fmu, const fmi1ValueReference valueReferences[], size_t nValueReferences, fmi1Real values[])
 {
     TRACEFUNC
     return fmu->fmi1.getReal(fmu->fmi1.component, valueReferences, nValueReferences, values);
 }
 
-fmi1Status fmi1_getInteger(fmiHandle *fmu, const fmi1ValueReference valueReferences[], size_t nValueReferences, fmi1Integer values[])
+fmi1Status fmi1_getInteger(fmuHandle *fmu, const fmi1ValueReference valueReferences[], size_t nValueReferences, fmi1Integer values[])
 {
     TRACEFUNC
     return fmu->fmi1.getInteger(fmu->fmi1.component, valueReferences, nValueReferences, values);
 }
 
-fmi1Status fmi1_getBoolean(fmiHandle *fmu, const fmi1ValueReference valueReferences[], size_t nValueReferences, fmi1Boolean values[])
+fmi1Status fmi1_getBoolean(fmuHandle *fmu, const fmi1ValueReference valueReferences[], size_t nValueReferences, fmi1Boolean values[])
 {
     TRACEFUNC
     return fmu->fmi1.getBoolean(fmu->fmi1.component, valueReferences, nValueReferences, values);
 }
 
-fmi1Status fmi1_getString(fmiHandle *fmu, const fmi1ValueReference valueReferences[], size_t nValueReferences, fmi1String values[])
+fmi1Status fmi1_getString(fmuHandle *fmu, const fmi1ValueReference valueReferences[], size_t nValueReferences, fmi1String values[])
 {
     TRACEFUNC
     return fmu->fmi1.getString(fmu->fmi1.component, valueReferences, nValueReferences, values);
 }
 
-fmi1Status fmi1_setReal(fmiHandle *fmu, const fmi1ValueReference valueReferences[], size_t nValueReferences, const fmi1Real values[])
+fmi1Status fmi1_setReal(fmuHandle *fmu, const fmi1ValueReference valueReferences[], size_t nValueReferences, const fmi1Real values[])
 {
     TRACEFUNC
     return fmu->fmi1.setReal(fmu->fmi1.component, valueReferences, nValueReferences, values);
 }
 
-fmi1Status fmi1_setInteger(fmiHandle *fmu, const fmi1ValueReference valueReferences[], size_t nValueReferences, const fmi1Integer values[])
+fmi1Status fmi1_setInteger(fmuHandle *fmu, const fmi1ValueReference valueReferences[], size_t nValueReferences, const fmi1Integer values[])
 {
     TRACEFUNC
     return fmu->fmi1.setInteger(fmu->fmi1.component, valueReferences, nValueReferences, values);
 }
 
-fmi1Status fmi1_setBoolean(fmiHandle *fmu, const fmi1ValueReference valueReferences[], size_t nValueReferences, const fmi1Boolean values[])
+fmi1Status fmi1_setBoolean(fmuHandle *fmu, const fmi1ValueReference valueReferences[], size_t nValueReferences, const fmi1Boolean values[])
 {
     TRACEFUNC
     return fmu->fmi1.setBoolean(fmu->fmi1.component, valueReferences, nValueReferences, values);
 }
 
-fmi1Status fmi1_setString(fmiHandle *fmu, const fmi1ValueReference valueReferences[], size_t nValueReferences, const fmi1String values[])
+fmi1Status fmi1_setString(fmuHandle *fmu, const fmi1ValueReference valueReferences[], size_t nValueReferences, const fmi1String values[])
 {
     TRACEFUNC
     return fmu->fmi1.setString(fmu->fmi1.component, valueReferences, nValueReferences, values);
 }
 
-bool fmi1_instantiateSlave(fmiHandle *fmu, fmi1String mimeType, fmi1Real timeOut, fmi1Boolean visible, fmi1Boolean interactive, fmi1CallbackLogger_t logger, fmi1CallbackAllocateMemory_t allocateMemory, fmi1CallbackFreeMemory_t freeMemory, fmi1StepFinished_t stepFinished, fmi1Boolean loggingOn)
+bool fmi1_instantiateSlave(fmuHandle *fmu, fmi1String mimeType, fmi1Real timeOut, fmi1Boolean visible, fmi1Boolean interactive, fmi1CallbackLogger_t logger, fmi1CallbackAllocateMemory_t allocateMemory, fmi1CallbackFreeMemory_t freeMemory, fmi1StepFinished_t stepFinished, fmi1Boolean loggingOn)
 {
     TRACEFUNC
     fmu->fmi1.callbacksCoSimulation.logger = logger;
@@ -5292,92 +5282,92 @@ bool fmi1_instantiateSlave(fmiHandle *fmu, fmi1String mimeType, fmi1Real timeOut
     return (fmu->fmi1.component != NULL);
 }
 
-fmi1Status fmi1_initializeSlave(fmiHandle *fmu, fmi1Real startTime, fmi1Boolean stopTimeDefined, fmi1Real stopTime)
+fmi1Status fmi1_initializeSlave(fmuHandle *fmu, fmi1Real startTime, fmi1Boolean stopTimeDefined, fmi1Real stopTime)
 {
     TRACEFUNC
     return fmu->fmi1.initializeSlave(fmu->fmi1.component, startTime, stopTimeDefined, stopTime);
 }
 
-fmi1Status fmi1_terminateSlave(fmiHandle *fmu)
+fmi1Status fmi1_terminateSlave(fmuHandle *fmu)
 {
     TRACEFUNC
     return fmu->fmi1.terminateSlave(fmu->fmi1.component);
 }
 
-fmi1Status fmi1_resetSlave(fmiHandle *fmu)
+fmi1Status fmi1_resetSlave(fmuHandle *fmu)
 {
     TRACEFUNC
     return fmu->fmi1.resetSlave(fmu->fmi1.component);
 }
 
-void fmi1_freeSlaveInstance(fmiHandle *fmu)
+void fmi1_freeSlaveInstance(fmuHandle *fmu)
 {
     TRACEFUNC
     fmu->fmi1.freeSlaveInstance(fmu->fmi1.component);
 }
 
-fmi1Status fmi1_setRealInputDerivatives(fmiHandle *fmu, const fmi1ValueReference valueReferences[], size_t nValueReferences, const fmi1Integer orders[], const fmi1Real values[])
+fmi1Status fmi1_setRealInputDerivatives(fmuHandle *fmu, const fmi1ValueReference valueReferences[], size_t nValueReferences, const fmi1Integer orders[], const fmi1Real values[])
 {
     TRACEFUNC
     return fmu->fmi1.setRealInputDerivatives(fmu->fmi1.component, valueReferences, nValueReferences, orders, values);
 }
 
-fmi1Status fmi1_getRealOutputDerivatives(fmiHandle *fmu, const fmi1ValueReference valueReferences[], size_t nValueReferences, const fmi1Integer orders[], fmi1Real values[])
+fmi1Status fmi1_getRealOutputDerivatives(fmuHandle *fmu, const fmi1ValueReference valueReferences[], size_t nValueReferences, const fmi1Integer orders[], fmi1Real values[])
 {
     TRACEFUNC
     return fmu->fmi1.getRealOutputDerivatives(fmu->fmi1.component, valueReferences, nValueReferences, orders, values);
 }
 
-fmi1Status fmi1_cancelStep(fmiHandle *fmu)
+fmi1Status fmi1_cancelStep(fmuHandle *fmu)
 {
     TRACEFUNC
     return fmu->fmi1.cancelStep(fmu->fmi1.component);
 }
 
-fmi1Status fmi1_doStep(fmiHandle *fmu, fmi1Real currentCommunicationPoint, fmi1Real communicationStepSize, fmi1Boolean newStep)
+fmi1Status fmi1_doStep(fmuHandle *fmu, fmi1Real currentCommunicationPoint, fmi1Real communicationStepSize, fmi1Boolean newStep)
 {
     TRACEFUNC
     return fmu->fmi1.doStep(fmu->fmi1.component, currentCommunicationPoint, communicationStepSize, newStep);
 }
 
-fmi1Status fmi1_getStatus(fmiHandle *fmu, const fmi1StatusKind statusKind, fmi1Status *value)
+fmi1Status fmi1_getStatus(fmuHandle *fmu, const fmi1StatusKind statusKind, fmi1Status *value)
 {
     TRACEFUNC
     return fmu->fmi1.getStatus(fmu->fmi1.component, statusKind, value);
 }
 
-fmi1Status fmi1_getRealStatus(fmiHandle *fmu, const fmi1StatusKind statusKind, fmi1Real *value)
+fmi1Status fmi1_getRealStatus(fmuHandle *fmu, const fmi1StatusKind statusKind, fmi1Real *value)
 {
     TRACEFUNC
     return fmu->fmi1.getRealStatus(fmu->fmi1.component, statusKind, value);
 }
 
-fmi1Status fmi1_getIntegerStatus(fmiHandle *fmu, const fmi1StatusKind statusKind, fmi1Integer *value)
+fmi1Status fmi1_getIntegerStatus(fmuHandle *fmu, const fmi1StatusKind statusKind, fmi1Integer *value)
 {
     TRACEFUNC
     return fmu->fmi1.getIntegerStatus(fmu->fmi1.component, statusKind, value);
 }
 
-fmi1Status fmi1_getBooleanStatus(fmiHandle *fmu, const fmi1StatusKind statusKind, fmi1Boolean *value)
+fmi1Status fmi1_getBooleanStatus(fmuHandle *fmu, const fmi1StatusKind statusKind, fmi1Boolean *value)
 {
     TRACEFUNC
     return fmu->fmi1.getBooleanStatus(fmu->fmi1.component, statusKind, value);
 }
 
-fmi1Status fmi1_getStringStatus(fmiHandle *fmu, const fmi1StatusKind statusKind, fmi1String *value)
+fmi1Status fmi1_getStringStatus(fmuHandle *fmu, const fmi1StatusKind statusKind, fmi1String *value)
 {
     TRACEFUNC
     return fmu->fmi1.getStringStatus(fmu->fmi1.component, statusKind, value);
 }
 
-const char *fmi1_getModelTypesPlatform(fmiHandle *fmu)
+const char *fmi1_getModelTypesPlatform(fmuHandle *fmu)
 {
     TRACEFUNC
     return fmu->fmi1.getModelTypesPlatform();
 }
 
 
-bool fmi1_instantiateModel(fmiHandle *fmu, fmi1CallbackLogger_t logger, fmi1CallbackAllocateMemory_t allocateMemory, fmi1CallbackFreeMemory_t freeMemory, fmi1Boolean loggingOn)
+bool fmi1_instantiateModel(fmuHandle *fmu, fmi1CallbackLogger_t logger, fmi1CallbackAllocateMemory_t allocateMemory, fmi1CallbackFreeMemory_t freeMemory, fmi1Boolean loggingOn)
 {
     TRACEFUNC
     fmu->fmi1.callbacksModelExchange.logger = logger;
@@ -5388,73 +5378,73 @@ bool fmi1_instantiateModel(fmiHandle *fmu, fmi1CallbackLogger_t logger, fmi1Call
     return (fmu->fmi1.component != NULL);
 }
 
-void fmi1_freeModelInstance(fmiHandle *fmu)
+void fmi1_freeModelInstance(fmuHandle *fmu)
 {
     TRACEFUNC
     fmu->fmi1.freeModelInstance(fmu->fmi1.component);
 }
 
-fmi1Status fmi1_setTime(fmiHandle *fmu, fmi1Real time)
+fmi1Status fmi1_setTime(fmuHandle *fmu, fmi1Real time)
 {
     TRACEFUNC
     return fmu->fmi1.setTime(fmu->fmi1.component, time);
 }
 
-fmi1Status fmi1_setContinuousStates(fmiHandle *fmu, const fmi1Real values[], size_t nStates)
+fmi1Status fmi1_setContinuousStates(fmuHandle *fmu, const fmi1Real values[], size_t nStates)
 {
     TRACEFUNC
     return fmu->fmi1.setContinuousStates(fmu->fmi1.component, values, nStates);
 }
 
-fmi1Status fmi1_completedIntegratorStep(fmiHandle *fmu, fmi1Boolean *callEventUpdate)
+fmi1Status fmi1_completedIntegratorStep(fmuHandle *fmu, fmi1Boolean *callEventUpdate)
 {
     TRACEFUNC
     return fmu->fmi1.completedIntegratorStep(fmu->fmi1.component, callEventUpdate);
 }
 
-fmi1Status fmi1_initialize(fmiHandle *fmu, fmi1Boolean toleranceControlled, fmi1Real relativeTolerance, fmi1EventInfo *eventInfo)
+fmi1Status fmi1_initialize(fmuHandle *fmu, fmi1Boolean toleranceControlled, fmi1Real relativeTolerance, fmi1EventInfo *eventInfo)
 {
     TRACEFUNC
     return fmu->fmi1.initialize(fmu->fmi1.component, toleranceControlled, relativeTolerance, eventInfo);
 }
 
-fmi1Status fmi1_getDerivatives(fmiHandle *fmu, fmi1Real derivatives[], size_t nDerivatives)
+fmi1Status fmi1_getDerivatives(fmuHandle *fmu, fmi1Real derivatives[], size_t nDerivatives)
 {
     TRACEFUNC
     return fmu->fmi1.getDerivatives(fmu->fmi1.component, derivatives, nDerivatives);
 }
 
-fmi1Status fmi1_getEventIndicators(fmiHandle *fmu, fmi1Real indicators[], size_t nIndicators)
+fmi1Status fmi1_getEventIndicators(fmuHandle *fmu, fmi1Real indicators[], size_t nIndicators)
 {
     TRACEFUNC
     return fmu->fmi1.getEventIndicators(fmu->fmi1.component, indicators, nIndicators);
 }
 
-fmi1Status fmi1_eventUpdate(fmiHandle *fmu, fmi1Boolean intermediateResults, fmi1EventInfo *eventInfo)
+fmi1Status fmi1_eventUpdate(fmuHandle *fmu, fmi1Boolean intermediateResults, fmi1EventInfo *eventInfo)
 {
     TRACEFUNC
     return fmu->fmi1.eventUpdate(fmu->fmi1.component, intermediateResults, eventInfo);
 }
 
-fmi1Status fmi1_getContinuousStates(fmiHandle *fmu, fmi1Real states[], size_t nStates)
+fmi1Status fmi1_getContinuousStates(fmuHandle *fmu, fmi1Real states[], size_t nStates)
 {
     TRACEFUNC
     return fmu->fmi1.getContinuousStates(fmu->fmi1.component, states, nStates);
 }
 
-fmi1Status fmi1_getNominalContinuousStates(fmiHandle *fmu, fmi1Real nominals[], size_t nNominals)
+fmi1Status fmi1_getNominalContinuousStates(fmuHandle *fmu, fmi1Real nominals[], size_t nNominals)
 {
     TRACEFUNC
     return fmu->fmi1.getNominalContinuousStates(fmu->fmi1.component, nominals, nNominals);
 }
 
-fmi1Status fmi1_getStateValueReferences(fmiHandle *fmu, fmi1ValueReference valueReferences[], size_t nValueReferences)
+fmi1Status fmi1_getStateValueReferences(fmuHandle *fmu, fmi1ValueReference valueReferences[], size_t nValueReferences)
 {
     TRACEFUNC
     return fmu->fmi1.getStateValueReferences(fmu->fmi1.component, valueReferences, nValueReferences);
 }
 
-fmi1Status fmi1_terminate(fmiHandle *fmu)
+fmi1Status fmi1_terminate(fmuHandle *fmu)
 {
     TRACEFUNC
     return fmu->fmi1.terminate(fmu->fmi1.component);
@@ -5466,12 +5456,12 @@ fmi1DataType fmi1_getVariableDataType(fmi1VariableHandle *var)
     return var->datatype;
 }
 
-int fmi3_getNumberOfUnits(fmiHandle *fmu)
+int fmi3_getNumberOfUnits(fmuHandle *fmu)
 {
     return fmu->fmi3.numberOfUnits;
 }
 
-fmi3UnitHandle *fmi3_getUnitByIndex(fmiHandle *fmu, int i)
+fmi3UnitHandle *fmi3_getUnitByIndex(fmuHandle *fmu, int i)
 {
     return &fmu->fmi3.units[i];
 }
@@ -5616,7 +5606,7 @@ bool fmi3GetDisplayUnitInverse(fmi3DisplayUnitHandle *displayUnit)
     return displayUnit->inverse;
 }
 
-void fmi3_getFloat64Type(fmiHandle *fmu,
+void fmi3_getFloat64Type(fmuHandle *fmu,
                         const char *name,
                         const char **description,
                         const char **quantity,
@@ -5643,7 +5633,7 @@ void fmi3_getFloat64Type(fmiHandle *fmu,
     }
 }
 
-void fmi3_getFloat32Type(fmiHandle *fmu,
+void fmi3_getFloat32Type(fmuHandle *fmu,
                         const char *name,
                         const char **description,
                         const char **quantity,
@@ -5670,7 +5660,7 @@ void fmi3_getFloat32Type(fmiHandle *fmu,
     }
 }
 
-void fmi3_getInt64Type(fmiHandle *fmu,
+void fmi3_getInt64Type(fmuHandle *fmu,
                       const char *name,
                       const char **description,
                       const char **quantity,
@@ -5687,7 +5677,7 @@ void fmi3_getInt64Type(fmiHandle *fmu,
     }
 }
 
-void fmi3_getInt32Type(fmiHandle *fmu,
+void fmi3_getInt32Type(fmuHandle *fmu,
                       const char *name,
                       const char **description,
                       const char **quantity,
@@ -5704,7 +5694,7 @@ void fmi3_getInt32Type(fmiHandle *fmu,
     }
 }
 
-void fmi3_getInt16Type(fmiHandle *fmu,
+void fmi3_getInt16Type(fmuHandle *fmu,
                       const char *name,
                       const char **description,
                       const char **quantity,
@@ -5721,7 +5711,7 @@ void fmi3_getInt16Type(fmiHandle *fmu,
     }
 }
 
-void fmi3_getInt8Type(fmiHandle *fmu,
+void fmi3_getInt8Type(fmuHandle *fmu,
                       const char *name,
                       const char **description,
                       const char **quantity,
@@ -5738,7 +5728,7 @@ void fmi3_getInt8Type(fmiHandle *fmu,
     }
 }
 
-void fmi3_getUInt64Type(fmiHandle *fmu,
+void fmi3_getUInt64Type(fmuHandle *fmu,
                       const char *name,
                       const char **description,
                       const char **quantity,
@@ -5755,7 +5745,7 @@ void fmi3_getUInt64Type(fmiHandle *fmu,
     }
 }
 
-void fmi3_getUInt32Type(fmiHandle *fmu,
+void fmi3_getUInt32Type(fmuHandle *fmu,
                       const char *name,
                       const char **description,
                       const char **quantity,
@@ -5772,7 +5762,7 @@ void fmi3_getUInt32Type(fmiHandle *fmu,
     }
 }
 
-void fmi3_getUInt16Type(fmiHandle *fmu,
+void fmi3_getUInt16Type(fmuHandle *fmu,
                       const char *name,
                       const char **description,
                       const char **quantity,
@@ -5789,7 +5779,7 @@ void fmi3_getUInt16Type(fmiHandle *fmu,
     }
 }
 
-void fmi3_getUInt8Type(fmiHandle *fmu,
+void fmi3_getUInt8Type(fmuHandle *fmu,
                       const char *name,
                       const char **description,
                       const char **quantity,
@@ -5806,7 +5796,7 @@ void fmi3_getUInt8Type(fmiHandle *fmu,
     }
 }
 
-void fmi3_getBooleanType(fmiHandle *fmu,
+void fmi3_getBooleanType(fmuHandle *fmu,
                       const char *name,
                       const char **description)
 {
@@ -5817,7 +5807,7 @@ void fmi3_getBooleanType(fmiHandle *fmu,
     }
 }
 
-void fmi3_getStringType(fmiHandle *fmu,
+void fmi3_getStringType(fmuHandle *fmu,
                       const char *name,
                       const char **description)
 {
@@ -5828,7 +5818,7 @@ void fmi3_getStringType(fmiHandle *fmu,
     }
 }
 
-void fmi3_getBinaryType(fmiHandle *fmu,
+void fmi3_getBinaryType(fmuHandle *fmu,
                        const char *name,
                        const char **description,
                        const char **mimeType,
@@ -5843,7 +5833,7 @@ void fmi3_getBinaryType(fmiHandle *fmu,
     }
 }
 
-void fmi3_getEnumerationType(fmiHandle *fmu,
+void fmi3_getEnumerationType(fmuHandle *fmu,
                             const char *name,
                             const char **description,
                             const char **quantity,
@@ -5862,7 +5852,7 @@ void fmi3_getEnumerationType(fmiHandle *fmu,
     // TODO numberOfItems
 }
 
-void fmi3_getClockType(fmiHandle *fmu,
+void fmi3_getClockType(fmuHandle *fmu,
                       const char *name,
                       const char **description,
                       bool *canBeDeactivated,
@@ -5891,7 +5881,7 @@ void fmi3_getClockType(fmiHandle *fmu,
     }
 }
 
-void fmi3_getEnumerationItem(fmiHandle *fmu, const char *typeName, int itemId, const char **itemName, int64_t *value, const char **description)
+void fmi3_getEnumerationItem(fmuHandle *fmu, const char *typeName, int itemId, const char **itemName, int64_t *value, const char **description)
 {
     for(int i=0; i<fmu->fmi3.numberOfEnumerationTypes; ++i) {
         if(!strcmp(fmu->fmi3.enumTypes[i].name, typeName)) {
@@ -5905,12 +5895,12 @@ void fmi3_getEnumerationItem(fmiHandle *fmu, const char *typeName, int itemId, c
 }
 
 
-int fmi3_getNumberOfLogCategories(fmiHandle *fmu)
+int fmi3_getNumberOfLogCategories(fmuHandle *fmu)
 {
     return fmu->fmi3.numberOfLogCategories;
 }
 
-void fmi3_getLogCategory(fmiHandle *fmu, int id, const char **name, const char **description)
+void fmi3_getLogCategory(fmuHandle *fmu, int id, const char **name, const char **description)
 {
     if(id < fmu->fmi3.numberOfLogCategories) {
         *name = fmu->fmi3.logCategories[id].name;
@@ -5918,52 +5908,52 @@ void fmi3_getLogCategory(fmiHandle *fmu, int id, const char **name, const char *
     }
 }
 
-int fmi3_getNumberOfModelStructureOutputs(fmiHandle *fmu)
+int fmi3_getNumberOfModelStructureOutputs(fmuHandle *fmu)
 {
     return fmu->fmi3.modelStructure.numberOfOutputs;
 }
 
-int fmi3_getNumberOfModelStructureContinuousStateDerivatives(fmiHandle *fmu)
+int fmi3_getNumberOfModelStructureContinuousStateDerivatives(fmuHandle *fmu)
 {
     return fmu->fmi3.modelStructure.numberOfContinuousStateDerivatives;
 }
 
-int fmi3_getNumberOfModelStructureClockedStates(fmiHandle *fmu)
+int fmi3_getNumberOfModelStructureClockedStates(fmuHandle *fmu)
 {
     return fmu->fmi3.modelStructure.numberOfClockedStates;
 }
 
-int fmi3_getNumberOfModelStructureEventIndicators(fmiHandle *fmu)
+int fmi3_getNumberOfModelStructureEventIndicators(fmuHandle *fmu)
 {
     return fmu->fmi3.modelStructure.numberOfEventIndicators;
 }
 
-int fmi3_getNumberOfModelStructureInitialUnknowns(fmiHandle *fmu)
+int fmi3_getNumberOfModelStructureInitialUnknowns(fmuHandle *fmu)
 {
     return fmu->fmi3.modelStructure.numberOfInitialUnknowns;
 }
 
-fmi3ModelStructureHandle *fmi3_getModelStructureOutput(fmiHandle *fmu, size_t i)
+fmi3ModelStructureHandle *fmi3_getModelStructureOutput(fmuHandle *fmu, size_t i)
 {
     return &fmu->fmi3.modelStructure.outputs[i];
 }
 
-fmi3ModelStructureHandle *fmi3_getModelStructureContinuousStateDerivative(fmiHandle *fmu, size_t i)
+fmi3ModelStructureHandle *fmi3_getModelStructureContinuousStateDerivative(fmuHandle *fmu, size_t i)
 {
     return &fmu->fmi3.modelStructure.continuousStateDerivatives[i];
 }
 
-fmi3ModelStructureHandle *fmi3_getModelStructureClockedState(fmiHandle *fmu, size_t i)
+fmi3ModelStructureHandle *fmi3_getModelStructureClockedState(fmuHandle *fmu, size_t i)
 {
     return &fmu->fmi3.modelStructure.clockedStates[i];
 }
 
-fmi3ModelStructureHandle *fmi3_getModelStructureInitialUnknown(fmiHandle *fmu, size_t i)
+fmi3ModelStructureHandle *fmi3_getModelStructureInitialUnknown(fmuHandle *fmu, size_t i)
 {
     return &fmu->fmi3.modelStructure.initialUnknowns[i];
 }
 
-fmi3ModelStructureHandle *fmi3_getModelStructureEventIndicator(fmiHandle *fmu, size_t i)
+fmi3ModelStructureHandle *fmi3_getModelStructureEventIndicator(fmuHandle *fmu, size_t i)
 {
     return &fmu->fmi3.modelStructure.eventIndicators[i];
 }

--- a/src/fmi4c.c
+++ b/src/fmi4c.c
@@ -4671,7 +4671,7 @@ fmuHandle *fmi4c_loadUnzippedFmu_internal(const char *instanceName, const char *
 
     fmu->fmi1.getVersion = placeholder_fmiGetVersion;
     fmu->fmi1.getTypesPlatform = placeholder_fmiGetTypesPlatform;
-    fmu->fmi1.setDebugLogging = placeholder;
+    fmu->fmi1.setDebugLogging = placeholder_fmiSetDebugLogging;
     fmu->fmi1.getReal = placeholder_fmiGetReal;
     fmu->fmi1.getInteger = placeholder_fmiGetInteger;
     fmu->fmi1.getBoolean = placeholder_fmiGetBoolean;
@@ -5184,10 +5184,10 @@ const char *fmi1_getVersion(fmuHandle *fmu)
     return fmu->fmi1.getVersion();
 }
 
-fmi1Status fmi1_setDebugLogging(fmuHandle *fmu, fmi1Boolean loggingOn)
+fmi1Status fmi1_setDebugLogging(fmi1InstanceHandle *instance, fmi1Boolean loggingOn)
 {
     TRACEFUNC
-    return fmu->fmi1.setDebugLogging(fmu->fmi1.component, loggingOn);
+    return instance->fmu->fmi1.setDebugLogging(instance->component, loggingOn);
 }
 
 int fmi1_getNumberOfBaseUnits(fmuHandle *fmu)
@@ -5221,55 +5221,55 @@ void fmi1_getDisplayUnitByIndex(fmi1BaseUnitHandle *baseUnit, int id, const char
     *offset = baseUnit->displayUnits[id].offset;
 }
 
-fmi1Status fmi1_getReal(fmuHandle *fmu, const fmi1ValueReference valueReferences[], size_t nValueReferences, fmi1Real values[])
+fmi1Status fmi1_getReal(fmi1InstanceHandle *instance, const fmi1ValueReference valueReferences[], size_t nValueReferences, fmi1Real values[])
 {
     TRACEFUNC
-    return fmu->fmi1.getReal(fmu->fmi1.component, valueReferences, nValueReferences, values);
+    return instance->fmu->fmi1.getReal(instance->component, valueReferences, nValueReferences, values);
 }
 
-fmi1Status fmi1_getInteger(fmuHandle *fmu, const fmi1ValueReference valueReferences[], size_t nValueReferences, fmi1Integer values[])
+fmi1Status fmi1_getInteger(fmi1InstanceHandle *instance, const fmi1ValueReference valueReferences[], size_t nValueReferences, fmi1Integer values[])
 {
     TRACEFUNC
-    return fmu->fmi1.getInteger(fmu->fmi1.component, valueReferences, nValueReferences, values);
+    return instance->fmu->fmi1.getInteger(instance->component, valueReferences, nValueReferences, values);
 }
 
-fmi1Status fmi1_getBoolean(fmuHandle *fmu, const fmi1ValueReference valueReferences[], size_t nValueReferences, fmi1Boolean values[])
+fmi1Status fmi1_getBoolean(fmi1InstanceHandle *instance, const fmi1ValueReference valueReferences[], size_t nValueReferences, fmi1Boolean values[])
 {
     TRACEFUNC
-    return fmu->fmi1.getBoolean(fmu->fmi1.component, valueReferences, nValueReferences, values);
+    return instance->fmu->fmi1.getBoolean(instance->component, valueReferences, nValueReferences, values);
 }
 
-fmi1Status fmi1_getString(fmuHandle *fmu, const fmi1ValueReference valueReferences[], size_t nValueReferences, fmi1String values[])
+fmi1Status fmi1_getString(fmi1InstanceHandle *instance, const fmi1ValueReference valueReferences[], size_t nValueReferences, fmi1String values[])
 {
     TRACEFUNC
-    return fmu->fmi1.getString(fmu->fmi1.component, valueReferences, nValueReferences, values);
+    return instance->fmu->fmi1.getString(instance->component, valueReferences, nValueReferences, values);
 }
 
-fmi1Status fmi1_setReal(fmuHandle *fmu, const fmi1ValueReference valueReferences[], size_t nValueReferences, const fmi1Real values[])
+fmi1Status fmi1_setReal(fmi1InstanceHandle *instance, const fmi1ValueReference valueReferences[], size_t nValueReferences, const fmi1Real values[])
 {
     TRACEFUNC
-    return fmu->fmi1.setReal(fmu->fmi1.component, valueReferences, nValueReferences, values);
+    return instance->fmu->fmi1.setReal(instance->component, valueReferences, nValueReferences, values);
 }
 
-fmi1Status fmi1_setInteger(fmuHandle *fmu, const fmi1ValueReference valueReferences[], size_t nValueReferences, const fmi1Integer values[])
+fmi1Status fmi1_setInteger(fmi1InstanceHandle *instance, const fmi1ValueReference valueReferences[], size_t nValueReferences, const fmi1Integer values[])
 {
     TRACEFUNC
-    return fmu->fmi1.setInteger(fmu->fmi1.component, valueReferences, nValueReferences, values);
+    return instance->fmu->fmi1.setInteger(instance->component, valueReferences, nValueReferences, values);
 }
 
-fmi1Status fmi1_setBoolean(fmuHandle *fmu, const fmi1ValueReference valueReferences[], size_t nValueReferences, const fmi1Boolean values[])
+fmi1Status fmi1_setBoolean(fmi1InstanceHandle *instance, const fmi1ValueReference valueReferences[], size_t nValueReferences, const fmi1Boolean values[])
 {
     TRACEFUNC
-    return fmu->fmi1.setBoolean(fmu->fmi1.component, valueReferences, nValueReferences, values);
+    return instance->fmu->fmi1.setBoolean(instance->component, valueReferences, nValueReferences, values);
 }
 
-fmi1Status fmi1_setString(fmuHandle *fmu, const fmi1ValueReference valueReferences[], size_t nValueReferences, const fmi1String values[])
+fmi1Status fmi1_setString(fmi1InstanceHandle *instance, const fmi1ValueReference valueReferences[], size_t nValueReferences, const fmi1String values[])
 {
     TRACEFUNC
-    return fmu->fmi1.setString(fmu->fmi1.component, valueReferences, nValueReferences, values);
+    return instance->fmu->fmi1.setString(instance->component, valueReferences, nValueReferences, values);
 }
 
-bool fmi1_instantiateSlave(fmuHandle *fmu, fmi1String mimeType, fmi1Real timeOut, fmi1Boolean visible, fmi1Boolean interactive, fmi1CallbackLogger_t logger, fmi1CallbackAllocateMemory_t allocateMemory, fmi1CallbackFreeMemory_t freeMemory, fmi1StepFinished_t stepFinished, fmi1Boolean loggingOn)
+fmi1InstanceHandle *fmi1_instantiateSlave(fmuHandle *fmu, fmi1String mimeType, fmi1Real timeOut, fmi1Boolean visible, fmi1Boolean interactive, fmi1CallbackLogger_t logger, fmi1CallbackAllocateMemory_t allocateMemory, fmi1CallbackFreeMemory_t freeMemory, fmi1StepFinished_t stepFinished, fmi1Boolean loggingOn)
 {
     TRACEFUNC
     fmu->fmi1.callbacksCoSimulation.logger = logger;
@@ -5277,87 +5277,90 @@ bool fmi1_instantiateSlave(fmuHandle *fmu, fmi1String mimeType, fmi1Real timeOut
     fmu->fmi1.callbacksCoSimulation.freeMemory = freeMemory;
     fmu->fmi1.callbacksCoSimulation.stepFinished = stepFinished;
 
-    fmu->fmi1.component = fmu->fmi1.instantiateSlave(fmu->instanceName, fmu->fmi1.guid, fmu->resourcesLocation, mimeType, timeOut, visible, interactive, fmu->fmi1.callbacksCoSimulation, loggingOn);
+    fmi1Component_t comp = fmu->fmi1.instantiateSlave(fmu->instanceName, fmu->fmi1.guid, fmu->resourcesLocation, mimeType, timeOut, visible, interactive, fmu->fmi1.callbacksCoSimulation, loggingOn);
+    fmi1InstanceHandle *handle = calloc(1, sizeof(fmi1InstanceHandle));
+    handle->component = comp;
+    handle->fmu = (struct fmuHandle*)fmu;
 
-    return (fmu->fmi1.component != NULL);
+    return handle;
 }
 
-fmi1Status fmi1_initializeSlave(fmuHandle *fmu, fmi1Real startTime, fmi1Boolean stopTimeDefined, fmi1Real stopTime)
+fmi1Status fmi1_initializeSlave(fmi1InstanceHandle *instance, fmi1Real startTime, fmi1Boolean stopTimeDefined, fmi1Real stopTime)
 {
     TRACEFUNC
-    return fmu->fmi1.initializeSlave(fmu->fmi1.component, startTime, stopTimeDefined, stopTime);
+    return instance->fmu->fmi1.initializeSlave(instance->component, startTime, stopTimeDefined, stopTime);
 }
 
-fmi1Status fmi1_terminateSlave(fmuHandle *fmu)
+fmi1Status fmi1_terminateSlave(fmi1InstanceHandle *instance)
 {
     TRACEFUNC
-    return fmu->fmi1.terminateSlave(fmu->fmi1.component);
+    return instance->fmu->fmi1.terminateSlave(instance->component);
 }
 
-fmi1Status fmi1_resetSlave(fmuHandle *fmu)
+fmi1Status fmi1_resetSlave(fmi1InstanceHandle *instance)
 {
     TRACEFUNC
-    return fmu->fmi1.resetSlave(fmu->fmi1.component);
+    return instance->fmu->fmi1.resetSlave(instance->component);
 }
 
-void fmi1_freeSlaveInstance(fmuHandle *fmu)
+void fmi1_freeSlaveInstance(fmi1InstanceHandle *instance)
 {
     TRACEFUNC
-    fmu->fmi1.freeSlaveInstance(fmu->fmi1.component);
+    instance->fmu->fmi1.freeSlaveInstance(instance->component);
 }
 
-fmi1Status fmi1_setRealInputDerivatives(fmuHandle *fmu, const fmi1ValueReference valueReferences[], size_t nValueReferences, const fmi1Integer orders[], const fmi1Real values[])
+fmi1Status fmi1_setRealInputDerivatives(fmi1InstanceHandle *instance, const fmi1ValueReference valueReferences[], size_t nValueReferences, const fmi1Integer orders[], const fmi1Real values[])
 {
     TRACEFUNC
-    return fmu->fmi1.setRealInputDerivatives(fmu->fmi1.component, valueReferences, nValueReferences, orders, values);
+    return instance->fmu->fmi1.setRealInputDerivatives(instance->component, valueReferences, nValueReferences, orders, values);
 }
 
-fmi1Status fmi1_getRealOutputDerivatives(fmuHandle *fmu, const fmi1ValueReference valueReferences[], size_t nValueReferences, const fmi1Integer orders[], fmi1Real values[])
+fmi1Status fmi1_getRealOutputDerivatives(fmi1InstanceHandle *instance, const fmi1ValueReference valueReferences[], size_t nValueReferences, const fmi1Integer orders[], fmi1Real values[])
 {
     TRACEFUNC
-    return fmu->fmi1.getRealOutputDerivatives(fmu->fmi1.component, valueReferences, nValueReferences, orders, values);
+    return instance->fmu->fmi1.getRealOutputDerivatives(instance->component, valueReferences, nValueReferences, orders, values);
 }
 
-fmi1Status fmi1_cancelStep(fmuHandle *fmu)
+fmi1Status fmi1_cancelStep(fmi1InstanceHandle *instance)
 {
     TRACEFUNC
-    return fmu->fmi1.cancelStep(fmu->fmi1.component);
+    return instance->fmu->fmi1.cancelStep(instance->component);
 }
 
-fmi1Status fmi1_doStep(fmuHandle *fmu, fmi1Real currentCommunicationPoint, fmi1Real communicationStepSize, fmi1Boolean newStep)
+fmi1Status fmi1_doStep(fmi1InstanceHandle *instance, fmi1Real currentCommunicationPoint, fmi1Real communicationStepSize, fmi1Boolean newStep)
 {
     TRACEFUNC
-    return fmu->fmi1.doStep(fmu->fmi1.component, currentCommunicationPoint, communicationStepSize, newStep);
+    return instance->fmu->fmi1.doStep(instance->component, currentCommunicationPoint, communicationStepSize, newStep);
 }
 
-fmi1Status fmi1_getStatus(fmuHandle *fmu, const fmi1StatusKind statusKind, fmi1Status *value)
+fmi1Status fmi1_getStatus(fmi1InstanceHandle *instance, const fmi1StatusKind statusKind, fmi1Status *value)
 {
     TRACEFUNC
-    return fmu->fmi1.getStatus(fmu->fmi1.component, statusKind, value);
+    return instance->fmu->fmi1.getStatus(instance->component, statusKind, value);
 }
 
-fmi1Status fmi1_getRealStatus(fmuHandle *fmu, const fmi1StatusKind statusKind, fmi1Real *value)
+fmi1Status fmi1_getRealStatus(fmi1InstanceHandle *instance, const fmi1StatusKind statusKind, fmi1Real *value)
 {
     TRACEFUNC
-    return fmu->fmi1.getRealStatus(fmu->fmi1.component, statusKind, value);
+    return instance->fmu->fmi1.getRealStatus(instance->component, statusKind, value);
 }
 
-fmi1Status fmi1_getIntegerStatus(fmuHandle *fmu, const fmi1StatusKind statusKind, fmi1Integer *value)
+fmi1Status fmi1_getIntegerStatus(fmi1InstanceHandle *instance, const fmi1StatusKind statusKind, fmi1Integer *value)
 {
     TRACEFUNC
-    return fmu->fmi1.getIntegerStatus(fmu->fmi1.component, statusKind, value);
+    return instance->fmu->fmi1.getIntegerStatus(instance->component, statusKind, value);
 }
 
-fmi1Status fmi1_getBooleanStatus(fmuHandle *fmu, const fmi1StatusKind statusKind, fmi1Boolean *value)
+fmi1Status fmi1_getBooleanStatus(fmi1InstanceHandle *instance, const fmi1StatusKind statusKind, fmi1Boolean *value)
 {
     TRACEFUNC
-    return fmu->fmi1.getBooleanStatus(fmu->fmi1.component, statusKind, value);
+    return instance->fmu->fmi1.getBooleanStatus(instance->component, statusKind, value);
 }
 
-fmi1Status fmi1_getStringStatus(fmuHandle *fmu, const fmi1StatusKind statusKind, fmi1String *value)
+fmi1Status fmi1_getStringStatus(fmi1InstanceHandle *instance, const fmi1StatusKind statusKind, fmi1String *value)
 {
     TRACEFUNC
-    return fmu->fmi1.getStringStatus(fmu->fmi1.component, statusKind, value);
+    return instance->fmu->fmi1.getStringStatus(instance->component, statusKind, value);
 }
 
 const char *fmi1_getModelTypesPlatform(fmuHandle *fmu)
@@ -5367,87 +5370,90 @@ const char *fmi1_getModelTypesPlatform(fmuHandle *fmu)
 }
 
 
-bool fmi1_instantiateModel(fmuHandle *fmu, fmi1CallbackLogger_t logger, fmi1CallbackAllocateMemory_t allocateMemory, fmi1CallbackFreeMemory_t freeMemory, fmi1Boolean loggingOn)
+fmi1InstanceHandle *fmi1_instantiateModel(fmuHandle *fmu, fmi1CallbackLogger_t logger, fmi1CallbackAllocateMemory_t allocateMemory, fmi1CallbackFreeMemory_t freeMemory, fmi1Boolean loggingOn)
 {
     TRACEFUNC
     fmu->fmi1.callbacksModelExchange.logger = logger;
     fmu->fmi1.callbacksModelExchange.allocateMemory = allocateMemory;
     fmu->fmi1.callbacksModelExchange.freeMemory = freeMemory;
-    fmu->fmi1.component = fmu->fmi1.instantiateModel(fmu->instanceName, fmu->fmi1.guid, fmu->fmi1.callbacksModelExchange, loggingOn);
+    fmi1Component_t comp = fmu->fmi1.instantiateModel(fmu->instanceName, fmu->fmi1.guid, fmu->fmi1.callbacksModelExchange, loggingOn);
+    fmi1InstanceHandle *handle = calloc(1, sizeof(fmi1InstanceHandle));
+    handle->component = comp;
+    handle->fmu = (struct fmuHandle*)fmu;
 
-    return (fmu->fmi1.component != NULL);
+    return handle;
 }
 
-void fmi1_freeModelInstance(fmuHandle *fmu)
+void fmi1_freeModelInstance(fmi1InstanceHandle *instance)
 {
     TRACEFUNC
-    fmu->fmi1.freeModelInstance(fmu->fmi1.component);
+    instance->fmu->fmi1.freeModelInstance(instance->component);
 }
 
-fmi1Status fmi1_setTime(fmuHandle *fmu, fmi1Real time)
+fmi1Status fmi1_setTime(fmi1InstanceHandle *instance, fmi1Real time)
 {
     TRACEFUNC
-    return fmu->fmi1.setTime(fmu->fmi1.component, time);
+    return instance->fmu->fmi1.setTime(instance->component, time);
 }
 
-fmi1Status fmi1_setContinuousStates(fmuHandle *fmu, const fmi1Real values[], size_t nStates)
+fmi1Status fmi1_setContinuousStates(fmi1InstanceHandle *instance, const fmi1Real values[], size_t nStates)
 {
     TRACEFUNC
-    return fmu->fmi1.setContinuousStates(fmu->fmi1.component, values, nStates);
+    return instance->fmu->fmi1.setContinuousStates(instance->component, values, nStates);
 }
 
-fmi1Status fmi1_completedIntegratorStep(fmuHandle *fmu, fmi1Boolean *callEventUpdate)
+fmi1Status fmi1_completedIntegratorStep(fmi1InstanceHandle *instance, fmi1Boolean *callEventUpdate)
 {
     TRACEFUNC
-    return fmu->fmi1.completedIntegratorStep(fmu->fmi1.component, callEventUpdate);
+    return instance->fmu->fmi1.completedIntegratorStep(instance->component, callEventUpdate);
 }
 
-fmi1Status fmi1_initialize(fmuHandle *fmu, fmi1Boolean toleranceControlled, fmi1Real relativeTolerance, fmi1EventInfo *eventInfo)
+fmi1Status fmi1_initialize(fmi1InstanceHandle *instance, fmi1Boolean toleranceControlled, fmi1Real relativeTolerance, fmi1EventInfo *eventInfo)
 {
     TRACEFUNC
-    return fmu->fmi1.initialize(fmu->fmi1.component, toleranceControlled, relativeTolerance, eventInfo);
+    return instance->fmu->fmi1.initialize(instance->component, toleranceControlled, relativeTolerance, eventInfo);
 }
 
-fmi1Status fmi1_getDerivatives(fmuHandle *fmu, fmi1Real derivatives[], size_t nDerivatives)
+fmi1Status fmi1_getDerivatives(fmi1InstanceHandle *instance, fmi1Real derivatives[], size_t nDerivatives)
 {
     TRACEFUNC
-    return fmu->fmi1.getDerivatives(fmu->fmi1.component, derivatives, nDerivatives);
+    return instance->fmu->fmi1.getDerivatives(instance->component, derivatives, nDerivatives);
 }
 
-fmi1Status fmi1_getEventIndicators(fmuHandle *fmu, fmi1Real indicators[], size_t nIndicators)
+fmi1Status fmi1_getEventIndicators(fmi1InstanceHandle *instance, fmi1Real indicators[], size_t nIndicators)
 {
     TRACEFUNC
-    return fmu->fmi1.getEventIndicators(fmu->fmi1.component, indicators, nIndicators);
+    return instance->fmu->fmi1.getEventIndicators(instance->component, indicators, nIndicators);
 }
 
-fmi1Status fmi1_eventUpdate(fmuHandle *fmu, fmi1Boolean intermediateResults, fmi1EventInfo *eventInfo)
+fmi1Status fmi1_eventUpdate(fmi1InstanceHandle *instance, fmi1Boolean intermediateResults, fmi1EventInfo *eventInfo)
 {
     TRACEFUNC
-    return fmu->fmi1.eventUpdate(fmu->fmi1.component, intermediateResults, eventInfo);
+    return instance->fmu->fmi1.eventUpdate(instance->component, intermediateResults, eventInfo);
 }
 
-fmi1Status fmi1_getContinuousStates(fmuHandle *fmu, fmi1Real states[], size_t nStates)
+fmi1Status fmi1_getContinuousStates(fmi1InstanceHandle *instance, fmi1Real states[], size_t nStates)
 {
     TRACEFUNC
-    return fmu->fmi1.getContinuousStates(fmu->fmi1.component, states, nStates);
+    return instance->fmu->fmi1.getContinuousStates(instance->component, states, nStates);
 }
 
-fmi1Status fmi1_getNominalContinuousStates(fmuHandle *fmu, fmi1Real nominals[], size_t nNominals)
+fmi1Status fmi1_getNominalContinuousStates(fmi1InstanceHandle *instance, fmi1Real nominals[], size_t nNominals)
 {
     TRACEFUNC
-    return fmu->fmi1.getNominalContinuousStates(fmu->fmi1.component, nominals, nNominals);
+    return instance->fmu->fmi1.getNominalContinuousStates(instance->component, nominals, nNominals);
 }
 
-fmi1Status fmi1_getStateValueReferences(fmuHandle *fmu, fmi1ValueReference valueReferences[], size_t nValueReferences)
+fmi1Status fmi1_getStateValueReferences(fmi1InstanceHandle *instance, fmi1ValueReference valueReferences[], size_t nValueReferences)
 {
     TRACEFUNC
-    return fmu->fmi1.getStateValueReferences(fmu->fmi1.component, valueReferences, nValueReferences);
+    return instance->fmu->fmi1.getStateValueReferences(instance->component, valueReferences, nValueReferences);
 }
 
-fmi1Status fmi1_terminate(fmuHandle *fmu)
+fmi1Status fmi1_terminate(fmi1InstanceHandle *instance)
 {
     TRACEFUNC
-    return fmu->fmi1.terminate(fmu->fmi1.component);
+    return instance->fmu->fmi1.terminate(instance->component);
 }
 
 fmi1DataType fmi1_getVariableDataType(fmi1VariableHandle *var)

--- a/src/fmi4c_placeholders.h
+++ b/src/fmi4c_placeholders.h
@@ -29,23 +29,23 @@ const char* STDCALL placeholder_fmiGetTypesPlatform() {
     return NULL;
 }
 
-fmi1Status STDCALL placeholder_fmiSetDebugLogging(fmi1Component_t c, fmi1Boolean loggingOn) {
-    UNUSED(c);
+fmi1Status STDCALL placeholder_fmiSetDebugLogging(fmi1InstanceHandle *instance, fmi1Boolean loggingOn) {
+    UNUSED(instance);
     UNUSED(loggingOn);
     NOT_IMPLEMENTED(fmiSetDebugLogging);
     return fmi1Error;
 }
 
-fmi1Status STDCALL placeholder_fmiGetReal(fmi1Component_t c, const fmi1ValueReference vr[], size_t nvr, fmi1Real value[]) {
-    UNUSED(c);
+fmi1Status STDCALL placeholder_fmiGetReal(fmi1InstanceHandle *instance, const fmi1ValueReference vr[], size_t nvr, fmi1Real value[]) {
+    UNUSED(instance);
     UNUSED(vr);
     UNUSED(nvr);
     UNUSED(value);
     NOT_IMPLEMENTED(fmiGetReal);
     return fmi1Error;
 }
-fmi1Status STDCALL placeholder_fmiGetInteger(fmi1Component_t c, const fmi1ValueReference vr[], size_t nvr, fmi1Integer value[]) {
-    UNUSED(c);
+fmi1Status STDCALL placeholder_fmiGetInteger(fmi1InstanceHandle *instance, const fmi1ValueReference vr[], size_t nvr, fmi1Integer value[]) {
+    UNUSED(instance);
     UNUSED(vr);
     UNUSED(nvr);
     UNUSED(value);
@@ -53,8 +53,8 @@ fmi1Status STDCALL placeholder_fmiGetInteger(fmi1Component_t c, const fmi1ValueR
     return fmi1Error;
 }
 
-fmi1Status STDCALL placeholder_fmiGetBoolean(fmi1Component_t c, const fmi1ValueReference vr[], size_t nvr, fmi1Boolean value[]) {
-    UNUSED(c);
+fmi1Status STDCALL placeholder_fmiGetBoolean(fmi1InstanceHandle *instance, const fmi1ValueReference vr[], size_t nvr, fmi1Boolean value[]) {
+    UNUSED(instance);
     UNUSED(vr);
     UNUSED(nvr);
     UNUSED(value);
@@ -62,8 +62,8 @@ fmi1Status STDCALL placeholder_fmiGetBoolean(fmi1Component_t c, const fmi1ValueR
     return fmi1Error;
 }
 
-fmi1Status STDCALL placeholder_fmiGetString(fmi1Component_t c, const fmi1ValueReference vr[], size_t nvr, fmi1String  value[]) {
-    UNUSED(c);
+fmi1Status STDCALL placeholder_fmiGetString(fmi1InstanceHandle *instance, const fmi1ValueReference vr[], size_t nvr, fmi1String  value[]) {
+    UNUSED(instance);
     UNUSED(vr);
     UNUSED(nvr);
     UNUSED(value);
@@ -71,8 +71,8 @@ fmi1Status STDCALL placeholder_fmiGetString(fmi1Component_t c, const fmi1ValueRe
     return fmi1Error;
 }
 
-fmi1Status STDCALL placeholder_fmiSetReal(fmi1Component_t c, const fmi1ValueReference vr[], size_t nvr, const fmi1Real value[]) {
-    UNUSED(c);
+fmi1Status STDCALL placeholder_fmiSetReal(fmi1InstanceHandle *instance, const fmi1ValueReference vr[], size_t nvr, const fmi1Real value[]) {
+    UNUSED(instance);
     UNUSED(vr);
     UNUSED(nvr);
     UNUSED(value);
@@ -80,8 +80,8 @@ fmi1Status STDCALL placeholder_fmiSetReal(fmi1Component_t c, const fmi1ValueRefe
     return fmi1Error;
 }
 
-fmi1Status STDCALL placeholder_fmiSetInteger(fmi1Component_t c, const fmi1ValueReference vr[], size_t nvr, const fmi1Integer value[]) {
-    UNUSED(c);
+fmi1Status STDCALL placeholder_fmiSetInteger(fmi1InstanceHandle *instance, const fmi1ValueReference vr[], size_t nvr, const fmi1Integer value[]) {
+    UNUSED(instance);
     UNUSED(vr);
     UNUSED(nvr);
     UNUSED(value);
@@ -89,8 +89,8 @@ fmi1Status STDCALL placeholder_fmiSetInteger(fmi1Component_t c, const fmi1ValueR
     return fmi1Error;
 }
 
-fmi1Status STDCALL placeholder_fmiSetBoolean(fmi1Component_t c, const fmi1ValueReference vr[], size_t nvr, const fmi1Boolean value[]) {
-    UNUSED(c);
+fmi1Status STDCALL placeholder_fmiSetBoolean(fmi1InstanceHandle *instance, const fmi1ValueReference vr[], size_t nvr, const fmi1Boolean value[]) {
+    UNUSED(instance);
     UNUSED(vr);
     UNUSED(nvr);
     UNUSED(value);
@@ -98,23 +98,23 @@ fmi1Status STDCALL placeholder_fmiSetBoolean(fmi1Component_t c, const fmi1ValueR
     return fmi1Error;
 }
 
-fmi1Status STDCALL placeholder_fmiSetString(fmi1Component_t c, const fmi1ValueReference vr[], size_t nvr, const fmi1String value[]) {
-    UNUSED(c);
+fmi1Status STDCALL placeholder_fmiSetString(fmi1InstanceHandle *instance, const fmi1ValueReference vr[], size_t nvr, const fmi1String value[]) {
+    UNUSED(instance);
     UNUSED(vr);
     UNUSED(nvr);
     UNUSED(value);
    NOT_IMPLEMENTED(fmiSetString);
    return fmi1Error;
 }
-fmi1Component_t STDCALL placeholder_fmiInstantiateSlave(fmi1String instanceName,
-                                                fmi1String fmuGUID,
-                                                fmi1String fmuLocation,
-                                                fmi1String mimeType,
-                                                fmi1Real timeout,
-                                                fmi1Boolean visible,
-                                                fmi1Boolean interactive,
-                                                fmi1CallbackFunctionsCoSimulation functions,
-                                                fmi1Boolean loggingOn) {
+fmi1InstanceHandle *STDCALL placeholder_fmiInstantiateSlave(fmi1String instanceName,
+                                                            fmi1String fmuGUID,
+                                                            fmi1String fmuLocation,
+                                                            fmi1String mimeType,
+                                                            fmi1Real timeout,
+                                                            fmi1Boolean visible,
+                                                            fmi1Boolean interactive,
+                                                            fmi1CallbackFunctionsCoSimulation functions,
+                                                            fmi1Boolean loggingOn) {
     UNUSED(instanceName);
     UNUSED(fmuGUID);
     UNUSED(fmuLocation);
@@ -128,11 +128,11 @@ fmi1Component_t STDCALL placeholder_fmiInstantiateSlave(fmi1String instanceName,
     return NULL;
 }
 
-fmi1Status STDCALL placeholder_fmiInitializeSlave(fmi1Component_t c,
-                                          fmi1Real tStart,
-                                          fmi1Boolean StopTimeDefined,
-                                          fmi1Real tStop) {
-    UNUSED(c);
+fmi1Status STDCALL placeholder_fmiInitializeSlave(fmi1InstanceHandle *instance,
+                                                  fmi1Real tStart,
+                                                  fmi1Boolean StopTimeDefined,
+                                                  fmi1Real tStop) {
+    UNUSED(instance);
     UNUSED(tStart);
     UNUSED(StopTimeDefined);
     UNUSED(tStop);
@@ -140,29 +140,29 @@ fmi1Status STDCALL placeholder_fmiInitializeSlave(fmi1Component_t c,
     return fmi1Error;
 }
 
-fmi1Status STDCALL placeholder_fmiTerminateSlave(fmi1Component_t c) {
-    UNUSED(c);
+fmi1Status STDCALL placeholder_fmiTerminateSlave(fmi1InstanceHandle *instance) {
+    UNUSED(instance);
     NOT_IMPLEMENTED(fmiTerminateSlave);
     return fmi1Error;
 }
 
-fmi1Status STDCALL placeholder_fmiResetSlave(fmi1Component_t c) {
-    UNUSED(c);
+fmi1Status STDCALL placeholder_fmiResetSlave(fmi1InstanceHandle *instance) {
+    UNUSED(instance);
     NOT_IMPLEMENTED(fmiResetSlave);
     return fmi1Error;
 }
 
-void STDCALL placeholder_fmiFreeSlaveInstance(fmi1Component_t c) {
-    UNUSED(c);
+void STDCALL placeholder_fmiFreeSlaveInstance(fmi1InstanceHandle *instance) {
+    UNUSED(instance);
     NOT_IMPLEMENTED(fmiFreeSlaveInstance);
 }
 
-fmi1Status STDCALL placeholder_fmiSetRealInputDerivatives(fmiComponent c,
-                                                  const  fmiValueReference vr[],
-                                                  size_t nvr,
-                                                  const  fmi1Integer order[],
-                                                  const  fmi1Real value[]) {
-    UNUSED(c);
+fmi1Status STDCALL placeholder_fmiSetRealInputDerivatives(fmi1InstanceHandle *instance,
+                                                          const  fmiValueReference vr[],
+                                                          size_t nvr,
+                                                          const  fmi1Integer order[],
+                                                          const  fmi1Real value[]) {
+    UNUSED(instance);
     UNUSED(vr);
     UNUSED(nvr);
     UNUSED(order);
@@ -171,12 +171,12 @@ fmi1Status STDCALL placeholder_fmiSetRealInputDerivatives(fmiComponent c,
     return fmi1Error;
 }
 
-fmi1Status STDCALL placeholder_fmiGetRealOutputDerivatives(fmi1Component_t c,
+fmi1Status STDCALL placeholder_fmiGetRealOutputDerivatives(fmi1InstanceHandle *instance,
                                                    const fmi1ValueReference vr[],
                                                    size_t nvr,
                                                    const fmi1Integer order[],
                                                    fmi1Real value[]) {
-    UNUSED(c);
+    UNUSED(instance);
     UNUSED(vr);
     UNUSED(nvr);
     UNUSED(order);
@@ -185,17 +185,17 @@ fmi1Status STDCALL placeholder_fmiGetRealOutputDerivatives(fmi1Component_t c,
     return fmi1Error;
 }
 
-fmi1Status STDCALL placeholder_fmiCancelStep(fmi1Component_t c) {
-    UNUSED(c);
+fmi1Status STDCALL placeholder_fmiCancelStep(fmi1InstanceHandle *instance) {
+    UNUSED(instance);
     NOT_IMPLEMENTED(fmiCancelStep);
     return fmi1Error;
 }
 
-fmi1Status STDCALL placeholder_fmiDoStep(fmi1Component_t c,
+fmi1Status STDCALL placeholder_fmiDoStep(fmi1InstanceHandle *instance,
                                  fmi1Real currentCommunicationPoint,
                                  fmi1Real communicationStepSize,
                                  fmi1Boolean newStep) {
-    UNUSED(c);
+    UNUSED(instance);
     UNUSED(currentCommunicationPoint);
     UNUSED(communicationStepSize);
     UNUSED(newStep);
@@ -203,40 +203,40 @@ fmi1Status STDCALL placeholder_fmiDoStep(fmi1Component_t c,
     return fmi1Error;
 }
 
-fmi1Status STDCALL placeholder_fmiGetStatus(fmi1Component_t c, const fmi1StatusKind s, fmi1Status* value) {
-    UNUSED(c);
+fmi1Status STDCALL placeholder_fmiGetStatus(fmi1InstanceHandle *instance, const fmi1StatusKind s, fmi1Status* value) {
+    UNUSED(instance);
     UNUSED(s);
     UNUSED(value);
     NOT_IMPLEMENTED(fmiGetStatus);
     return fmi1Error;
 }
 
-fmi1Status STDCALL placeholder_fmiGetRealStatus(fmi1Component_t c, const fmi1StatusKind s, fmi1Real* value) {
-    UNUSED(c);
+fmi1Status STDCALL placeholder_fmiGetRealStatus(fmi1InstanceHandle *instance, const fmi1StatusKind s, fmi1Real* value) {
+    UNUSED(instance);
     UNUSED(s);
     UNUSED(value);
     NOT_IMPLEMENTED(fmiGetRealStatus);
     return fmi1Error;
 }
 
-fmi1Status STDCALL placeholder_fmiGetIntegerStatus(fmi1Component_t c, const fmi1StatusKind s, fmi1Integer* value) {
-    UNUSED(c);
+fmi1Status STDCALL placeholder_fmiGetIntegerStatus(fmi1InstanceHandle *instance, const fmi1StatusKind s, fmi1Integer* value) {
+    UNUSED(instance);
     UNUSED(s);
     UNUSED(value);
     NOT_IMPLEMENTED(fmiGetIntegerStatus);
     return fmi1Error;
 }
 
-fmi1Status STDCALL placeholder_fmiGetBooleanStatus(fmi1Component_t c, const fmi1StatusKind s, fmi1Boolean* value) {
-    UNUSED(c);
+fmi1Status STDCALL placeholder_fmiGetBooleanStatus(fmi1InstanceHandle *instance, const fmi1StatusKind s, fmi1Boolean* value) {
+    UNUSED(instance);
     UNUSED(s);
     UNUSED(value);
     NOT_IMPLEMENTED(fmiGetBooleanStatus);
     return fmi1Error;
 }
 
-fmi1Status STDCALL placeholder_fmiGetStringStatus(fmi1Component_t c, const fmi1StatusKind s, fmi1String* value) {
-    UNUSED(c);
+fmi1Status STDCALL placeholder_fmiGetStringStatus(fmi1InstanceHandle *instance, const fmi1StatusKind s, fmi1String* value) {
+    UNUSED(instance);
     UNUSED(s);
     UNUSED(value);
     NOT_IMPLEMENTED(fmiGetStringStatus);
@@ -248,7 +248,7 @@ const char* STDCALL placeholder_fmiGetModelTypesPlatform() {
     return NULL;
 }
 
-fmi1Component_t STDCALL placeholder_fmiInstantiateModel(fmi1String instanceName,
+fmi1InstanceHandle *STDCALL placeholder_fmiInstantiateModel(fmi1String instanceName,
                                                 fmi1String fmuGUID,
                                                 fmi1CallbackFunctionsModelExchange functions,
                                                 fmi1Boolean loggingOn) {
@@ -260,41 +260,41 @@ fmi1Component_t STDCALL placeholder_fmiInstantiateModel(fmi1String instanceName,
     return NULL;
 }
 
-void STDCALL placeholder_fmiFreeModelInstance(fmi1Component_t c) {
-    UNUSED(c);
+void STDCALL placeholder_fmiFreeModelInstance(fmi1InstanceHandle *instance) {
+    UNUSED(instance);
     NOT_IMPLEMENTED(fmiFreeModelInstance);
 }
 
-fmi1Status STDCALL placeholder_fmiSetTime(fmi1Component_t c,
+fmi1Status STDCALL placeholder_fmiSetTime(fmi1InstanceHandle *instance,
                                   fmi1Real time) {
-    UNUSED(c);
+    UNUSED(instance);
     UNUSED(time);
     NOT_IMPLEMENTED(fmiSetTime);
     return fmi1Error;
 }
 
-fmi1Status STDCALL placeholder_fmiSetContinuousStates(fmi1Component_t c,
+fmi1Status STDCALL placeholder_fmiSetContinuousStates(fmi1InstanceHandle *instance,
                                               const fmi1Real x[],
                                               size_t nx) {
-    UNUSED(c);
+    UNUSED(instance);
     UNUSED(x);
     UNUSED(nx);
     NOT_IMPLEMENTED(fmiSetContinuousStates);
     return fmi1Error;
 }
 
-fmi1Status STDCALL placeholder_fmiCompletedIntegratorStep(fmi1Component_t c, fmi1Boolean* callEventUpdate) {
-    UNUSED(c);
+fmi1Status STDCALL placeholder_fmiCompletedIntegratorStep(fmi1InstanceHandle *instance, fmi1Boolean* callEventUpdate) {
+    UNUSED(instance);
     UNUSED(callEventUpdate);
     NOT_IMPLEMENTED(fmiCompletedIntegratorStep);
     return fmi1Error;
 }
 
-fmi1Status STDCALL placeholder_fmiInitialize(fmi1Component_t c,
+fmi1Status STDCALL placeholder_fmiInitialize(fmi1InstanceHandle *instance,
                                      fmi1Boolean toleranceControlled,
                                      fmi1Real relativeTolerance,
                                      fmi1EventInfo *eventInfo) {
-    UNUSED(c);
+    UNUSED(instance);
     UNUSED(toleranceControlled);
     UNUSED(relativeTolerance);
     UNUSED(eventInfo);
@@ -302,68 +302,68 @@ fmi1Status STDCALL placeholder_fmiInitialize(fmi1Component_t c,
     return fmi1Error;
 }
 
-fmi1Status STDCALL placeholder_fmiGetDerivatives(fmi1Component_t c,
+fmi1Status STDCALL placeholder_fmiGetDerivatives(fmi1InstanceHandle *instance,
                                          fmi1Real derivatives[],
                                          size_t nx) {
-    UNUSED(c);
+    UNUSED(instance);
     UNUSED(derivatives);
     UNUSED(nx);
     NOT_IMPLEMENTED(fmiGetDerivatives);
     return fmi1Error;
 }
 
-fmi1Status STDCALL placeholder_fmiGetEventIndicators(fmi1Component_t c,
+fmi1Status STDCALL placeholder_fmiGetEventIndicators(fmi1InstanceHandle *instance,
                                              fmi1Real eventIndicators[],
                                              size_t ni) {
-    UNUSED(c);
+    UNUSED(instance);
     UNUSED(eventIndicators);
     UNUSED(ni);
     NOT_IMPLEMENTED(fmiGetEventIndicators);
     return fmi1Error;
 }
 
-fmi1Status STDCALL placeholder_fmiEventUpdate(fmi1Component_t c,
+fmi1Status STDCALL placeholder_fmiEventUpdate(fmi1InstanceHandle *instance,
                                       fmi1Boolean intermediateResults,
                                       fmi1EventInfo* eventInfo) {
-    UNUSED(c);
+    UNUSED(instance);
     UNUSED(intermediateResults);
     UNUSED(eventInfo);
     NOT_IMPLEMENTED(fmiEventUpdate);
     return fmi1Error;
 }
 
-fmi1Status STDCALL placeholder_fmiGetContinuousStates(fmi1Component_t c,
+fmi1Status STDCALL placeholder_fmiGetContinuousStates(fmi1InstanceHandle *instance,
                                               fmi1Real states[],
                                               size_t nx) {
-    UNUSED(c);
+    UNUSED(instance);
     UNUSED(states);
     UNUSED(nx);
     NOT_IMPLEMENTED(fmiGetContinuousStates);
     return fmi1Error;
 }
 
-fmi1Status STDCALL placeholder_fmiGetNominalContinuousStates(fmi1Component_t c,
+fmi1Status STDCALL placeholder_fmiGetNominalContinuousStates(fmi1InstanceHandle *instance,
                                                      fmi1Real x_nominal[],
                                                      size_t nx) {
-    UNUSED(c);
+    UNUSED(instance);
     UNUSED(x_nominal);
     UNUSED(nx);
     NOT_IMPLEMENTED(fmiGetNominalContinuousStates);
     return fmi1Error;
 }
 
-fmi1Status STDCALL placeholder_fmiGetStateValueReferences(fmi1Component_t c,
+fmi1Status STDCALL placeholder_fmiGetStateValueReferences(fmi1InstanceHandle *instance,
                                                   fmi1ValueReference vrx[],
                                                   size_t nx) {
-    UNUSED(c);
+    UNUSED(instance);
     UNUSED(vrx);
     UNUSED(nx);
     NOT_IMPLEMENTED(fmiGetStateValueReferences);
     return fmi1Error;
 }
 
-fmi1Status STDCALL placeholder_fmiTerminate(fmi1Component_t c) {
-    UNUSED(c);
+fmi1Status STDCALL placeholder_fmiTerminate(fmi1InstanceHandle *instance) {
+    UNUSED(instance);
     NOT_IMPLEMENTED(fmiTerminate);
     return fmi1Error;
 }
@@ -378,11 +378,11 @@ const char* STDCALL placeholder_fmi2_getVersion(void) {
     return NULL;
 }
 
-fmi2Status STDCALL placeholder_fmi2_setDebugLogging(fmi2InstanceHandle* c,
+fmi2Status STDCALL placeholder_fmi2_setDebugLogging(fmi2InstanceHandle* instance,
                                fmi2Boolean loggingOn,
                                size_t nCategories,
                                const fmi2String categories[]) {
-    UNUSED(c);
+    UNUSED(instance);
     UNUSED(loggingOn);
     UNUSED(nCategories);
     UNUSED(categories);

--- a/src/fmi4c_placeholders.h
+++ b/src/fmi4c_placeholders.h
@@ -378,7 +378,7 @@ const char* STDCALL placeholder_fmi2_getVersion(void) {
     return NULL;
 }
 
-fmi2Status STDCALL placeholder_fmi2_setDebugLogging(fmi2Component c,
+fmi2Status STDCALL placeholder_fmi2_setDebugLogging(fmi2InstanceHandle* c,
                                fmi2Boolean loggingOn,
                                size_t nCategories,
                                const fmi2String categories[]) {
@@ -410,19 +410,19 @@ fmi2Component STDCALL placeholder_fmi2Instantiate(fmi2String instanceName,
     return NULL;
 }
 
-void STDCALL placeholder_fmi2FreeInstance(fmi2Component c) {
-    UNUSED(c);
+void STDCALL placeholder_fmi2FreeInstance(fmi2InstanceHandle* instance) {
+    UNUSED(instance);
     NOT_IMPLEMENTED(fmi2FreeInstance);
 }
 
 /* Enter and exit initialization mode, terminate and reset */
-fmi2Status STDCALL placeholder_fmi2_setupExperiment(fmi2Component c,
+fmi2Status STDCALL placeholder_fmi2_setupExperiment(fmi2InstanceHandle* instance,
                                            fmi2Boolean toleranceDefined,
                                            fmi2Real tolerance,
                                            fmi2Real startTime,
                                            fmi2Boolean stopTimeDefined,
                                            fmi2Real stopTime) {
-    UNUSED(c);
+    UNUSED(instance);
     UNUSED(toleranceDefined);
     UNUSED(tolerance);
     UNUSED(startTime);
@@ -432,35 +432,35 @@ fmi2Status STDCALL placeholder_fmi2_setupExperiment(fmi2Component c,
     return fmi2Error;
 }
 
-fmi2Status STDCALL placeholder_fmi2EnterInitializationMode(fmi2Component c) {
-    UNUSED(c);
+fmi2Status STDCALL placeholder_fmi2EnterInitializationMode(fmi2InstanceHandle* instance) {
+    UNUSED(instance);
     NOT_IMPLEMENTED(fmi2EnterInitializationMode);
     return fmi2Error;
 }
 
-fmi2Status STDCALL placeholder_fmi2ExitInitializationMode(fmi2Component c) {
-    UNUSED(c);
+fmi2Status STDCALL placeholder_fmi2ExitInitializationMode(fmi2InstanceHandle* instance) {
+    UNUSED(instance);
     NOT_IMPLEMENTED(fmi2ExitInitializationMode);
     return fmi2Error;
 }
 
-fmi2Status STDCALL placeholder_fmi2Terminate(fmi2Component c) {
-    UNUSED(c);
+fmi2Status STDCALL placeholder_fmi2Terminate(fmi2InstanceHandle* instance) {
+    UNUSED(instance);
     NOT_IMPLEMENTED(fmi2Terminate);
     return fmi2Error;
 }
 
-fmi2Status STDCALL placeholder_fmi2Reset(fmi2Component c) {
-    UNUSED(c);
+fmi2Status STDCALL placeholder_fmi2Reset(fmi2InstanceHandle* instance) {
+    UNUSED(instance);
     NOT_IMPLEMENTED(fmi2Reset);
     return fmi2Error;
 }
 
-fmi2Status STDCALL placeholder_fmi2_getReal(fmi2Component c,
+fmi2Status STDCALL placeholder_fmi2_getReal(fmi2InstanceHandle* instance,
                                    const fmi2ValueReference vr[],
                                    size_t nvr,
                                    fmi2Real value[]) {
-    UNUSED(c);
+    UNUSED(instance);
     UNUSED(vr);
     UNUSED(nvr);
     UNUSED(value);
@@ -468,11 +468,11 @@ fmi2Status STDCALL placeholder_fmi2_getReal(fmi2Component c,
     return fmi2Error;
 }
 
-fmi2Status STDCALL placeholder_fmi2_getInteger(fmi2Component c,
+fmi2Status STDCALL placeholder_fmi2_getInteger(fmi2InstanceHandle* instance,
                                    const fmi2ValueReference vr[],
                                    size_t nvr,
                                    fmi2Integer value[]) {
-    UNUSED(c);
+    UNUSED(instance);
     UNUSED(vr);
     UNUSED(nvr);
     UNUSED(value);
@@ -480,11 +480,11 @@ fmi2Status STDCALL placeholder_fmi2_getInteger(fmi2Component c,
     return fmi2Error;
 }
 
-fmi2Status STDCALL placeholder_fmi2_getBoolean(fmi2Component c,
+fmi2Status STDCALL placeholder_fmi2_getBoolean(fmi2InstanceHandle* instance,
                                    const fmi2ValueReference vr[],
                                    size_t nvr,
                                    fmi2Boolean value[]) {
-    UNUSED(c);
+    UNUSED(instance);
     UNUSED(vr);
     UNUSED(nvr);
     UNUSED(value);
@@ -492,11 +492,11 @@ fmi2Status STDCALL placeholder_fmi2_getBoolean(fmi2Component c,
     return fmi2Error;
 }
 
-fmi2Status STDCALL placeholder_fmi2_getString(fmi2Component c,
+fmi2Status STDCALL placeholder_fmi2_getString(fmi2InstanceHandle* instance,
                                      const fmi2ValueReference vr[],
                                      size_t nvr,
                                      fmi2String value[]) {
-    UNUSED(c);
+    UNUSED(instance);
     UNUSED(vr);
     UNUSED(nvr);
     UNUSED(value);
@@ -504,11 +504,11 @@ fmi2Status STDCALL placeholder_fmi2_getString(fmi2Component c,
     return fmi2Error;
 }
 
-fmi2Status STDCALL placeholder_fmi2_setReal(fmi2Component c,
+fmi2Status STDCALL placeholder_fmi2_setReal(fmi2InstanceHandle* instance,
                                    const fmi2ValueReference vr[],
                                    size_t nvr,
                                    const fmi2Real value[]) {
-    UNUSED(c);
+    UNUSED(instance);
     UNUSED(vr);
     UNUSED(nvr);
     UNUSED(value);
@@ -516,11 +516,11 @@ fmi2Status STDCALL placeholder_fmi2_setReal(fmi2Component c,
     return fmi2Error;
 }
 
-fmi2Status STDCALL placeholder_fmi2_setInteger(fmi2Component c,
+fmi2Status STDCALL placeholder_fmi2_setInteger(fmi2InstanceHandle* instance,
                                    const fmi2ValueReference vr[],
                                    size_t nvr,
                                    const fmi2Integer value[]) {
-    UNUSED(c);
+    UNUSED(instance);
     UNUSED(vr);
     UNUSED(nvr);
     UNUSED(value);
@@ -528,11 +528,11 @@ fmi2Status STDCALL placeholder_fmi2_setInteger(fmi2Component c,
     return fmi2Error;
 }
 
-fmi2Status STDCALL placeholder_fmi2_setBoolean(fmi2Component c,
+fmi2Status STDCALL placeholder_fmi2_setBoolean(fmi2InstanceHandle* instance,
                                    const fmi2ValueReference vr[],
                                    size_t nvr,
                                    const fmi2Boolean value[]) {
-    UNUSED(c);
+    UNUSED(instance);
     UNUSED(vr);
     UNUSED(nvr);
     UNUSED(value);
@@ -540,11 +540,11 @@ fmi2Status STDCALL placeholder_fmi2_setBoolean(fmi2Component c,
     return fmi2Error;
 }
 
-fmi2Status STDCALL placeholder_fmi2_setString(fmi2Component c,
+fmi2Status STDCALL placeholder_fmi2_setString(fmi2InstanceHandle* instance,
                                    const fmi2ValueReference vr[],
                                    size_t nvr,
                                    const fmi2String value[]) {
-    UNUSED(c);
+    UNUSED(instance);
     UNUSED(vr);
     UNUSED(nvr);
     UNUSED(value);
@@ -552,33 +552,33 @@ fmi2Status STDCALL placeholder_fmi2_setString(fmi2Component c,
     return fmi2Error;
 }
 
-fmi2Status STDCALL placeholder_fmi2EnterEventMode(fmi2Component c) {
-    UNUSED(c);
+fmi2Status STDCALL placeholder_fmi2EnterEventMode(fmi2InstanceHandle* instance) {
+    UNUSED(instance);
     NOT_IMPLEMENTED(fmi2EnterEventMode);
     return fmi2Error;
 }
 
-fmi2Status STDCALL placeholder_fmi2NewDiscreteStates(fmi2Component c, fmi2EventInfo* eventInfo)
+fmi2Status STDCALL placeholder_fmi2NewDiscreteStates(fmi2InstanceHandle* instance, fmi2EventInfo* eventInfo)
 {
-    UNUSED(c);
+    UNUSED(instance);
     UNUSED(eventInfo);
     NOT_IMPLEMENTED(fmi2NewDiscreteStates);
     return fmi2Error;
 }
 
-fmi2Status STDCALL placeholder_fmi2EnterContinuousTimeMode(fmi2Component c)
+fmi2Status STDCALL placeholder_fmi2EnterContinuousTimeMode(fmi2InstanceHandle* instance)
 {
-    UNUSED(c);
+    UNUSED(instance);
     NOT_IMPLEMENTED(fmi2EnterContinuousTimeMode);
     return fmi2Error;
 }
 
-fmi2Status STDCALL placeholder_fmi2CompletedIntegratorStep(fmi2Component c,
+fmi2Status STDCALL placeholder_fmi2CompletedIntegratorStep(fmi2InstanceHandle* instance,
                                        fmi2Boolean noSetFMUStatePriorToCurrentPoint,
                                        fmi2Boolean* enterEventMode,
                                        fmi2Boolean* terminateSimulation)
 {
-    UNUSED(c);
+    UNUSED(instance);
     UNUSED(noSetFMUStatePriorToCurrentPoint);
     UNUSED(enterEventMode);
     UNUSED(terminateSimulation);
@@ -586,74 +586,74 @@ fmi2Status STDCALL placeholder_fmi2CompletedIntegratorStep(fmi2Component c,
     return fmi2Error;
 }
 
-fmi2Status STDCALL placeholder_fmi2_setTime(fmi2Component c, fmi2Real time)
+fmi2Status STDCALL placeholder_fmi2_setTime(fmi2InstanceHandle* instance, fmi2Real time)
 {
-    UNUSED(c);
+    UNUSED(instance);
     UNUSED(time);
     NOT_IMPLEMENTED(fmi2_setTime);
     return fmi2Error;
 }
 
-fmi2Status STDCALL placeholder_fmi2_setContinuousStates(fmi2Component c,
+fmi2Status STDCALL placeholder_fmi2_setContinuousStates(fmi2InstanceHandle* instance,
                                                const fmi2Real states[],
                                                size_t nStates)
 {
-    UNUSED(c);
+    UNUSED(instance);
     UNUSED(states);
     UNUSED(nStates);
     NOT_IMPLEMENTED(fmi2_setContinuousStates);
     return fmi2Error;
 }
 
-fmi2Status STDCALL placeholder_fmi2_getDerivatives(fmi2Component c,
+fmi2Status STDCALL placeholder_fmi2_getDerivatives(fmi2InstanceHandle* instance,
                                           fmi2Real derivatives[],
                                           size_t nx)
 {
-    UNUSED(c);
+    UNUSED(instance);
     UNUSED(derivatives);
     UNUSED(nx);
     NOT_IMPLEMENTED(fmi2_getDerivatives);
     return fmi2Error;
 }
 
-fmi2Status STDCALL placeholder_fmi2_getEventIndicators(fmi2Component c,
+fmi2Status STDCALL placeholder_fmi2_getEventIndicators(fmi2InstanceHandle* instance,
                                               fmi2Real eventIndicators[],
                                               size_t ni)
 {
-   UNUSED(c);
+   UNUSED(instance);
    UNUSED(eventIndicators);
    UNUSED(ni);
    NOT_IMPLEMENTED(fmi2_getEventIndicators);
    return fmi2Error;
 }
 
-fmi2Status STDCALL placeholder_fmi2_getContinuousStates(fmi2Component c,
+fmi2Status STDCALL placeholder_fmi2_getContinuousStates(fmi2InstanceHandle* instance,
                                    fmi2Real states[],
                                    size_t nStates)
 {
-    UNUSED(c);
+    UNUSED(instance);
     UNUSED(states);
     UNUSED(nStates);
     NOT_IMPLEMENTED(fmi2_getContinuousStates);
     return fmi2Error;
 }
 
-fmi2Status STDCALL placeholder_fmi2_getNominalsOfContinuousStates(fmi2Component c,
+fmi2Status STDCALL placeholder_fmi2_getNominalsOfContinuousStates(fmi2InstanceHandle* instance,
                                                          fmi2Real x_nominal[],
                                                          size_t nx)
 {
-    UNUSED(c);
+    UNUSED(instance);
     UNUSED(x_nominal);
     UNUSED(nx);
     NOT_IMPLEMENTED(fmi2_getNominalsOfContinuousStates);
     return fmi2Error;
 }
 
-fmi2Status STDCALL placeholder_fmi2DoStep(fmi2Component c,
+fmi2Status STDCALL placeholder_fmi2DoStep(fmi2InstanceHandle* instance,
                       fmi2Real currentCommunicationPoint,
                       fmi2Real communicationStepSize,
                       fmi2Boolean noSetFMUStatePriorToCurrentPoint) {
-    UNUSED(c);
+    UNUSED(instance);
     UNUSED(currentCommunicationPoint);
     UNUSED(communicationStepSize);
     UNUSED(noSetFMUStatePriorToCurrentPoint);
@@ -661,45 +661,45 @@ fmi2Status STDCALL placeholder_fmi2DoStep(fmi2Component c,
     return fmi2OK;
 }
 
-fmi2Status STDCALL placeholder_fmi2_getFMUstate(fmi2Component c,
+fmi2Status STDCALL placeholder_fmi2_getFMUstate(fmi2InstanceHandle* instance,
                                        fmi2FMUstate* FMUstate) {
-    UNUSED(c);
+    UNUSED(instance);
     UNUSED(FMUstate);
     NOT_IMPLEMENTED(fmi2_getFMUstate);
     return fmi2Error;
 }
 
-fmi2Status STDCALL placeholder_fmi2_setFMUstate(fmi2Component c,
+fmi2Status STDCALL placeholder_fmi2_setFMUstate(fmi2InstanceHandle* instance,
                                        fmi2FMUstate FMUstate) {
-    UNUSED(c);
+    UNUSED(instance);
     UNUSED(FMUstate);
     NOT_IMPLEMENTED(fmi2_setFMUstate);
     return fmi2Error;
 }
 
-fmi2Status STDCALL placeholder_fmi2FreeFMUstate(fmi2Component c,
+fmi2Status STDCALL placeholder_fmi2FreeFMUstate(fmi2InstanceHandle* instance,
                                         fmi2FMUstate* FMUstate) {
-    UNUSED(c);
+    UNUSED(instance);
     UNUSED(FMUstate);
     NOT_IMPLEMENTED(fmi2FreeFMUstate);
     return fmi2Error;
 }
 
-fmi2Status STDCALL placeholder_fmi2SerializedFMUstateSize(fmi2Component c,
+fmi2Status STDCALL placeholder_fmi2SerializedFMUstateSize(fmi2InstanceHandle* instance,
                                                   fmi2FMUstate FMUstate,
                                                   size_t* size) {
-    UNUSED(c);
+    UNUSED(instance);
     UNUSED(FMUstate);
     UNUSED(size);
     NOT_IMPLEMENTED(fmi2SerializedFMUstateSize);
     return fmi2Error;
 }
 
-fmi2Status STDCALL placeholder_fmi2SerializeFMUstate(fmi2Component c,
+fmi2Status STDCALL placeholder_fmi2SerializeFMUstate(fmi2InstanceHandle* instance,
                                              fmi2FMUstate FMUstate,
                                              fmi2Byte serializedState[],
                                              size_t size) {
-    UNUSED(c);
+    UNUSED(instance);
     UNUSED(FMUstate);
     UNUSED(serializedState);
     UNUSED(size);
@@ -707,11 +707,11 @@ fmi2Status STDCALL placeholder_fmi2SerializeFMUstate(fmi2Component c,
     return fmi2Error;
 }
 
-fmi2Status STDCALL placeholder_fmi2DeSerializeFMUstate(fmi2Component c,
+fmi2Status STDCALL placeholder_fmi2DeSerializeFMUstate(fmi2InstanceHandle* instance,
                                                const fmi2Byte serializedState[],
                                                size_t size,
                                                fmi2FMUstate* FMUstate) {
-    UNUSED(c);
+    UNUSED(instance);
     UNUSED(serializedState);
     UNUSED(size);
     UNUSED(FMUstate);
@@ -719,14 +719,14 @@ fmi2Status STDCALL placeholder_fmi2DeSerializeFMUstate(fmi2Component c,
     return fmi2Error;
 }
 
-fmi2Status STDCALL placeholder_fmi2_getDirectionalDerivative(fmi2Component c,
+fmi2Status STDCALL placeholder_fmi2_getDirectionalDerivative(fmi2InstanceHandle* instance,
                                                     const fmi2ValueReference vUnknownRef[],
                                                     size_t nUnknown,
                                                     const fmi2ValueReference vKnownRef[],
                                                     size_t nKnown,
                                                     const fmi2Real dvKnown[],
                                                     fmi2Real dvUnknown[]) {
-    UNUSED(c);
+    UNUSED(instance);
     UNUSED(vUnknownRef);
     UNUSED(nUnknown);
     UNUSED(vKnownRef);
@@ -737,12 +737,12 @@ fmi2Status STDCALL placeholder_fmi2_getDirectionalDerivative(fmi2Component c,
     return fmi2Error;
 }
 
-fmi2Status STDCALL placeholder_fmi2_setRealInputDerivatives(fmi2Component c,
+fmi2Status STDCALL placeholder_fmi2_setRealInputDerivatives(fmi2InstanceHandle* instance,
                                                    const fmi2ValueReference vr[],
                                                    size_t nvr,
                                                    const fmi2Integer order[],
                                                    const fmi2Real value[]) {
-    UNUSED(c);
+    UNUSED(instance);
     UNUSED(vr);
     UNUSED(nvr);
     UNUSED(order);
@@ -751,12 +751,12 @@ fmi2Status STDCALL placeholder_fmi2_setRealInputDerivatives(fmi2Component c,
     return fmi2Error;
 }
 
-fmi2Status STDCALL placeholder_fmi2_getRealOutputDerivatives(fmi2Component c,
+fmi2Status STDCALL placeholder_fmi2_getRealOutputDerivatives(fmi2InstanceHandle* instance,
                                                     const fmi2ValueReference vr[],
                                                     size_t nvr,
                                                     const fmi2Integer order[],
                                                     fmi2Real value[]) {
-    UNUSED(c);
+    UNUSED(instance);
     UNUSED(vr);
     UNUSED(nvr);
     UNUSED(order);
@@ -765,48 +765,48 @@ fmi2Status STDCALL placeholder_fmi2_getRealOutputDerivatives(fmi2Component c,
     return fmi2Error;
 }
 
-fmi2Status STDCALL placeholder_fmi2CancelStep(fmi2Component c) {
-    UNUSED(c);
+fmi2Status STDCALL placeholder_fmi2CancelStep(fmi2InstanceHandle* instance) {
+    UNUSED(instance);
     NOT_IMPLEMENTED(fmi2CancelStep);
     return fmi2Error;
 }
 
-fmi2Status STDCALL placeholder_fmi2_getStatus(fmi2Component c, const fmi2StatusKind s, fmi2Status* value) {
-    UNUSED(c);
+fmi2Status STDCALL placeholder_fmi2_getStatus(fmi2InstanceHandle* instance, const fmi2StatusKind s, fmi2Status* value) {
+    UNUSED(instance);
     UNUSED(s);
     UNUSED(value);
     NOT_IMPLEMENTED(fmi2_getStatus);
     return fmi2Error;
 }
 
-fmi2Status STDCALL placeholder_fmi2_getRealStatus(fmi2Component c, const fmi2StatusKind s, fmi2Real* value) {
-    UNUSED(c);
+fmi2Status STDCALL placeholder_fmi2_getRealStatus(fmi2InstanceHandle* instance, const fmi2StatusKind s, fmi2Real* value) {
+    UNUSED(instance);
     UNUSED(s);
     UNUSED(value);
     NOT_IMPLEMENTED(fmi2_getRealStatus);
     return fmi2Error;
 }
 
-fmi2Status STDCALL placeholder_fmi2_getIntegerStatus(fmi2Component c, const fmi2StatusKind s, fmi2Integer* value) {
-    UNUSED(c);
+fmi2Status STDCALL placeholder_fmi2_getIntegerStatus(fmi2InstanceHandle* instance, const fmi2StatusKind s, fmi2Integer* value) {
+    UNUSED(instance);
     UNUSED(s);
     UNUSED(value);
     NOT_IMPLEMENTED(fmi2_getIntegerStatus);
     return fmi2Error;
 }
 
-fmi2Status STDCALL placeholder_fmi2_getBooleanStatus(fmi2Component c, const fmi2StatusKind s, fmi2Boolean* value) {
-    UNUSED(c);
+fmi2Status STDCALL placeholder_fmi2_getBooleanStatus(fmi2InstanceHandle* instance, const fmi2StatusKind s, fmi2Boolean* value) {
+    UNUSED(instance);
     UNUSED(s);
     UNUSED(value);
     NOT_IMPLEMENTED(fmi2_getBooleanStatus);
     return fmi2Error;
 }
 
-fmi2Status STDCALL placeholder_fmi2_getStringStatus(fmi2Component c,
+fmi2Status STDCALL placeholder_fmi2_getStringStatus(fmi2InstanceHandle* instance,
                                            const fmi2StatusKind s,
                                            fmi2String* value) {
-    UNUSED(c);
+    UNUSED(instance);
     UNUSED(s);
     UNUSED(value);
     NOT_IMPLEMENTED(fmi2_getStringStatus);

--- a/src/fmi4c_placeholders.h
+++ b/src/fmi4c_placeholders.h
@@ -13,7 +13,7 @@
 
 #include <stdio.h>
 
-fmi1Status STDCALL placeholder(fmi1Component_t component, fmi1Boolean x) {
+fmi1Status STDCALL placeholder(fmi1Component component, fmi1Boolean x) {
     return fmi1Error;
 }
 
@@ -29,23 +29,23 @@ const char* STDCALL placeholder_fmiGetTypesPlatform() {
     return NULL;
 }
 
-fmi1Status STDCALL placeholder_fmiSetDebugLogging(fmi1InstanceHandle *instance, fmi1Boolean loggingOn) {
-    UNUSED(instance);
+fmi1Status STDCALL placeholder_fmiSetDebugLogging(fmi1Component *component, fmi1Boolean loggingOn) {
+    UNUSED(component);
     UNUSED(loggingOn);
     NOT_IMPLEMENTED(fmiSetDebugLogging);
     return fmi1Error;
 }
 
-fmi1Status STDCALL placeholder_fmiGetReal(fmi1InstanceHandle *instance, const fmi1ValueReference vr[], size_t nvr, fmi1Real value[]) {
-    UNUSED(instance);
+fmi1Status STDCALL placeholder_fmiGetReal(fmi1Component *component, const fmi1ValueReference vr[], size_t nvr, fmi1Real value[]) {
+    UNUSED(component);
     UNUSED(vr);
     UNUSED(nvr);
     UNUSED(value);
     NOT_IMPLEMENTED(fmiGetReal);
     return fmi1Error;
 }
-fmi1Status STDCALL placeholder_fmiGetInteger(fmi1InstanceHandle *instance, const fmi1ValueReference vr[], size_t nvr, fmi1Integer value[]) {
-    UNUSED(instance);
+fmi1Status STDCALL placeholder_fmiGetInteger(fmi1Component *component, const fmi1ValueReference vr[], size_t nvr, fmi1Integer value[]) {
+    UNUSED(component);
     UNUSED(vr);
     UNUSED(nvr);
     UNUSED(value);
@@ -53,8 +53,8 @@ fmi1Status STDCALL placeholder_fmiGetInteger(fmi1InstanceHandle *instance, const
     return fmi1Error;
 }
 
-fmi1Status STDCALL placeholder_fmiGetBoolean(fmi1InstanceHandle *instance, const fmi1ValueReference vr[], size_t nvr, fmi1Boolean value[]) {
-    UNUSED(instance);
+fmi1Status STDCALL placeholder_fmiGetBoolean(fmi1Component *component, const fmi1ValueReference vr[], size_t nvr, fmi1Boolean value[]) {
+    UNUSED(component);
     UNUSED(vr);
     UNUSED(nvr);
     UNUSED(value);
@@ -62,8 +62,8 @@ fmi1Status STDCALL placeholder_fmiGetBoolean(fmi1InstanceHandle *instance, const
     return fmi1Error;
 }
 
-fmi1Status STDCALL placeholder_fmiGetString(fmi1InstanceHandle *instance, const fmi1ValueReference vr[], size_t nvr, fmi1String  value[]) {
-    UNUSED(instance);
+fmi1Status STDCALL placeholder_fmiGetString(fmi1Component *component, const fmi1ValueReference vr[], size_t nvr, fmi1String  value[]) {
+    UNUSED(component);
     UNUSED(vr);
     UNUSED(nvr);
     UNUSED(value);
@@ -71,8 +71,8 @@ fmi1Status STDCALL placeholder_fmiGetString(fmi1InstanceHandle *instance, const 
     return fmi1Error;
 }
 
-fmi1Status STDCALL placeholder_fmiSetReal(fmi1InstanceHandle *instance, const fmi1ValueReference vr[], size_t nvr, const fmi1Real value[]) {
-    UNUSED(instance);
+fmi1Status STDCALL placeholder_fmiSetReal(fmi1Component *component, const fmi1ValueReference vr[], size_t nvr, const fmi1Real value[]) {
+    UNUSED(component);
     UNUSED(vr);
     UNUSED(nvr);
     UNUSED(value);
@@ -80,8 +80,8 @@ fmi1Status STDCALL placeholder_fmiSetReal(fmi1InstanceHandle *instance, const fm
     return fmi1Error;
 }
 
-fmi1Status STDCALL placeholder_fmiSetInteger(fmi1InstanceHandle *instance, const fmi1ValueReference vr[], size_t nvr, const fmi1Integer value[]) {
-    UNUSED(instance);
+fmi1Status STDCALL placeholder_fmiSetInteger(fmi1Component *component, const fmi1ValueReference vr[], size_t nvr, const fmi1Integer value[]) {
+    UNUSED(component);
     UNUSED(vr);
     UNUSED(nvr);
     UNUSED(value);
@@ -89,8 +89,8 @@ fmi1Status STDCALL placeholder_fmiSetInteger(fmi1InstanceHandle *instance, const
     return fmi1Error;
 }
 
-fmi1Status STDCALL placeholder_fmiSetBoolean(fmi1InstanceHandle *instance, const fmi1ValueReference vr[], size_t nvr, const fmi1Boolean value[]) {
-    UNUSED(instance);
+fmi1Status STDCALL placeholder_fmiSetBoolean(fmi1Component *component, const fmi1ValueReference vr[], size_t nvr, const fmi1Boolean value[]) {
+    UNUSED(component);
     UNUSED(vr);
     UNUSED(nvr);
     UNUSED(value);
@@ -98,8 +98,8 @@ fmi1Status STDCALL placeholder_fmiSetBoolean(fmi1InstanceHandle *instance, const
     return fmi1Error;
 }
 
-fmi1Status STDCALL placeholder_fmiSetString(fmi1InstanceHandle *instance, const fmi1ValueReference vr[], size_t nvr, const fmi1String value[]) {
-    UNUSED(instance);
+fmi1Status STDCALL placeholder_fmiSetString(fmi1Component *component, const fmi1ValueReference vr[], size_t nvr, const fmi1String value[]) {
+    UNUSED(component);
     UNUSED(vr);
     UNUSED(nvr);
     UNUSED(value);
@@ -128,11 +128,11 @@ fmi1InstanceHandle *STDCALL placeholder_fmiInstantiateSlave(fmi1String instanceN
     return NULL;
 }
 
-fmi1Status STDCALL placeholder_fmiInitializeSlave(fmi1InstanceHandle *instance,
+fmi1Status STDCALL placeholder_fmiInitializeSlave(fmi1Component *component,
                                                   fmi1Real tStart,
                                                   fmi1Boolean StopTimeDefined,
                                                   fmi1Real tStop) {
-    UNUSED(instance);
+    UNUSED(component);
     UNUSED(tStart);
     UNUSED(StopTimeDefined);
     UNUSED(tStop);
@@ -140,29 +140,29 @@ fmi1Status STDCALL placeholder_fmiInitializeSlave(fmi1InstanceHandle *instance,
     return fmi1Error;
 }
 
-fmi1Status STDCALL placeholder_fmiTerminateSlave(fmi1InstanceHandle *instance) {
-    UNUSED(instance);
+fmi1Status STDCALL placeholder_fmiTerminateSlave(fmi1Component *component) {
+    UNUSED(component);
     NOT_IMPLEMENTED(fmiTerminateSlave);
     return fmi1Error;
 }
 
-fmi1Status STDCALL placeholder_fmiResetSlave(fmi1InstanceHandle *instance) {
-    UNUSED(instance);
+fmi1Status STDCALL placeholder_fmiResetSlave(fmi1Component *component) {
+    UNUSED(component);
     NOT_IMPLEMENTED(fmiResetSlave);
     return fmi1Error;
 }
 
-void STDCALL placeholder_fmiFreeSlaveInstance(fmi1InstanceHandle *instance) {
-    UNUSED(instance);
+void STDCALL placeholder_fmiFreeSlaveInstance(fmi1Component *component) {
+    UNUSED(component);
     NOT_IMPLEMENTED(fmiFreeSlaveInstance);
 }
 
-fmi1Status STDCALL placeholder_fmiSetRealInputDerivatives(fmi1InstanceHandle *instance,
+fmi1Status STDCALL placeholder_fmiSetRealInputDerivatives(fmi1Component *component,
                                                           const  fmiValueReference vr[],
                                                           size_t nvr,
                                                           const  fmi1Integer order[],
                                                           const  fmi1Real value[]) {
-    UNUSED(instance);
+    UNUSED(component);
     UNUSED(vr);
     UNUSED(nvr);
     UNUSED(order);
@@ -171,12 +171,12 @@ fmi1Status STDCALL placeholder_fmiSetRealInputDerivatives(fmi1InstanceHandle *in
     return fmi1Error;
 }
 
-fmi1Status STDCALL placeholder_fmiGetRealOutputDerivatives(fmi1InstanceHandle *instance,
+fmi1Status STDCALL placeholder_fmiGetRealOutputDerivatives(fmi1Component *component,
                                                    const fmi1ValueReference vr[],
                                                    size_t nvr,
                                                    const fmi1Integer order[],
                                                    fmi1Real value[]) {
-    UNUSED(instance);
+    UNUSED(component);
     UNUSED(vr);
     UNUSED(nvr);
     UNUSED(order);
@@ -185,17 +185,17 @@ fmi1Status STDCALL placeholder_fmiGetRealOutputDerivatives(fmi1InstanceHandle *i
     return fmi1Error;
 }
 
-fmi1Status STDCALL placeholder_fmiCancelStep(fmi1InstanceHandle *instance) {
-    UNUSED(instance);
+fmi1Status STDCALL placeholder_fmiCancelStep(fmi1Component *component) {
+    UNUSED(component);
     NOT_IMPLEMENTED(fmiCancelStep);
     return fmi1Error;
 }
 
-fmi1Status STDCALL placeholder_fmiDoStep(fmi1InstanceHandle *instance,
+fmi1Status STDCALL placeholder_fmiDoStep(fmi1Component *component,
                                  fmi1Real currentCommunicationPoint,
                                  fmi1Real communicationStepSize,
                                  fmi1Boolean newStep) {
-    UNUSED(instance);
+    UNUSED(component);
     UNUSED(currentCommunicationPoint);
     UNUSED(communicationStepSize);
     UNUSED(newStep);
@@ -203,40 +203,40 @@ fmi1Status STDCALL placeholder_fmiDoStep(fmi1InstanceHandle *instance,
     return fmi1Error;
 }
 
-fmi1Status STDCALL placeholder_fmiGetStatus(fmi1InstanceHandle *instance, const fmi1StatusKind s, fmi1Status* value) {
-    UNUSED(instance);
+fmi1Status STDCALL placeholder_fmiGetStatus(fmi1Component *component, const fmi1StatusKind s, fmi1Status* value) {
+    UNUSED(component);
     UNUSED(s);
     UNUSED(value);
     NOT_IMPLEMENTED(fmiGetStatus);
     return fmi1Error;
 }
 
-fmi1Status STDCALL placeholder_fmiGetRealStatus(fmi1InstanceHandle *instance, const fmi1StatusKind s, fmi1Real* value) {
-    UNUSED(instance);
+fmi1Status STDCALL placeholder_fmiGetRealStatus(fmi1Component *component, const fmi1StatusKind s, fmi1Real* value) {
+    UNUSED(component);
     UNUSED(s);
     UNUSED(value);
     NOT_IMPLEMENTED(fmiGetRealStatus);
     return fmi1Error;
 }
 
-fmi1Status STDCALL placeholder_fmiGetIntegerStatus(fmi1InstanceHandle *instance, const fmi1StatusKind s, fmi1Integer* value) {
-    UNUSED(instance);
+fmi1Status STDCALL placeholder_fmiGetIntegerStatus(fmi1Component *component, const fmi1StatusKind s, fmi1Integer* value) {
+    UNUSED(component);
     UNUSED(s);
     UNUSED(value);
     NOT_IMPLEMENTED(fmiGetIntegerStatus);
     return fmi1Error;
 }
 
-fmi1Status STDCALL placeholder_fmiGetBooleanStatus(fmi1InstanceHandle *instance, const fmi1StatusKind s, fmi1Boolean* value) {
-    UNUSED(instance);
+fmi1Status STDCALL placeholder_fmiGetBooleanStatus(fmi1Component *component, const fmi1StatusKind s, fmi1Boolean* value) {
+    UNUSED(component);
     UNUSED(s);
     UNUSED(value);
     NOT_IMPLEMENTED(fmiGetBooleanStatus);
     return fmi1Error;
 }
 
-fmi1Status STDCALL placeholder_fmiGetStringStatus(fmi1InstanceHandle *instance, const fmi1StatusKind s, fmi1String* value) {
-    UNUSED(instance);
+fmi1Status STDCALL placeholder_fmiGetStringStatus(fmi1Component *component, const fmi1StatusKind s, fmi1String* value) {
+    UNUSED(component);
     UNUSED(s);
     UNUSED(value);
     NOT_IMPLEMENTED(fmiGetStringStatus);
@@ -260,41 +260,41 @@ fmi1InstanceHandle *STDCALL placeholder_fmiInstantiateModel(fmi1String instanceN
     return NULL;
 }
 
-void STDCALL placeholder_fmiFreeModelInstance(fmi1InstanceHandle *instance) {
-    UNUSED(instance);
+void STDCALL placeholder_fmiFreeModelInstance(fmi1Component *component) {
+    UNUSED(component);
     NOT_IMPLEMENTED(fmiFreeModelInstance);
 }
 
-fmi1Status STDCALL placeholder_fmiSetTime(fmi1InstanceHandle *instance,
+fmi1Status STDCALL placeholder_fmiSetTime(fmi1Component *component,
                                   fmi1Real time) {
-    UNUSED(instance);
+    UNUSED(component);
     UNUSED(time);
     NOT_IMPLEMENTED(fmiSetTime);
     return fmi1Error;
 }
 
-fmi1Status STDCALL placeholder_fmiSetContinuousStates(fmi1InstanceHandle *instance,
+fmi1Status STDCALL placeholder_fmiSetContinuousStates(fmi1Component *component,
                                               const fmi1Real x[],
                                               size_t nx) {
-    UNUSED(instance);
+    UNUSED(component);
     UNUSED(x);
     UNUSED(nx);
     NOT_IMPLEMENTED(fmiSetContinuousStates);
     return fmi1Error;
 }
 
-fmi1Status STDCALL placeholder_fmiCompletedIntegratorStep(fmi1InstanceHandle *instance, fmi1Boolean* callEventUpdate) {
-    UNUSED(instance);
+fmi1Status STDCALL placeholder_fmiCompletedIntegratorStep(fmi1Component *component, fmi1Boolean* callEventUpdate) {
+    UNUSED(component);
     UNUSED(callEventUpdate);
     NOT_IMPLEMENTED(fmiCompletedIntegratorStep);
     return fmi1Error;
 }
 
-fmi1Status STDCALL placeholder_fmiInitialize(fmi1InstanceHandle *instance,
+fmi1Status STDCALL placeholder_fmiInitialize(fmi1Component *component,
                                      fmi1Boolean toleranceControlled,
                                      fmi1Real relativeTolerance,
                                      fmi1EventInfo *eventInfo) {
-    UNUSED(instance);
+    UNUSED(component);
     UNUSED(toleranceControlled);
     UNUSED(relativeTolerance);
     UNUSED(eventInfo);
@@ -302,68 +302,68 @@ fmi1Status STDCALL placeholder_fmiInitialize(fmi1InstanceHandle *instance,
     return fmi1Error;
 }
 
-fmi1Status STDCALL placeholder_fmiGetDerivatives(fmi1InstanceHandle *instance,
+fmi1Status STDCALL placeholder_fmiGetDerivatives(fmi1Component *component,
                                          fmi1Real derivatives[],
                                          size_t nx) {
-    UNUSED(instance);
+    UNUSED(component);
     UNUSED(derivatives);
     UNUSED(nx);
     NOT_IMPLEMENTED(fmiGetDerivatives);
     return fmi1Error;
 }
 
-fmi1Status STDCALL placeholder_fmiGetEventIndicators(fmi1InstanceHandle *instance,
+fmi1Status STDCALL placeholder_fmiGetEventIndicators(fmi1Component *component,
                                              fmi1Real eventIndicators[],
                                              size_t ni) {
-    UNUSED(instance);
+    UNUSED(component);
     UNUSED(eventIndicators);
     UNUSED(ni);
     NOT_IMPLEMENTED(fmiGetEventIndicators);
     return fmi1Error;
 }
 
-fmi1Status STDCALL placeholder_fmiEventUpdate(fmi1InstanceHandle *instance,
+fmi1Status STDCALL placeholder_fmiEventUpdate(fmi1Component *component,
                                       fmi1Boolean intermediateResults,
                                       fmi1EventInfo* eventInfo) {
-    UNUSED(instance);
+    UNUSED(component);
     UNUSED(intermediateResults);
     UNUSED(eventInfo);
     NOT_IMPLEMENTED(fmiEventUpdate);
     return fmi1Error;
 }
 
-fmi1Status STDCALL placeholder_fmiGetContinuousStates(fmi1InstanceHandle *instance,
+fmi1Status STDCALL placeholder_fmiGetContinuousStates(fmi1Component *component,
                                               fmi1Real states[],
                                               size_t nx) {
-    UNUSED(instance);
+    UNUSED(component);
     UNUSED(states);
     UNUSED(nx);
     NOT_IMPLEMENTED(fmiGetContinuousStates);
     return fmi1Error;
 }
 
-fmi1Status STDCALL placeholder_fmiGetNominalContinuousStates(fmi1InstanceHandle *instance,
+fmi1Status STDCALL placeholder_fmiGetNominalContinuousStates(fmi1Component *component,
                                                      fmi1Real x_nominal[],
                                                      size_t nx) {
-    UNUSED(instance);
+    UNUSED(component);
     UNUSED(x_nominal);
     UNUSED(nx);
     NOT_IMPLEMENTED(fmiGetNominalContinuousStates);
     return fmi1Error;
 }
 
-fmi1Status STDCALL placeholder_fmiGetStateValueReferences(fmi1InstanceHandle *instance,
+fmi1Status STDCALL placeholder_fmiGetStateValueReferences(fmi1Component *component,
                                                   fmi1ValueReference vrx[],
                                                   size_t nx) {
-    UNUSED(instance);
+    UNUSED(component);
     UNUSED(vrx);
     UNUSED(nx);
     NOT_IMPLEMENTED(fmiGetStateValueReferences);
     return fmi1Error;
 }
 
-fmi1Status STDCALL placeholder_fmiTerminate(fmi1InstanceHandle *instance) {
-    UNUSED(instance);
+fmi1Status STDCALL placeholder_fmiTerminate(fmi1Component *component) {
+    UNUSED(component);
     NOT_IMPLEMENTED(fmiTerminate);
     return fmi1Error;
 }
@@ -378,11 +378,11 @@ const char* STDCALL placeholder_fmi2_getVersion(void) {
     return NULL;
 }
 
-fmi2Status STDCALL placeholder_fmi2_setDebugLogging(fmi2InstanceHandle* instance,
+fmi2Status STDCALL placeholder_fmi2_setDebugLogging(fmi2Component *component,
                                fmi2Boolean loggingOn,
                                size_t nCategories,
                                const fmi2String categories[]) {
-    UNUSED(instance);
+    UNUSED(component);
     UNUSED(loggingOn);
     UNUSED(nCategories);
     UNUSED(categories);
@@ -410,19 +410,19 @@ fmi2Component STDCALL placeholder_fmi2Instantiate(fmi2String instanceName,
     return NULL;
 }
 
-void STDCALL placeholder_fmi2FreeInstance(fmi2InstanceHandle* instance) {
-    UNUSED(instance);
+void STDCALL placeholder_fmi2FreeInstance(fmi2Component *component) {
+    UNUSED(component);
     NOT_IMPLEMENTED(fmi2FreeInstance);
 }
 
 /* Enter and exit initialization mode, terminate and reset */
-fmi2Status STDCALL placeholder_fmi2_setupExperiment(fmi2InstanceHandle* instance,
+fmi2Status STDCALL placeholder_fmi2_setupExperiment(fmi2Component *component,
                                            fmi2Boolean toleranceDefined,
                                            fmi2Real tolerance,
                                            fmi2Real startTime,
                                            fmi2Boolean stopTimeDefined,
                                            fmi2Real stopTime) {
-    UNUSED(instance);
+    UNUSED(component);
     UNUSED(toleranceDefined);
     UNUSED(tolerance);
     UNUSED(startTime);
@@ -432,35 +432,35 @@ fmi2Status STDCALL placeholder_fmi2_setupExperiment(fmi2InstanceHandle* instance
     return fmi2Error;
 }
 
-fmi2Status STDCALL placeholder_fmi2EnterInitializationMode(fmi2InstanceHandle* instance) {
-    UNUSED(instance);
+fmi2Status STDCALL placeholder_fmi2EnterInitializationMode(fmi2Component *component) {
+    UNUSED(component);
     NOT_IMPLEMENTED(fmi2EnterInitializationMode);
     return fmi2Error;
 }
 
-fmi2Status STDCALL placeholder_fmi2ExitInitializationMode(fmi2InstanceHandle* instance) {
-    UNUSED(instance);
+fmi2Status STDCALL placeholder_fmi2ExitInitializationMode(fmi2Component *component) {
+    UNUSED(component);
     NOT_IMPLEMENTED(fmi2ExitInitializationMode);
     return fmi2Error;
 }
 
-fmi2Status STDCALL placeholder_fmi2Terminate(fmi2InstanceHandle* instance) {
-    UNUSED(instance);
+fmi2Status STDCALL placeholder_fmi2Terminate(fmi2Component *component) {
+    UNUSED(component);
     NOT_IMPLEMENTED(fmi2Terminate);
     return fmi2Error;
 }
 
-fmi2Status STDCALL placeholder_fmi2Reset(fmi2InstanceHandle* instance) {
-    UNUSED(instance);
+fmi2Status STDCALL placeholder_fmi2Reset(fmi2Component *component) {
+    UNUSED(component);
     NOT_IMPLEMENTED(fmi2Reset);
     return fmi2Error;
 }
 
-fmi2Status STDCALL placeholder_fmi2_getReal(fmi2InstanceHandle* instance,
+fmi2Status STDCALL placeholder_fmi2_getReal(fmi2Component *component,
                                    const fmi2ValueReference vr[],
                                    size_t nvr,
                                    fmi2Real value[]) {
-    UNUSED(instance);
+    UNUSED(component);
     UNUSED(vr);
     UNUSED(nvr);
     UNUSED(value);
@@ -468,11 +468,11 @@ fmi2Status STDCALL placeholder_fmi2_getReal(fmi2InstanceHandle* instance,
     return fmi2Error;
 }
 
-fmi2Status STDCALL placeholder_fmi2_getInteger(fmi2InstanceHandle* instance,
+fmi2Status STDCALL placeholder_fmi2_getInteger(fmi2Component *component,
                                    const fmi2ValueReference vr[],
                                    size_t nvr,
                                    fmi2Integer value[]) {
-    UNUSED(instance);
+    UNUSED(component);
     UNUSED(vr);
     UNUSED(nvr);
     UNUSED(value);
@@ -480,11 +480,11 @@ fmi2Status STDCALL placeholder_fmi2_getInteger(fmi2InstanceHandle* instance,
     return fmi2Error;
 }
 
-fmi2Status STDCALL placeholder_fmi2_getBoolean(fmi2InstanceHandle* instance,
+fmi2Status STDCALL placeholder_fmi2_getBoolean(fmi2Component *component,
                                    const fmi2ValueReference vr[],
                                    size_t nvr,
                                    fmi2Boolean value[]) {
-    UNUSED(instance);
+    UNUSED(component);
     UNUSED(vr);
     UNUSED(nvr);
     UNUSED(value);
@@ -492,11 +492,11 @@ fmi2Status STDCALL placeholder_fmi2_getBoolean(fmi2InstanceHandle* instance,
     return fmi2Error;
 }
 
-fmi2Status STDCALL placeholder_fmi2_getString(fmi2InstanceHandle* instance,
+fmi2Status STDCALL placeholder_fmi2_getString(fmi2Component *component,
                                      const fmi2ValueReference vr[],
                                      size_t nvr,
                                      fmi2String value[]) {
-    UNUSED(instance);
+    UNUSED(component);
     UNUSED(vr);
     UNUSED(nvr);
     UNUSED(value);
@@ -504,11 +504,11 @@ fmi2Status STDCALL placeholder_fmi2_getString(fmi2InstanceHandle* instance,
     return fmi2Error;
 }
 
-fmi2Status STDCALL placeholder_fmi2_setReal(fmi2InstanceHandle* instance,
+fmi2Status STDCALL placeholder_fmi2_setReal(fmi2Component *component,
                                    const fmi2ValueReference vr[],
                                    size_t nvr,
                                    const fmi2Real value[]) {
-    UNUSED(instance);
+    UNUSED(component);
     UNUSED(vr);
     UNUSED(nvr);
     UNUSED(value);
@@ -516,11 +516,11 @@ fmi2Status STDCALL placeholder_fmi2_setReal(fmi2InstanceHandle* instance,
     return fmi2Error;
 }
 
-fmi2Status STDCALL placeholder_fmi2_setInteger(fmi2InstanceHandle* instance,
+fmi2Status STDCALL placeholder_fmi2_setInteger(fmi2Component *component,
                                    const fmi2ValueReference vr[],
                                    size_t nvr,
                                    const fmi2Integer value[]) {
-    UNUSED(instance);
+    UNUSED(component);
     UNUSED(vr);
     UNUSED(nvr);
     UNUSED(value);
@@ -528,11 +528,11 @@ fmi2Status STDCALL placeholder_fmi2_setInteger(fmi2InstanceHandle* instance,
     return fmi2Error;
 }
 
-fmi2Status STDCALL placeholder_fmi2_setBoolean(fmi2InstanceHandle* instance,
+fmi2Status STDCALL placeholder_fmi2_setBoolean(fmi2Component *component,
                                    const fmi2ValueReference vr[],
                                    size_t nvr,
                                    const fmi2Boolean value[]) {
-    UNUSED(instance);
+    UNUSED(component);
     UNUSED(vr);
     UNUSED(nvr);
     UNUSED(value);
@@ -540,11 +540,11 @@ fmi2Status STDCALL placeholder_fmi2_setBoolean(fmi2InstanceHandle* instance,
     return fmi2Error;
 }
 
-fmi2Status STDCALL placeholder_fmi2_setString(fmi2InstanceHandle* instance,
+fmi2Status STDCALL placeholder_fmi2_setString(fmi2Component *component,
                                    const fmi2ValueReference vr[],
                                    size_t nvr,
                                    const fmi2String value[]) {
-    UNUSED(instance);
+    UNUSED(component);
     UNUSED(vr);
     UNUSED(nvr);
     UNUSED(value);
@@ -552,33 +552,33 @@ fmi2Status STDCALL placeholder_fmi2_setString(fmi2InstanceHandle* instance,
     return fmi2Error;
 }
 
-fmi2Status STDCALL placeholder_fmi2EnterEventMode(fmi2InstanceHandle* instance) {
-    UNUSED(instance);
+fmi2Status STDCALL placeholder_fmi2EnterEventMode(fmi2Component *component) {
+    UNUSED(component);
     NOT_IMPLEMENTED(fmi2EnterEventMode);
     return fmi2Error;
 }
 
-fmi2Status STDCALL placeholder_fmi2NewDiscreteStates(fmi2InstanceHandle* instance, fmi2EventInfo* eventInfo)
+fmi2Status STDCALL placeholder_fmi2NewDiscreteStates(fmi2Component *component, fmi2EventInfo* eventInfo)
 {
-    UNUSED(instance);
+    UNUSED(component);
     UNUSED(eventInfo);
     NOT_IMPLEMENTED(fmi2NewDiscreteStates);
     return fmi2Error;
 }
 
-fmi2Status STDCALL placeholder_fmi2EnterContinuousTimeMode(fmi2InstanceHandle* instance)
+fmi2Status STDCALL placeholder_fmi2EnterContinuousTimeMode(fmi2Component *component)
 {
-    UNUSED(instance);
+    UNUSED(component);
     NOT_IMPLEMENTED(fmi2EnterContinuousTimeMode);
     return fmi2Error;
 }
 
-fmi2Status STDCALL placeholder_fmi2CompletedIntegratorStep(fmi2InstanceHandle* instance,
+fmi2Status STDCALL placeholder_fmi2CompletedIntegratorStep(fmi2Component *component,
                                        fmi2Boolean noSetFMUStatePriorToCurrentPoint,
                                        fmi2Boolean* enterEventMode,
                                        fmi2Boolean* terminateSimulation)
 {
-    UNUSED(instance);
+    UNUSED(component);
     UNUSED(noSetFMUStatePriorToCurrentPoint);
     UNUSED(enterEventMode);
     UNUSED(terminateSimulation);
@@ -586,74 +586,74 @@ fmi2Status STDCALL placeholder_fmi2CompletedIntegratorStep(fmi2InstanceHandle* i
     return fmi2Error;
 }
 
-fmi2Status STDCALL placeholder_fmi2_setTime(fmi2InstanceHandle* instance, fmi2Real time)
+fmi2Status STDCALL placeholder_fmi2_setTime(fmi2Component *component, fmi2Real time)
 {
-    UNUSED(instance);
+    UNUSED(component);
     UNUSED(time);
     NOT_IMPLEMENTED(fmi2_setTime);
     return fmi2Error;
 }
 
-fmi2Status STDCALL placeholder_fmi2_setContinuousStates(fmi2InstanceHandle* instance,
+fmi2Status STDCALL placeholder_fmi2_setContinuousStates(fmi2Component *component,
                                                const fmi2Real states[],
                                                size_t nStates)
 {
-    UNUSED(instance);
+    UNUSED(component);
     UNUSED(states);
     UNUSED(nStates);
     NOT_IMPLEMENTED(fmi2_setContinuousStates);
     return fmi2Error;
 }
 
-fmi2Status STDCALL placeholder_fmi2_getDerivatives(fmi2InstanceHandle* instance,
+fmi2Status STDCALL placeholder_fmi2_getDerivatives(fmi2Component *component,
                                           fmi2Real derivatives[],
                                           size_t nx)
 {
-    UNUSED(instance);
+    UNUSED(component);
     UNUSED(derivatives);
     UNUSED(nx);
     NOT_IMPLEMENTED(fmi2_getDerivatives);
     return fmi2Error;
 }
 
-fmi2Status STDCALL placeholder_fmi2_getEventIndicators(fmi2InstanceHandle* instance,
+fmi2Status STDCALL placeholder_fmi2_getEventIndicators(fmi2Component *component,
                                               fmi2Real eventIndicators[],
                                               size_t ni)
 {
-   UNUSED(instance);
+   UNUSED(component);
    UNUSED(eventIndicators);
    UNUSED(ni);
    NOT_IMPLEMENTED(fmi2_getEventIndicators);
    return fmi2Error;
 }
 
-fmi2Status STDCALL placeholder_fmi2_getContinuousStates(fmi2InstanceHandle* instance,
+fmi2Status STDCALL placeholder_fmi2_getContinuousStates(fmi2Component *component,
                                    fmi2Real states[],
                                    size_t nStates)
 {
-    UNUSED(instance);
+    UNUSED(component);
     UNUSED(states);
     UNUSED(nStates);
     NOT_IMPLEMENTED(fmi2_getContinuousStates);
     return fmi2Error;
 }
 
-fmi2Status STDCALL placeholder_fmi2_getNominalsOfContinuousStates(fmi2InstanceHandle* instance,
+fmi2Status STDCALL placeholder_fmi2_getNominalsOfContinuousStates(fmi2Component *component,
                                                          fmi2Real x_nominal[],
                                                          size_t nx)
 {
-    UNUSED(instance);
+    UNUSED(component);
     UNUSED(x_nominal);
     UNUSED(nx);
     NOT_IMPLEMENTED(fmi2_getNominalsOfContinuousStates);
     return fmi2Error;
 }
 
-fmi2Status STDCALL placeholder_fmi2DoStep(fmi2InstanceHandle* instance,
+fmi2Status STDCALL placeholder_fmi2DoStep(fmi2Component *component,
                       fmi2Real currentCommunicationPoint,
                       fmi2Real communicationStepSize,
                       fmi2Boolean noSetFMUStatePriorToCurrentPoint) {
-    UNUSED(instance);
+    UNUSED(component);
     UNUSED(currentCommunicationPoint);
     UNUSED(communicationStepSize);
     UNUSED(noSetFMUStatePriorToCurrentPoint);
@@ -661,45 +661,45 @@ fmi2Status STDCALL placeholder_fmi2DoStep(fmi2InstanceHandle* instance,
     return fmi2OK;
 }
 
-fmi2Status STDCALL placeholder_fmi2_getFMUstate(fmi2InstanceHandle* instance,
+fmi2Status STDCALL placeholder_fmi2_getFMUstate(fmi2Component *component,
                                        fmi2FMUstate* FMUstate) {
-    UNUSED(instance);
+    UNUSED(component);
     UNUSED(FMUstate);
     NOT_IMPLEMENTED(fmi2_getFMUstate);
     return fmi2Error;
 }
 
-fmi2Status STDCALL placeholder_fmi2_setFMUstate(fmi2InstanceHandle* instance,
+fmi2Status STDCALL placeholder_fmi2_setFMUstate(fmi2Component *component,
                                        fmi2FMUstate FMUstate) {
-    UNUSED(instance);
+    UNUSED(component);
     UNUSED(FMUstate);
     NOT_IMPLEMENTED(fmi2_setFMUstate);
     return fmi2Error;
 }
 
-fmi2Status STDCALL placeholder_fmi2FreeFMUstate(fmi2InstanceHandle* instance,
+fmi2Status STDCALL placeholder_fmi2FreeFMUstate(fmi2Component *component,
                                         fmi2FMUstate* FMUstate) {
-    UNUSED(instance);
+    UNUSED(component);
     UNUSED(FMUstate);
     NOT_IMPLEMENTED(fmi2FreeFMUstate);
     return fmi2Error;
 }
 
-fmi2Status STDCALL placeholder_fmi2SerializedFMUstateSize(fmi2InstanceHandle* instance,
+fmi2Status STDCALL placeholder_fmi2SerializedFMUstateSize(fmi2Component *component,
                                                   fmi2FMUstate FMUstate,
                                                   size_t* size) {
-    UNUSED(instance);
+    UNUSED(component);
     UNUSED(FMUstate);
     UNUSED(size);
     NOT_IMPLEMENTED(fmi2SerializedFMUstateSize);
     return fmi2Error;
 }
 
-fmi2Status STDCALL placeholder_fmi2SerializeFMUstate(fmi2InstanceHandle* instance,
+fmi2Status STDCALL placeholder_fmi2SerializeFMUstate(fmi2Component *component,
                                              fmi2FMUstate FMUstate,
                                              fmi2Byte serializedState[],
                                              size_t size) {
-    UNUSED(instance);
+    UNUSED(component);
     UNUSED(FMUstate);
     UNUSED(serializedState);
     UNUSED(size);
@@ -707,11 +707,11 @@ fmi2Status STDCALL placeholder_fmi2SerializeFMUstate(fmi2InstanceHandle* instanc
     return fmi2Error;
 }
 
-fmi2Status STDCALL placeholder_fmi2DeSerializeFMUstate(fmi2InstanceHandle* instance,
+fmi2Status STDCALL placeholder_fmi2DeSerializeFMUstate(fmi2Component *component,
                                                const fmi2Byte serializedState[],
                                                size_t size,
                                                fmi2FMUstate* FMUstate) {
-    UNUSED(instance);
+    UNUSED(component);
     UNUSED(serializedState);
     UNUSED(size);
     UNUSED(FMUstate);
@@ -719,14 +719,14 @@ fmi2Status STDCALL placeholder_fmi2DeSerializeFMUstate(fmi2InstanceHandle* insta
     return fmi2Error;
 }
 
-fmi2Status STDCALL placeholder_fmi2_getDirectionalDerivative(fmi2InstanceHandle* instance,
+fmi2Status STDCALL placeholder_fmi2_getDirectionalDerivative(fmi2Component *component,
                                                     const fmi2ValueReference vUnknownRef[],
                                                     size_t nUnknown,
                                                     const fmi2ValueReference vKnownRef[],
                                                     size_t nKnown,
                                                     const fmi2Real dvKnown[],
                                                     fmi2Real dvUnknown[]) {
-    UNUSED(instance);
+    UNUSED(component);
     UNUSED(vUnknownRef);
     UNUSED(nUnknown);
     UNUSED(vKnownRef);
@@ -737,12 +737,12 @@ fmi2Status STDCALL placeholder_fmi2_getDirectionalDerivative(fmi2InstanceHandle*
     return fmi2Error;
 }
 
-fmi2Status STDCALL placeholder_fmi2_setRealInputDerivatives(fmi2InstanceHandle* instance,
+fmi2Status STDCALL placeholder_fmi2_setRealInputDerivatives(fmi2Component *component,
                                                    const fmi2ValueReference vr[],
                                                    size_t nvr,
                                                    const fmi2Integer order[],
                                                    const fmi2Real value[]) {
-    UNUSED(instance);
+    UNUSED(component);
     UNUSED(vr);
     UNUSED(nvr);
     UNUSED(order);
@@ -751,12 +751,12 @@ fmi2Status STDCALL placeholder_fmi2_setRealInputDerivatives(fmi2InstanceHandle* 
     return fmi2Error;
 }
 
-fmi2Status STDCALL placeholder_fmi2_getRealOutputDerivatives(fmi2InstanceHandle* instance,
+fmi2Status STDCALL placeholder_fmi2_getRealOutputDerivatives(fmi2Component *component,
                                                     const fmi2ValueReference vr[],
                                                     size_t nvr,
                                                     const fmi2Integer order[],
                                                     fmi2Real value[]) {
-    UNUSED(instance);
+    UNUSED(component);
     UNUSED(vr);
     UNUSED(nvr);
     UNUSED(order);
@@ -765,48 +765,48 @@ fmi2Status STDCALL placeholder_fmi2_getRealOutputDerivatives(fmi2InstanceHandle*
     return fmi2Error;
 }
 
-fmi2Status STDCALL placeholder_fmi2CancelStep(fmi2InstanceHandle* instance) {
-    UNUSED(instance);
+fmi2Status STDCALL placeholder_fmi2CancelStep(fmi2Component *component) {
+    UNUSED(component);
     NOT_IMPLEMENTED(fmi2CancelStep);
     return fmi2Error;
 }
 
-fmi2Status STDCALL placeholder_fmi2_getStatus(fmi2InstanceHandle* instance, const fmi2StatusKind s, fmi2Status* value) {
-    UNUSED(instance);
+fmi2Status STDCALL placeholder_fmi2_getStatus(fmi2Component *component, const fmi2StatusKind s, fmi2Status* value) {
+    UNUSED(component);
     UNUSED(s);
     UNUSED(value);
     NOT_IMPLEMENTED(fmi2_getStatus);
     return fmi2Error;
 }
 
-fmi2Status STDCALL placeholder_fmi2_getRealStatus(fmi2InstanceHandle* instance, const fmi2StatusKind s, fmi2Real* value) {
-    UNUSED(instance);
+fmi2Status STDCALL placeholder_fmi2_getRealStatus(fmi2Component *component, const fmi2StatusKind s, fmi2Real* value) {
+    UNUSED(component);
     UNUSED(s);
     UNUSED(value);
     NOT_IMPLEMENTED(fmi2_getRealStatus);
     return fmi2Error;
 }
 
-fmi2Status STDCALL placeholder_fmi2_getIntegerStatus(fmi2InstanceHandle* instance, const fmi2StatusKind s, fmi2Integer* value) {
-    UNUSED(instance);
+fmi2Status STDCALL placeholder_fmi2_getIntegerStatus(fmi2Component *component, const fmi2StatusKind s, fmi2Integer* value) {
+    UNUSED(component);
     UNUSED(s);
     UNUSED(value);
     NOT_IMPLEMENTED(fmi2_getIntegerStatus);
     return fmi2Error;
 }
 
-fmi2Status STDCALL placeholder_fmi2_getBooleanStatus(fmi2InstanceHandle* instance, const fmi2StatusKind s, fmi2Boolean* value) {
-    UNUSED(instance);
+fmi2Status STDCALL placeholder_fmi2_getBooleanStatus(fmi2Component *component, const fmi2StatusKind s, fmi2Boolean* value) {
+    UNUSED(component);
     UNUSED(s);
     UNUSED(value);
     NOT_IMPLEMENTED(fmi2_getBooleanStatus);
     return fmi2Error;
 }
 
-fmi2Status STDCALL placeholder_fmi2_getStringStatus(fmi2InstanceHandle* instance,
+fmi2Status STDCALL placeholder_fmi2_getStringStatus(fmi2Component *component,
                                            const fmi2StatusKind s,
                                            fmi2String* value) {
-    UNUSED(instance);
+    UNUSED(component);
     UNUSED(s);
     UNUSED(value);
     NOT_IMPLEMENTED(fmi2_getStringStatus);
@@ -818,11 +818,11 @@ const char* STDCALL placeholder_fmi3GetVersion() {
     return NULL;
 }
 
-fmi3Status STDCALL placeholder_fmi3SetDebugLogging(fmi3InstanceHandle *instance,
-                                           fmi3Boolean loggingOn,
-                                           size_t nCategories,
-                                           const fmi3String categories[]) {
-    UNUSED(instance);
+fmi3Status STDCALL placeholder_fmi3SetDebugLogging(fmi3Component *component,
+                                                   fmi3Boolean loggingOn,
+                                                   size_t nCategories,
+                                                   const fmi3String categories[]) {
+    UNUSED(component);
     UNUSED(loggingOn);
     UNUSED(nCategories);
     UNUSED(categories);
@@ -830,18 +830,18 @@ fmi3Status STDCALL placeholder_fmi3SetDebugLogging(fmi3InstanceHandle *instance,
     return fmi3Error;
 }
 
-fmi3InstanceHandle *STDCALL placeholder_fmi3InstantiateCoSimulation(fmi3String instanceName,
-                                                       fmi3String instantiationToken,
-                                                       fmi3String resourcePath,
-                                                       fmi3Boolean visible,
-                                                       fmi3Boolean loggingOn,
-                                                       fmi3Boolean eventModeUsed,
-                                                       fmi3Boolean earlyReturnAllowed,
-                                                       const fmi3ValueReference requiredIntermediateVariables[],
-                                                       size_t nRequiredIntermediateVariables,
-                                                       fmi3InstanceEnvironment instanceEnvironment,
-                                                       fmi3LogMessageCallback logMessage,
-                                                       fmi3IntermediateUpdateCallback intermediateUpdate) {
+fmi3Component *STDCALL placeholder_fmi3InstantiateCoSimulation(fmi3String instanceName,
+                                                               fmi3String instantiationToken,
+                                                               fmi3String resourcePath,
+                                                               fmi3Boolean visible,
+                                                               fmi3Boolean loggingOn,
+                                                               fmi3Boolean eventModeUsed,
+                                                               fmi3Boolean earlyReturnAllowed,
+                                                               const fmi3ValueReference requiredIntermediateVariables[],
+                                                               size_t nRequiredIntermediateVariables,
+                                                               fmi3InstanceEnvironment instanceEnvironment,
+                                                               fmi3LogMessageCallback logMessage,
+                                                               fmi3IntermediateUpdateCallback intermediateUpdate) {
     UNUSED(instanceName);
     UNUSED(instantiationToken);
     UNUSED(resourcePath);
@@ -858,7 +858,7 @@ fmi3InstanceHandle *STDCALL placeholder_fmi3InstantiateCoSimulation(fmi3String i
     return NULL;
 }
 
-fmi3InstanceHandle *STDCALL placeholder_fmi3InstantiateModelExchange(fmi3String instanceName,
+fmi3Component *STDCALL placeholder_fmi3InstantiateModelExchange(fmi3String instanceName,
                                                         fmi3String instantiationToken,
                                                         fmi3String resourcePath,
                                                         fmi3Boolean visible,
@@ -900,18 +900,18 @@ fmi3InstanceHandle *STDCALL placeholder_fmi3InstantiateScheduledExecution(fmi3St
     return NULL;
 }
 
-void STDCALL placeholder_fmi3FreeInstance(fmi3InstanceHandle *instance) {
-    UNUSED(instance);
+void STDCALL placeholder_fmi3FreeInstance(fmi3Component *component) {
+    UNUSED(component);
     NOT_IMPLEMENTED(fmi3FreeInstance);
 }
 
-fmi3Status STDCALL placeholder_fmi3EnterInitializationMode(fmi3InstanceHandle *instance,
+fmi3Status STDCALL placeholder_fmi3EnterInitializationMode(fmi3Component *component,
                                                    fmi3Boolean toleranceDefined,
                                                    fmi3Float64 tolerance,
                                                    fmi3Float64 startTime,
                                                    fmi3Boolean stopTimeDefined,
                                                    fmi3Float64 stopTime) {
-    UNUSED(instance);
+    UNUSED(component);
     UNUSED(toleranceDefined);
     UNUSED(tolerance);
     UNUSED(startTime);
@@ -921,19 +921,19 @@ fmi3Status STDCALL placeholder_fmi3EnterInitializationMode(fmi3InstanceHandle *i
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3ExitInitializationMode(fmi3InstanceHandle *instance) {
-    UNUSED(instance);
+fmi3Status STDCALL placeholder_fmi3ExitInitializationMode(fmi3Component *component) {
+    UNUSED(component);
     NOT_IMPLEMENTED(fmi3ExitInitializationMode);
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3Terminate(fmi3InstanceHandle *instance) {
-    UNUSED(instance);
+fmi3Status STDCALL placeholder_fmi3Terminate(fmi3Component *component) {
+    UNUSED(component);
     NOT_IMPLEMENTED(fmi3Terminate);
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3DoStep(fmi3InstanceHandle *instance,
+fmi3Status STDCALL placeholder_fmi3DoStep(fmi3Component *component,
                                   fmi3Float64 currentCommunicationPoint,
                                   fmi3Float64 communicationStepSize,
                                   fmi3Boolean noSetFMUStatePriorToCurrentPoint,
@@ -941,7 +941,7 @@ fmi3Status STDCALL placeholder_fmi3DoStep(fmi3InstanceHandle *instance,
                                   fmi3Boolean* terminateSimulation,
                                   fmi3Boolean* earlyReturn,
                                   fmi3Float64* lastSuccessfulTime) {
-    UNUSED(instance);
+    UNUSED(component);
     UNUSED(currentCommunicationPoint);
     UNUSED(communicationStepSize);
     UNUSED(noSetFMUStatePriorToCurrentPoint);
@@ -954,24 +954,24 @@ fmi3Status STDCALL placeholder_fmi3DoStep(fmi3InstanceHandle *instance,
 
 }
 
-fmi3Status STDCALL placeholder_fmi3EnterEventMode(fmi3InstanceHandle *instance) {
-    UNUSED(instance);
+fmi3Status STDCALL placeholder_fmi3EnterEventMode(fmi3Component *component) {
+    UNUSED(component);
     NOT_IMPLEMENTED(fmi3EnterEventMode);
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3Reset(fmi3InstanceHandle *instance) {
-    UNUSED(instance);
+fmi3Status STDCALL placeholder_fmi3Reset(fmi3Component *component) {
+    UNUSED(component);
     NOT_IMPLEMENTED(fmi3Reset);
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3GetFloat64(fmi3InstanceHandle *instance,
+fmi3Status STDCALL placeholder_fmi3GetFloat64(fmi3Component *component,
                                       const fmi3ValueReference valueReferences[],
                                       size_t nValueReferences,
                                       fmi3Float64 values[],
                                       size_t nValues) {
-    UNUSED(instance);
+    UNUSED(component);
     UNUSED(valueReferences);
     UNUSED(nValueReferences);
     UNUSED(values);
@@ -980,12 +980,12 @@ fmi3Status STDCALL placeholder_fmi3GetFloat64(fmi3InstanceHandle *instance,
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3SetFloat64(fmi3InstanceHandle *instance,
+fmi3Status STDCALL placeholder_fmi3SetFloat64(fmi3Component *component,
                                       const fmi3ValueReference valueReferences[],
                                       size_t nValueReferences,
                                       const fmi3Float64 values[],
                                       size_t nValues) {
-    UNUSED(instance);
+    UNUSED(component);
     UNUSED(valueReferences);
     UNUSED(nValueReferences);
     UNUSED(values);
@@ -994,12 +994,12 @@ fmi3Status STDCALL placeholder_fmi3SetFloat64(fmi3InstanceHandle *instance,
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3GetFloat32(fmi3InstanceHandle *instance,
+fmi3Status STDCALL placeholder_fmi3GetFloat32(fmi3Component *component,
                                       const fmi3ValueReference valueReferences[],
                                       size_t nValueReferences,
                                       fmi3Float32 values[],
                                       size_t nValues) {
-    UNUSED(instance);
+    UNUSED(component);
     UNUSED(valueReferences);
     UNUSED(nValueReferences);
     UNUSED(values);
@@ -1008,12 +1008,12 @@ fmi3Status STDCALL placeholder_fmi3GetFloat32(fmi3InstanceHandle *instance,
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3GetInt8(fmi3InstanceHandle *instance,
+fmi3Status STDCALL placeholder_fmi3GetInt8(fmi3Component *component,
                                    const fmi3ValueReference valueReferences[],
                                    size_t nValueReferences,
                                    fmi3Int8 values[],
                                    size_t nValues) {
-    UNUSED(instance);
+    UNUSED(component);
     UNUSED(valueReferences);
     UNUSED(nValueReferences);
     UNUSED(values);
@@ -1022,12 +1022,12 @@ fmi3Status STDCALL placeholder_fmi3GetInt8(fmi3InstanceHandle *instance,
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3GetUInt8(fmi3InstanceHandle *instance,
+fmi3Status STDCALL placeholder_fmi3GetUInt8(fmi3Component *component,
                                     const fmi3ValueReference valueReferences[],
                                     size_t nValueReferences,
                                     fmi3UInt8 values[],
                                     size_t nValues) {
-    UNUSED(instance);
+    UNUSED(component);
     UNUSED(valueReferences);
     UNUSED(nValueReferences);
     UNUSED(values);
@@ -1036,12 +1036,12 @@ fmi3Status STDCALL placeholder_fmi3GetUInt8(fmi3InstanceHandle *instance,
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3GetInt16(fmi3InstanceHandle *instance,
+fmi3Status STDCALL placeholder_fmi3GetInt16(fmi3Component *component,
                                     const fmi3ValueReference valueReferences[],
                                     size_t nValueReferences,
                                     fmi3Int16 values[],
                                     size_t nValues) {
-    UNUSED(instance);
+    UNUSED(component);
     UNUSED(valueReferences);
     UNUSED(nValueReferences);
     UNUSED(values);
@@ -1050,12 +1050,12 @@ fmi3Status STDCALL placeholder_fmi3GetInt16(fmi3InstanceHandle *instance,
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3GetUInt16(fmi3InstanceHandle *instance,
+fmi3Status STDCALL placeholder_fmi3GetUInt16(fmi3Component *component,
                                      const fmi3ValueReference valueReferences[],
                                      size_t nValueReferences,
                                      fmi3UInt16 values[],
                                      size_t nValues) {
-    UNUSED(instance);
+    UNUSED(component);
     UNUSED(valueReferences);
     UNUSED(nValueReferences);
     UNUSED(values);
@@ -1064,12 +1064,12 @@ fmi3Status STDCALL placeholder_fmi3GetUInt16(fmi3InstanceHandle *instance,
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3GetInt32(fmi3InstanceHandle *instance,
+fmi3Status STDCALL placeholder_fmi3GetInt32(fmi3Component *component,
                                     const fmi3ValueReference valueReferences[],
                                     size_t nValueReferences,
                                     fmi3Int32 values[],
                                     size_t nValues) {
-    UNUSED(instance);
+    UNUSED(component);
     UNUSED(valueReferences);
     UNUSED(nValueReferences);
     UNUSED(values);
@@ -1078,12 +1078,12 @@ fmi3Status STDCALL placeholder_fmi3GetInt32(fmi3InstanceHandle *instance,
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3GetUInt32(fmi3InstanceHandle *instance,
+fmi3Status STDCALL placeholder_fmi3GetUInt32(fmi3Component *component,
                                      const fmi3ValueReference valueReferences[],
                                      size_t nValueReferences,
                                      fmi3UInt32 values[],
                                      size_t nValues) {
-    UNUSED(instance);
+    UNUSED(component);
     UNUSED(valueReferences);
     UNUSED(nValueReferences);
     UNUSED(values);
@@ -1092,12 +1092,12 @@ fmi3Status STDCALL placeholder_fmi3GetUInt32(fmi3InstanceHandle *instance,
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3GetInt64(fmi3InstanceHandle *instance,
+fmi3Status STDCALL placeholder_fmi3GetInt64(fmi3Component *component,
                                     const fmi3ValueReference valueReferences[],
                                     size_t nValueReferences,
                                     fmi3Int64 values[],
                                     size_t nValues) {
-    UNUSED(instance);
+    UNUSED(component);
     UNUSED(valueReferences);
     UNUSED(nValueReferences);
     UNUSED(values);
@@ -1106,12 +1106,12 @@ fmi3Status STDCALL placeholder_fmi3GetInt64(fmi3InstanceHandle *instance,
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3GetUInt64(fmi3InstanceHandle *instance,
+fmi3Status STDCALL placeholder_fmi3GetUInt64(fmi3Component *component,
                                      const fmi3ValueReference valueReferences[],
                                      size_t nValueReferences,
                                      fmi3UInt64 values[],
                                      size_t nValues) {
-    UNUSED(instance);
+    UNUSED(component);
     UNUSED(valueReferences);
     UNUSED(nValueReferences);
     UNUSED(values);
@@ -1120,12 +1120,12 @@ fmi3Status STDCALL placeholder_fmi3GetUInt64(fmi3InstanceHandle *instance,
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3GetBoolean(fmi3InstanceHandle *instance,
+fmi3Status STDCALL placeholder_fmi3GetBoolean(fmi3Component *component,
                                       const fmi3ValueReference valueReferences[],
                                       size_t nValueReferences,
                                       fmi3Boolean values[],
                                       size_t nValues) {
-    UNUSED(instance);
+    UNUSED(component);
     UNUSED(valueReferences);
     UNUSED(nValueReferences);
     UNUSED(values);
@@ -1134,12 +1134,12 @@ fmi3Status STDCALL placeholder_fmi3GetBoolean(fmi3InstanceHandle *instance,
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3GetString(fmi3InstanceHandle *instance,
+fmi3Status STDCALL placeholder_fmi3GetString(fmi3Component *component,
                                      const fmi3ValueReference valueReferences[],
                                      size_t nValueReferences,
                                      fmi3String values[],
                                      size_t nValues) {
-    UNUSED(instance);
+    UNUSED(component);
     UNUSED(valueReferences);
     UNUSED(nValueReferences);
     UNUSED(values);
@@ -1148,13 +1148,13 @@ fmi3Status STDCALL placeholder_fmi3GetString(fmi3InstanceHandle *instance,
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3GetBinary(fmi3InstanceHandle *instance,
+fmi3Status STDCALL placeholder_fmi3GetBinary(fmi3Component *component,
                                      const fmi3ValueReference valueReferences[],
                                      size_t nValueReferences,
                                      size_t valueSizes[],
                                      fmi3Binary values[],
                                      size_t nValues) {
-    UNUSED(instance);
+    UNUSED(component);
     UNUSED(valueReferences);
     UNUSED(nValueReferences);
     UNUSED(valueSizes);
@@ -1164,11 +1164,11 @@ fmi3Status STDCALL placeholder_fmi3GetBinary(fmi3InstanceHandle *instance,
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3GetClock(fmi3InstanceHandle *instance,
+fmi3Status STDCALL placeholder_fmi3GetClock(fmi3Component *component,
                                     const fmi3ValueReference valueReferences[],
                                     size_t nValueReferences,
                                     fmi3Clock values[]) {
-    UNUSED(instance);
+    UNUSED(component);
     UNUSED(valueReferences);
     UNUSED(nValueReferences);
     UNUSED(values);
@@ -1176,12 +1176,12 @@ fmi3Status STDCALL placeholder_fmi3GetClock(fmi3InstanceHandle *instance,
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3SetFloat32(fmi3InstanceHandle *instance,
+fmi3Status STDCALL placeholder_fmi3SetFloat32(fmi3Component *component,
                                       const fmi3ValueReference valueReferences[],
                                       size_t nValueReferences,
                                       const fmi3Float32 values[],
                                       size_t nValues) {
-    UNUSED(instance);
+    UNUSED(component);
     UNUSED(valueReferences);
     UNUSED(nValueReferences);
     UNUSED(values);
@@ -1190,12 +1190,12 @@ fmi3Status STDCALL placeholder_fmi3SetFloat32(fmi3InstanceHandle *instance,
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3SetInt8(fmi3InstanceHandle *instance,
+fmi3Status STDCALL placeholder_fmi3SetInt8(fmi3Component *component,
                                    const fmi3ValueReference valueReferences[],
                                    size_t nValueReferences,
                                    const fmi3Int8 values[],
                                    size_t nValues) {
-    UNUSED(instance);
+    UNUSED(component);
     UNUSED(valueReferences);
     UNUSED(nValueReferences);
     UNUSED(values);
@@ -1204,12 +1204,12 @@ fmi3Status STDCALL placeholder_fmi3SetInt8(fmi3InstanceHandle *instance,
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3SetUInt8(fmi3InstanceHandle *instance,
+fmi3Status STDCALL placeholder_fmi3SetUInt8(fmi3Component *component,
                                     const fmi3ValueReference valueReferences[],
                                     size_t nValueReferences,
                                     const fmi3UInt8 values[],
                                     size_t nValues) {
-    UNUSED(instance);
+    UNUSED(component);
     UNUSED(valueReferences);
     UNUSED(nValueReferences);
     UNUSED(values);
@@ -1218,12 +1218,12 @@ fmi3Status STDCALL placeholder_fmi3SetUInt8(fmi3InstanceHandle *instance,
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3SetInt16(fmi3InstanceHandle *instance,
+fmi3Status STDCALL placeholder_fmi3SetInt16(fmi3Component *component,
                                     const fmi3ValueReference valueReferences[],
                                     size_t nValueReferences,
                                     const fmi3Int16 values[],
                                     size_t nValues) {
-    UNUSED(instance);
+    UNUSED(component);
     UNUSED(valueReferences);
     UNUSED(nValueReferences);
     UNUSED(values);
@@ -1232,12 +1232,12 @@ fmi3Status STDCALL placeholder_fmi3SetInt16(fmi3InstanceHandle *instance,
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3SetUInt16(fmi3InstanceHandle *instance,
+fmi3Status STDCALL placeholder_fmi3SetUInt16(fmi3Component *component,
                                      const fmi3ValueReference valueReferences[],
                                      size_t nValueReferences,
                                      const fmi3UInt16 values[],
                                      size_t nValues) {
-    UNUSED(instance);
+    UNUSED(component);
     UNUSED(valueReferences);
     UNUSED(nValueReferences);
     UNUSED(values);
@@ -1246,12 +1246,12 @@ fmi3Status STDCALL placeholder_fmi3SetUInt16(fmi3InstanceHandle *instance,
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3SetInt32(fmi3InstanceHandle *instance,
+fmi3Status STDCALL placeholder_fmi3SetInt32(fmi3Component *component,
                                     const fmi3ValueReference valueReferences[],
                                     size_t nValueReferences,
                                     const fmi3Int32 values[],
                                     size_t nValues) {
-    UNUSED(instance);
+    UNUSED(component);
     UNUSED(valueReferences);
     UNUSED(nValueReferences);
     UNUSED(values);
@@ -1260,12 +1260,12 @@ fmi3Status STDCALL placeholder_fmi3SetInt32(fmi3InstanceHandle *instance,
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3SetUInt32(fmi3InstanceHandle *instance,
+fmi3Status STDCALL placeholder_fmi3SetUInt32(fmi3Component *component,
                                      const fmi3ValueReference valueReferences[],
                                      size_t nValueReferences,
                                      const fmi3UInt32 values[],
                                      size_t nValues) {
-    UNUSED(instance);
+    UNUSED(component);
     UNUSED(valueReferences);
     UNUSED(nValueReferences);
     UNUSED(values);
@@ -1274,12 +1274,12 @@ fmi3Status STDCALL placeholder_fmi3SetUInt32(fmi3InstanceHandle *instance,
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3SetInt64(fmi3InstanceHandle *instance,
+fmi3Status STDCALL placeholder_fmi3SetInt64(fmi3Component *component,
                                     const fmi3ValueReference valueReferences[],
                                     size_t nValueReferences,
                                     const fmi3Int64 values[],
                                     size_t nValues) {
-    UNUSED(instance);
+    UNUSED(component);
     UNUSED(valueReferences);
     UNUSED(nValueReferences);
     UNUSED(values);
@@ -1288,12 +1288,12 @@ fmi3Status STDCALL placeholder_fmi3SetInt64(fmi3InstanceHandle *instance,
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3SetUInt64(fmi3InstanceHandle *instance,
+fmi3Status STDCALL placeholder_fmi3SetUInt64(fmi3Component *component,
                                      const fmi3ValueReference valueReferences[],
                                      size_t nValueReferences,
                                      const fmi3UInt64 values[],
                                      size_t nValues) {
-    UNUSED(instance);
+    UNUSED(component);
     UNUSED(valueReferences);
     UNUSED(nValueReferences);
     UNUSED(values);
@@ -1302,12 +1302,12 @@ fmi3Status STDCALL placeholder_fmi3SetUInt64(fmi3InstanceHandle *instance,
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3SetBoolean(fmi3InstanceHandle *instance,
+fmi3Status STDCALL placeholder_fmi3SetBoolean(fmi3Component *component,
                                       const fmi3ValueReference valueReferences[],
                                       size_t nValueReferences,
                                       const fmi3Boolean values[],
                                       size_t nValues) {
-    UNUSED(instance);
+    UNUSED(component);
     UNUSED(valueReferences);
     UNUSED(nValueReferences);
     UNUSED(values);
@@ -1316,12 +1316,12 @@ fmi3Status STDCALL placeholder_fmi3SetBoolean(fmi3InstanceHandle *instance,
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3SetString(fmi3InstanceHandle *instance,
+fmi3Status STDCALL placeholder_fmi3SetString(fmi3Component *component,
                                      const fmi3ValueReference valueReferences[],
                                      size_t nValueReferences,
                                      const fmi3String values[],
                                      size_t nValues) {
-    UNUSED(instance);
+    UNUSED(component);
     UNUSED(valueReferences);
     UNUSED(nValueReferences);
     UNUSED(values);
@@ -1330,13 +1330,13 @@ fmi3Status STDCALL placeholder_fmi3SetString(fmi3InstanceHandle *instance,
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3SetBinary(fmi3InstanceHandle *instance,
+fmi3Status STDCALL placeholder_fmi3SetBinary(fmi3Component *component,
                                      const fmi3ValueReference valueReferences[],
                                      size_t nValueReferences,
                                      const size_t valueSizes[],
                                      const fmi3Binary values[],
                                      size_t nValues) {
-    UNUSED(instance);
+    UNUSED(component);
     UNUSED(valueReferences);
     UNUSED(nValueReferences);
     UNUSED(valueSizes);
@@ -1346,11 +1346,11 @@ fmi3Status STDCALL placeholder_fmi3SetBinary(fmi3InstanceHandle *instance,
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3SetClock(fmi3InstanceHandle *instance,
+fmi3Status STDCALL placeholder_fmi3SetClock(fmi3Component *component,
                                     const fmi3ValueReference valueReferences[],
                                     size_t nValueReferences,
                                     const fmi3Clock values[]) {
-    UNUSED(instance);
+    UNUSED(component);
     UNUSED(valueReferences);
     UNUSED(nValueReferences);
     UNUSED(values);
@@ -1358,24 +1358,24 @@ fmi3Status STDCALL placeholder_fmi3SetClock(fmi3InstanceHandle *instance,
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3GetNumberOfVariableDependencies(fmi3InstanceHandle *instance,
+fmi3Status STDCALL placeholder_fmi3GetNumberOfVariableDependencies(fmi3Component *component,
                                                            fmi3ValueReference valueReference,
                                                            size_t* nDependencies) {
-    UNUSED(instance);
+    UNUSED(component);
     UNUSED(valueReference);
     UNUSED(nDependencies);
     NOT_IMPLEMENTED(fmi3GetNumberOfVariableDependencies);
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3GetVariableDependencies(fmi3InstanceHandle *instance,
+fmi3Status STDCALL placeholder_fmi3GetVariableDependencies(fmi3Component *component,
                                                    fmi3ValueReference dependent,
                                                    size_t elementIndicesOfDependent[],
                                                    fmi3ValueReference independents[],
                                                    size_t elementIndicesOfIndependents[],
                                                    fmi3DependencyKind dependencyKinds[],
                                                    size_t nDependencies) {
-    UNUSED(instance);
+    UNUSED(component);
     UNUSED(dependent);
     UNUSED(elementIndicesOfDependent);
     UNUSED(independents);
@@ -1386,45 +1386,45 @@ fmi3Status STDCALL placeholder_fmi3GetVariableDependencies(fmi3InstanceHandle *i
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3GetFMUState(fmi3InstanceHandle *instance,
+fmi3Status STDCALL placeholder_fmi3GetFMUState(fmi3Component *component,
                                        fmi3FMUState* FMUState) {
-    UNUSED(instance);
+    UNUSED(component);
     UNUSED(FMUState);
     NOT_IMPLEMENTED(fmi3GetFMUState);
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3SetFMUState(fmi3InstanceHandle *instance,
+fmi3Status STDCALL placeholder_fmi3SetFMUState(fmi3Component *component,
                                        fmi3FMUState FMUState) {
-    UNUSED(instance);
+    UNUSED(component);
     UNUSED(FMUState);
     NOT_IMPLEMENTED(fmi3SetFMUState);
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3FreeFMUState(fmi3InstanceHandle *instance,
+fmi3Status STDCALL placeholder_fmi3FreeFMUState(fmi3Component *component,
                                         fmi3FMUState* FMUState) {
-    UNUSED(instance);
+    UNUSED(component);
     UNUSED(FMUState);
     NOT_IMPLEMENTED(fmi3FreeFMUState);
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3SerializedFMUStateSize(fmi3InstanceHandle *instance,
+fmi3Status STDCALL placeholder_fmi3SerializedFMUStateSize(fmi3Component *component,
                                                   fmi3FMUState FMUState,
                                                   size_t* size) {
-    UNUSED(instance);
+    UNUSED(component);
     UNUSED(FMUState);
     UNUSED(size);
     NOT_IMPLEMENTED(fmi3SerializedFMUStateSize);
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3SerializeFMUState(fmi3InstanceHandle *instance,
+fmi3Status STDCALL placeholder_fmi3SerializeFMUState(fmi3Component *component,
                                              fmi3FMUState FMUState,
                                              fmi3Byte serializedState[],
                                              size_t size) {
-    UNUSED(instance);
+    UNUSED(component);
     UNUSED(FMUState);
     UNUSED(serializedState);
     UNUSED(size);
@@ -1432,11 +1432,11 @@ fmi3Status STDCALL placeholder_fmi3SerializeFMUState(fmi3InstanceHandle *instanc
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3DeserializeFMUState(fmi3InstanceHandle *instance,
+fmi3Status STDCALL placeholder_fmi3DeserializeFMUState(fmi3Component *component,
                                                const fmi3Byte serializedState[],
                                                size_t size,
                                                fmi3FMUState* FMUState) {
-    UNUSED(instance);
+    UNUSED(component);
     UNUSED(serializedState);
     UNUSED(size);
     UNUSED(FMUState);
@@ -1444,7 +1444,7 @@ fmi3Status STDCALL placeholder_fmi3DeserializeFMUState(fmi3InstanceHandle *insta
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3GetDirectionalDerivative(fmi3InstanceHandle *instance,
+fmi3Status STDCALL placeholder_fmi3GetDirectionalDerivative(fmi3Component *component,
                                                     const fmi3ValueReference unknowns[],
                                                     size_t nUnknowns,
                                                     const fmi3ValueReference knowns[],
@@ -1453,7 +1453,7 @@ fmi3Status STDCALL placeholder_fmi3GetDirectionalDerivative(fmi3InstanceHandle *
                                                     size_t nSeed,
                                                     fmi3Float64 sensitivity[],
                                                     size_t nSensitivity) {
-    UNUSED(instance);
+    UNUSED(component);
     UNUSED(unknowns);
     UNUSED(nUnknowns);
     UNUSED(knowns);
@@ -1466,7 +1466,7 @@ fmi3Status STDCALL placeholder_fmi3GetDirectionalDerivative(fmi3InstanceHandle *
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3GetAdjointDerivative(fmi3InstanceHandle *instance,
+fmi3Status STDCALL placeholder_fmi3GetAdjointDerivative(fmi3Component *component,
                                                 const fmi3ValueReference unknowns[],
                                                 size_t nUnknowns,
                                                 const fmi3ValueReference knowns[],
@@ -1475,7 +1475,7 @@ fmi3Status STDCALL placeholder_fmi3GetAdjointDerivative(fmi3InstanceHandle *inst
                                                 size_t nSeed,
                                                 fmi3Float64 sensitivity[],
                                                 size_t nSensitivity) {
-    UNUSED(instance);
+    UNUSED(component);
     UNUSED(unknowns);
     UNUSED(nUnknowns);
     UNUSED(knowns);
@@ -1488,24 +1488,24 @@ fmi3Status STDCALL placeholder_fmi3GetAdjointDerivative(fmi3InstanceHandle *inst
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3EnterConfigurationMode(fmi3InstanceHandle *instance) {
-    UNUSED(instance);
+fmi3Status STDCALL placeholder_fmi3EnterConfigurationMode(fmi3Component *component) {
+    UNUSED(component);
     NOT_IMPLEMENTED(fmi3EnterConfigurationMode);
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3ExitConfigurationMode(fmi3InstanceHandle *instance) {
-    UNUSED(instance);
+fmi3Status STDCALL placeholder_fmi3ExitConfigurationMode(fmi3Component *component) {
+    UNUSED(component);
     NOT_IMPLEMENTED(fmi3ExitConfigurationMode);
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3GetIntervalDecimal(fmi3InstanceHandle *instance,
+fmi3Status STDCALL placeholder_fmi3GetIntervalDecimal(fmi3Component *component,
                                               const fmi3ValueReference valueReferences[],
                                               size_t nValueReferences,
                                               fmi3Float64 intervals[],
                                               fmi3IntervalQualifier qualifiers[]) {
-    UNUSED(instance);
+    UNUSED(component);
     UNUSED(valueReferences);
     UNUSED(nValueReferences);
     UNUSED(intervals);
@@ -1514,13 +1514,13 @@ fmi3Status STDCALL placeholder_fmi3GetIntervalDecimal(fmi3InstanceHandle *instan
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3GetIntervalFraction(fmi3InstanceHandle *instance,
+fmi3Status STDCALL placeholder_fmi3GetIntervalFraction(fmi3Component *component,
                                                const fmi3ValueReference valueReferences[],
                                                size_t nValueReferences,
                                                fmi3UInt64 intervalCounters[],
                                                fmi3UInt64 resolutions[],
                                                fmi3IntervalQualifier qualifiers[]) {
-    UNUSED(instance);
+    UNUSED(component);
     UNUSED(valueReferences);
     UNUSED(nValueReferences);
     UNUSED(intervalCounters);
@@ -1530,11 +1530,11 @@ fmi3Status STDCALL placeholder_fmi3GetIntervalFraction(fmi3InstanceHandle *insta
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3GetShiftDecimal(fmi3InstanceHandle *instance,
+fmi3Status STDCALL placeholder_fmi3GetShiftDecimal(fmi3Component *component,
                                            const fmi3ValueReference valueReferences[],
                                            size_t nValueReferences,
                                            fmi3Float64 shifts[]) {
-    UNUSED(instance);
+    UNUSED(component);
     UNUSED(valueReferences);
     UNUSED(nValueReferences);
     UNUSED(shifts);
@@ -1542,12 +1542,12 @@ fmi3Status STDCALL placeholder_fmi3GetShiftDecimal(fmi3InstanceHandle *instance,
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3GetShiftFraction(fmi3InstanceHandle *instance,
+fmi3Status STDCALL placeholder_fmi3GetShiftFraction(fmi3Component *component,
                                             const fmi3ValueReference valueReferences[],
                                             size_t nValueReferences,
                                             fmi3UInt64 shiftCounters[],
                                             fmi3UInt64 resolutions[]) {
-    UNUSED(instance);
+    UNUSED(component);
     UNUSED(valueReferences);
     UNUSED(nValueReferences);
     UNUSED(shiftCounters);
@@ -1556,11 +1556,11 @@ fmi3Status STDCALL placeholder_fmi3GetShiftFraction(fmi3InstanceHandle *instance
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3SetIntervalDecimal(fmi3InstanceHandle *instance,
+fmi3Status STDCALL placeholder_fmi3SetIntervalDecimal(fmi3Component *component,
                                               const fmi3ValueReference valueReferences[],
                                               size_t nValueReferences,
                                               const fmi3Float64 intervals[]) {
-    UNUSED(instance);
+    UNUSED(component);
     UNUSED(valueReferences);
     UNUSED(nValueReferences);
     UNUSED(intervals);
@@ -1568,12 +1568,12 @@ fmi3Status STDCALL placeholder_fmi3SetIntervalDecimal(fmi3InstanceHandle *instan
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3SetIntervalFraction(fmi3InstanceHandle *instance,
+fmi3Status STDCALL placeholder_fmi3SetIntervalFraction(fmi3Component *component,
                                                const fmi3ValueReference valueReferences[],
                                                size_t nValueReferences,
                                                const fmi3UInt64 intervalCounters[],
                                                const fmi3UInt64 resolutions[]){
-    UNUSED(instance);
+    UNUSED(component);
     UNUSED(valueReferences);
     UNUSED(nValueReferences);
     UNUSED(intervalCounters);
@@ -1582,11 +1582,11 @@ fmi3Status STDCALL placeholder_fmi3SetIntervalFraction(fmi3InstanceHandle *insta
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3SetShiftDecimal(fmi3InstanceHandle *instance,
+fmi3Status STDCALL placeholder_fmi3SetShiftDecimal(fmi3Component *component,
                                            const fmi3ValueReference valueReferences[],
                                            size_t nValueReferences,
                                            const fmi3Float64 shifts[]) {
-    UNUSED(instance);
+    UNUSED(component);
     UNUSED(valueReferences);
     UNUSED(nValueReferences);
     UNUSED(shifts);
@@ -1594,12 +1594,12 @@ fmi3Status STDCALL placeholder_fmi3SetShiftDecimal(fmi3InstanceHandle *instance,
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3SetShiftFraction(fmi3InstanceHandle *instance,
+fmi3Status STDCALL placeholder_fmi3SetShiftFraction(fmi3Component *component,
                                             const fmi3ValueReference valueReferences[],
                                             size_t nValueReferences,
                                             const fmi3UInt64 counters[],
                                             const fmi3UInt64 resolutions[]) {
-    UNUSED(instance);
+    UNUSED(component);
     UNUSED(valueReferences);
     UNUSED(nValueReferences);
     UNUSED(counters);
@@ -1609,20 +1609,20 @@ fmi3Status STDCALL placeholder_fmi3SetShiftFraction(fmi3InstanceHandle *instance
 }
 
 
-fmi3Status STDCALL placeholder_fmi3EvaluateDiscreteStates(fmi3InstanceHandle *instance) {
-    UNUSED(instance);
+fmi3Status STDCALL placeholder_fmi3EvaluateDiscreteStates(fmi3Component *component) {
+    UNUSED(component);
     NOT_IMPLEMENTED(fmi3EvaluateDiscreteStates);
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3UpdateDiscreteStates(fmi3InstanceHandle *instance,
+fmi3Status STDCALL placeholder_fmi3UpdateDiscreteStates(fmi3Component *component,
                                                 fmi3Boolean* discreteStatesNeedUpdate,
                                                 fmi3Boolean* terminateSimulation,
                                                 fmi3Boolean* nominalsOfContinuousStatesChanged,
                                                 fmi3Boolean* valuesOfContinuousStatesChanged,
                                                 fmi3Boolean* nextEventTimeDefined,
                                                 fmi3Float64* nextEventTime) {
-    UNUSED(instance);
+    UNUSED(component);
     UNUSED(discreteStatesNeedUpdate);
     UNUSED(terminateSimulation);
     UNUSED(nominalsOfContinuousStatesChanged);
@@ -1633,17 +1633,17 @@ fmi3Status STDCALL placeholder_fmi3UpdateDiscreteStates(fmi3InstanceHandle *inst
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3EnterContinuousTimeMode(fmi3InstanceHandle *instance) {
-    UNUSED(instance);
+fmi3Status STDCALL placeholder_fmi3EnterContinuousTimeMode(fmi3Component *component) {
+    UNUSED(component);
     NOT_IMPLEMENTED(fmi3EnterContinuousTimeMode);
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3CompletedIntegratorStep(fmi3InstanceHandle *instance,
+fmi3Status STDCALL placeholder_fmi3CompletedIntegratorStep(fmi3Component *component,
                                                    fmi3Boolean noSetFMUStatePriorToCurrentPoint,
                                                    fmi3Boolean* enterEventMode,
                                                    fmi3Boolean* terminateSimulation) {
-    UNUSED(instance);
+    UNUSED(component);
     UNUSED(noSetFMUStatePriorToCurrentPoint);
     UNUSED(enterEventMode);
     UNUSED(terminateSimulation);
@@ -1651,93 +1651,93 @@ fmi3Status STDCALL placeholder_fmi3CompletedIntegratorStep(fmi3InstanceHandle *i
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3SetTime(fmi3InstanceHandle *instance,
+fmi3Status STDCALL placeholder_fmi3SetTime(fmi3Component *component,
                                    fmi3Float64 time) {
-    UNUSED(instance);
+    UNUSED(component);
     UNUSED(time);
     NOT_IMPLEMENTED(fmi3SetTime);
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3SetContinuousStates(fmi3InstanceHandle *instance,
+fmi3Status STDCALL placeholder_fmi3SetContinuousStates(fmi3Component *component,
                                                const fmi3Float64 continuousStates[],
                                                size_t nContinuousStates) {
-    UNUSED(instance);
+    UNUSED(component);
     UNUSED(continuousStates);
     UNUSED(nContinuousStates);
     NOT_IMPLEMENTED(fmi3SetContinuousStates);
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3GetContinuousStateDerivatives(fmi3InstanceHandle *instance,
+fmi3Status STDCALL placeholder_fmi3GetContinuousStateDerivatives(fmi3Component *component,
                                                          fmi3Float64 derivatives[],
                                                          size_t nContinuousStates) {
-    UNUSED(instance);
+    UNUSED(component);
     UNUSED(derivatives);
     UNUSED(nContinuousStates);
     NOT_IMPLEMENTED(fmi3GetContinuousStateDerivatives);
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3GetEventIndicators(fmi3InstanceHandle *instance,
+fmi3Status STDCALL placeholder_fmi3GetEventIndicators(fmi3Component *component,
                                               fmi3Float64 eventIndicators[],
                                               size_t nEventIndicators) {
-    UNUSED(instance);
+    UNUSED(component);
     UNUSED(eventIndicators);
     UNUSED(nEventIndicators);
     NOT_IMPLEMENTED(fmi3GetEventIndicators);
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3GetContinuousStates(fmi3InstanceHandle *instance,
+fmi3Status STDCALL placeholder_fmi3GetContinuousStates(fmi3Component *component,
                                                fmi3Float64 continuousStates[],
                                                size_t nContinuousStates) {
-    UNUSED(instance);
+    UNUSED(component);
     UNUSED(continuousStates);
     UNUSED(nContinuousStates);
     NOT_IMPLEMENTED(fmi3GetContinuousStates);
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3GetNominalsOfContinuousStates(fmi3InstanceHandle *instance,
+fmi3Status STDCALL placeholder_fmi3GetNominalsOfContinuousStates(fmi3Component *component,
                                                          fmi3Float64 nominals[],
                                                          size_t nContinuousStates) {
-    UNUSED(instance);
+    UNUSED(component);
     UNUSED(nominals);
     UNUSED(nContinuousStates);
     NOT_IMPLEMENTED(fmi3GetNominalsOfContinuousStates);
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3GetNumberOfEventIndicators(fmi3InstanceHandle *instance,
+fmi3Status STDCALL placeholder_fmi3GetNumberOfEventIndicators(fmi3Component *component,
                                                       size_t* nEventIndicators) {
-    UNUSED(instance);
+    UNUSED(component);
     UNUSED(nEventIndicators);
     NOT_IMPLEMENTED(fmi3GetNumberOfEventIndicators);
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3GetNumberOfContinuousStates(fmi3InstanceHandle *instance,
+fmi3Status STDCALL placeholder_fmi3GetNumberOfContinuousStates(fmi3Component *component,
                                                        size_t* nContinuousStates) {
-    UNUSED(instance);
+    UNUSED(component);
     UNUSED(nContinuousStates);
     NOT_IMPLEMENTED(fmi3GetNumberOfContinuousStates);
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3EnterStepMode(fmi3InstanceHandle *instance) {
-    UNUSED(instance);
+fmi3Status STDCALL placeholder_fmi3EnterStepMode(fmi3Component *component) {
+    UNUSED(component);
     NOT_IMPLEMENTED(fmi3EnterStepMode);
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3GetOutputDerivatives(fmi3InstanceHandle *instance,
+fmi3Status STDCALL placeholder_fmi3GetOutputDerivatives(fmi3Component *component,
                                                 const fmi3ValueReference valueReferences[],
                                                 size_t nValueReferences,
                                                 const fmi3Int32 orders[],
                                                 fmi3Float64 values[],
                                                 size_t nValues) {
-    UNUSED(instance);
+    UNUSED(component);
     UNUSED(valueReferences);
     UNUSED(nValueReferences);
     UNUSED(orders);
@@ -1747,10 +1747,10 @@ fmi3Status STDCALL placeholder_fmi3GetOutputDerivatives(fmi3InstanceHandle *inst
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3ActivateModelPartition(fmi3InstanceHandle *instance,
+fmi3Status STDCALL placeholder_fmi3ActivateModelPartition(fmi3Component *component,
                                                   fmi3ValueReference clockReference,
                                                   fmi3Float64 activationTime) {
-    UNUSED(instance);
+    UNUSED(component);
     UNUSED(clockReference);
     UNUSED(activationTime);
     NOT_IMPLEMENTED(fmi3ActivateModelPartition);

--- a/src/fmi4c_placeholders.h
+++ b/src/fmi4c_placeholders.h
@@ -818,7 +818,7 @@ const char* STDCALL placeholder_fmi3GetVersion() {
     return NULL;
 }
 
-fmi3Status STDCALL placeholder_fmi3SetDebugLogging(fmi3Instance instance,
+fmi3Status STDCALL placeholder_fmi3SetDebugLogging(fmi3InstanceHandle *instance,
                                            fmi3Boolean loggingOn,
                                            size_t nCategories,
                                            const fmi3String categories[]) {
@@ -830,7 +830,7 @@ fmi3Status STDCALL placeholder_fmi3SetDebugLogging(fmi3Instance instance,
     return fmi3Error;
 }
 
-fmi3Instance STDCALL placeholder_fmi3InstantiateCoSimulation(fmi3String instanceName,
+fmi3InstanceHandle *STDCALL placeholder_fmi3InstantiateCoSimulation(fmi3String instanceName,
                                                        fmi3String instantiationToken,
                                                        fmi3String resourcePath,
                                                        fmi3Boolean visible,
@@ -858,7 +858,7 @@ fmi3Instance STDCALL placeholder_fmi3InstantiateCoSimulation(fmi3String instance
     return NULL;
 }
 
-fmi3Instance STDCALL placeholder_fmi3InstantiateModelExchange(fmi3String instanceName,
+fmi3InstanceHandle *STDCALL placeholder_fmi3InstantiateModelExchange(fmi3String instanceName,
                                                         fmi3String instantiationToken,
                                                         fmi3String resourcePath,
                                                         fmi3Boolean visible,
@@ -876,7 +876,7 @@ fmi3Instance STDCALL placeholder_fmi3InstantiateModelExchange(fmi3String instanc
     return NULL;
 }
 
-fmi3Instance STDCALL placeholder_fmi3InstantiateScheduledExecution(fmi3String instanceName,
+fmi3InstanceHandle *STDCALL placeholder_fmi3InstantiateScheduledExecution(fmi3String instanceName,
                                                              fmi3String instantiationToken,
                                                              fmi3String resourcePath,
                                                              fmi3Boolean visible,
@@ -900,12 +900,12 @@ fmi3Instance STDCALL placeholder_fmi3InstantiateScheduledExecution(fmi3String in
     return NULL;
 }
 
-void STDCALL placeholder_fmi3FreeInstance(fmi3Instance instance) {
+void STDCALL placeholder_fmi3FreeInstance(fmi3InstanceHandle *instance) {
     UNUSED(instance);
     NOT_IMPLEMENTED(fmi3FreeInstance);
 }
 
-fmi3Status STDCALL placeholder_fmi3EnterInitializationMode(fmi3Instance instance,
+fmi3Status STDCALL placeholder_fmi3EnterInitializationMode(fmi3InstanceHandle *instance,
                                                    fmi3Boolean toleranceDefined,
                                                    fmi3Float64 tolerance,
                                                    fmi3Float64 startTime,
@@ -921,19 +921,19 @@ fmi3Status STDCALL placeholder_fmi3EnterInitializationMode(fmi3Instance instance
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3ExitInitializationMode(fmi3Instance instance) {
+fmi3Status STDCALL placeholder_fmi3ExitInitializationMode(fmi3InstanceHandle *instance) {
     UNUSED(instance);
     NOT_IMPLEMENTED(fmi3ExitInitializationMode);
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3Terminate(fmi3Instance instance) {
+fmi3Status STDCALL placeholder_fmi3Terminate(fmi3InstanceHandle *instance) {
     UNUSED(instance);
     NOT_IMPLEMENTED(fmi3Terminate);
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3DoStep(fmi3Instance instance,
+fmi3Status STDCALL placeholder_fmi3DoStep(fmi3InstanceHandle *instance,
                                   fmi3Float64 currentCommunicationPoint,
                                   fmi3Float64 communicationStepSize,
                                   fmi3Boolean noSetFMUStatePriorToCurrentPoint,
@@ -954,19 +954,19 @@ fmi3Status STDCALL placeholder_fmi3DoStep(fmi3Instance instance,
 
 }
 
-fmi3Status STDCALL placeholder_fmi3EnterEventMode(fmi3Instance instance) {
+fmi3Status STDCALL placeholder_fmi3EnterEventMode(fmi3InstanceHandle *instance) {
     UNUSED(instance);
     NOT_IMPLEMENTED(fmi3EnterEventMode);
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3Reset(fmi3Instance instance) {
+fmi3Status STDCALL placeholder_fmi3Reset(fmi3InstanceHandle *instance) {
     UNUSED(instance);
     NOT_IMPLEMENTED(fmi3Reset);
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3GetFloat64(fmi3Instance instance,
+fmi3Status STDCALL placeholder_fmi3GetFloat64(fmi3InstanceHandle *instance,
                                       const fmi3ValueReference valueReferences[],
                                       size_t nValueReferences,
                                       fmi3Float64 values[],
@@ -980,7 +980,7 @@ fmi3Status STDCALL placeholder_fmi3GetFloat64(fmi3Instance instance,
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3SetFloat64(fmi3Instance instance,
+fmi3Status STDCALL placeholder_fmi3SetFloat64(fmi3InstanceHandle *instance,
                                       const fmi3ValueReference valueReferences[],
                                       size_t nValueReferences,
                                       const fmi3Float64 values[],
@@ -994,7 +994,7 @@ fmi3Status STDCALL placeholder_fmi3SetFloat64(fmi3Instance instance,
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3GetFloat32(fmi3Instance instance,
+fmi3Status STDCALL placeholder_fmi3GetFloat32(fmi3InstanceHandle *instance,
                                       const fmi3ValueReference valueReferences[],
                                       size_t nValueReferences,
                                       fmi3Float32 values[],
@@ -1008,7 +1008,7 @@ fmi3Status STDCALL placeholder_fmi3GetFloat32(fmi3Instance instance,
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3GetInt8(fmi3Instance instance,
+fmi3Status STDCALL placeholder_fmi3GetInt8(fmi3InstanceHandle *instance,
                                    const fmi3ValueReference valueReferences[],
                                    size_t nValueReferences,
                                    fmi3Int8 values[],
@@ -1022,7 +1022,7 @@ fmi3Status STDCALL placeholder_fmi3GetInt8(fmi3Instance instance,
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3GetUInt8(fmi3Instance instance,
+fmi3Status STDCALL placeholder_fmi3GetUInt8(fmi3InstanceHandle *instance,
                                     const fmi3ValueReference valueReferences[],
                                     size_t nValueReferences,
                                     fmi3UInt8 values[],
@@ -1036,7 +1036,7 @@ fmi3Status STDCALL placeholder_fmi3GetUInt8(fmi3Instance instance,
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3GetInt16(fmi3Instance instance,
+fmi3Status STDCALL placeholder_fmi3GetInt16(fmi3InstanceHandle *instance,
                                     const fmi3ValueReference valueReferences[],
                                     size_t nValueReferences,
                                     fmi3Int16 values[],
@@ -1050,7 +1050,7 @@ fmi3Status STDCALL placeholder_fmi3GetInt16(fmi3Instance instance,
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3GetUInt16(fmi3Instance instance,
+fmi3Status STDCALL placeholder_fmi3GetUInt16(fmi3InstanceHandle *instance,
                                      const fmi3ValueReference valueReferences[],
                                      size_t nValueReferences,
                                      fmi3UInt16 values[],
@@ -1064,7 +1064,7 @@ fmi3Status STDCALL placeholder_fmi3GetUInt16(fmi3Instance instance,
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3GetInt32(fmi3Instance instance,
+fmi3Status STDCALL placeholder_fmi3GetInt32(fmi3InstanceHandle *instance,
                                     const fmi3ValueReference valueReferences[],
                                     size_t nValueReferences,
                                     fmi3Int32 values[],
@@ -1078,7 +1078,7 @@ fmi3Status STDCALL placeholder_fmi3GetInt32(fmi3Instance instance,
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3GetUInt32(fmi3Instance instance,
+fmi3Status STDCALL placeholder_fmi3GetUInt32(fmi3InstanceHandle *instance,
                                      const fmi3ValueReference valueReferences[],
                                      size_t nValueReferences,
                                      fmi3UInt32 values[],
@@ -1092,7 +1092,7 @@ fmi3Status STDCALL placeholder_fmi3GetUInt32(fmi3Instance instance,
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3GetInt64(fmi3Instance instance,
+fmi3Status STDCALL placeholder_fmi3GetInt64(fmi3InstanceHandle *instance,
                                     const fmi3ValueReference valueReferences[],
                                     size_t nValueReferences,
                                     fmi3Int64 values[],
@@ -1106,7 +1106,7 @@ fmi3Status STDCALL placeholder_fmi3GetInt64(fmi3Instance instance,
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3GetUInt64(fmi3Instance instance,
+fmi3Status STDCALL placeholder_fmi3GetUInt64(fmi3InstanceHandle *instance,
                                      const fmi3ValueReference valueReferences[],
                                      size_t nValueReferences,
                                      fmi3UInt64 values[],
@@ -1120,7 +1120,7 @@ fmi3Status STDCALL placeholder_fmi3GetUInt64(fmi3Instance instance,
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3GetBoolean(fmi3Instance instance,
+fmi3Status STDCALL placeholder_fmi3GetBoolean(fmi3InstanceHandle *instance,
                                       const fmi3ValueReference valueReferences[],
                                       size_t nValueReferences,
                                       fmi3Boolean values[],
@@ -1134,7 +1134,7 @@ fmi3Status STDCALL placeholder_fmi3GetBoolean(fmi3Instance instance,
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3GetString(fmi3Instance instance,
+fmi3Status STDCALL placeholder_fmi3GetString(fmi3InstanceHandle *instance,
                                      const fmi3ValueReference valueReferences[],
                                      size_t nValueReferences,
                                      fmi3String values[],
@@ -1148,7 +1148,7 @@ fmi3Status STDCALL placeholder_fmi3GetString(fmi3Instance instance,
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3GetBinary(fmi3Instance instance,
+fmi3Status STDCALL placeholder_fmi3GetBinary(fmi3InstanceHandle *instance,
                                      const fmi3ValueReference valueReferences[],
                                      size_t nValueReferences,
                                      size_t valueSizes[],
@@ -1164,7 +1164,7 @@ fmi3Status STDCALL placeholder_fmi3GetBinary(fmi3Instance instance,
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3GetClock(fmi3Instance instance,
+fmi3Status STDCALL placeholder_fmi3GetClock(fmi3InstanceHandle *instance,
                                     const fmi3ValueReference valueReferences[],
                                     size_t nValueReferences,
                                     fmi3Clock values[]) {
@@ -1176,7 +1176,7 @@ fmi3Status STDCALL placeholder_fmi3GetClock(fmi3Instance instance,
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3SetFloat32(fmi3Instance instance,
+fmi3Status STDCALL placeholder_fmi3SetFloat32(fmi3InstanceHandle *instance,
                                       const fmi3ValueReference valueReferences[],
                                       size_t nValueReferences,
                                       const fmi3Float32 values[],
@@ -1190,7 +1190,7 @@ fmi3Status STDCALL placeholder_fmi3SetFloat32(fmi3Instance instance,
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3SetInt8(fmi3Instance instance,
+fmi3Status STDCALL placeholder_fmi3SetInt8(fmi3InstanceHandle *instance,
                                    const fmi3ValueReference valueReferences[],
                                    size_t nValueReferences,
                                    const fmi3Int8 values[],
@@ -1204,7 +1204,7 @@ fmi3Status STDCALL placeholder_fmi3SetInt8(fmi3Instance instance,
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3SetUInt8(fmi3Instance instance,
+fmi3Status STDCALL placeholder_fmi3SetUInt8(fmi3InstanceHandle *instance,
                                     const fmi3ValueReference valueReferences[],
                                     size_t nValueReferences,
                                     const fmi3UInt8 values[],
@@ -1218,7 +1218,7 @@ fmi3Status STDCALL placeholder_fmi3SetUInt8(fmi3Instance instance,
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3SetInt16(fmi3Instance instance,
+fmi3Status STDCALL placeholder_fmi3SetInt16(fmi3InstanceHandle *instance,
                                     const fmi3ValueReference valueReferences[],
                                     size_t nValueReferences,
                                     const fmi3Int16 values[],
@@ -1232,7 +1232,7 @@ fmi3Status STDCALL placeholder_fmi3SetInt16(fmi3Instance instance,
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3SetUInt16(fmi3Instance instance,
+fmi3Status STDCALL placeholder_fmi3SetUInt16(fmi3InstanceHandle *instance,
                                      const fmi3ValueReference valueReferences[],
                                      size_t nValueReferences,
                                      const fmi3UInt16 values[],
@@ -1246,7 +1246,7 @@ fmi3Status STDCALL placeholder_fmi3SetUInt16(fmi3Instance instance,
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3SetInt32(fmi3Instance instance,
+fmi3Status STDCALL placeholder_fmi3SetInt32(fmi3InstanceHandle *instance,
                                     const fmi3ValueReference valueReferences[],
                                     size_t nValueReferences,
                                     const fmi3Int32 values[],
@@ -1260,7 +1260,7 @@ fmi3Status STDCALL placeholder_fmi3SetInt32(fmi3Instance instance,
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3SetUInt32(fmi3Instance instance,
+fmi3Status STDCALL placeholder_fmi3SetUInt32(fmi3InstanceHandle *instance,
                                      const fmi3ValueReference valueReferences[],
                                      size_t nValueReferences,
                                      const fmi3UInt32 values[],
@@ -1274,7 +1274,7 @@ fmi3Status STDCALL placeholder_fmi3SetUInt32(fmi3Instance instance,
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3SetInt64(fmi3Instance instance,
+fmi3Status STDCALL placeholder_fmi3SetInt64(fmi3InstanceHandle *instance,
                                     const fmi3ValueReference valueReferences[],
                                     size_t nValueReferences,
                                     const fmi3Int64 values[],
@@ -1288,7 +1288,7 @@ fmi3Status STDCALL placeholder_fmi3SetInt64(fmi3Instance instance,
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3SetUInt64(fmi3Instance instance,
+fmi3Status STDCALL placeholder_fmi3SetUInt64(fmi3InstanceHandle *instance,
                                      const fmi3ValueReference valueReferences[],
                                      size_t nValueReferences,
                                      const fmi3UInt64 values[],
@@ -1302,7 +1302,7 @@ fmi3Status STDCALL placeholder_fmi3SetUInt64(fmi3Instance instance,
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3SetBoolean(fmi3Instance instance,
+fmi3Status STDCALL placeholder_fmi3SetBoolean(fmi3InstanceHandle *instance,
                                       const fmi3ValueReference valueReferences[],
                                       size_t nValueReferences,
                                       const fmi3Boolean values[],
@@ -1316,7 +1316,7 @@ fmi3Status STDCALL placeholder_fmi3SetBoolean(fmi3Instance instance,
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3SetString(fmi3Instance instance,
+fmi3Status STDCALL placeholder_fmi3SetString(fmi3InstanceHandle *instance,
                                      const fmi3ValueReference valueReferences[],
                                      size_t nValueReferences,
                                      const fmi3String values[],
@@ -1330,7 +1330,7 @@ fmi3Status STDCALL placeholder_fmi3SetString(fmi3Instance instance,
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3SetBinary(fmi3Instance instance,
+fmi3Status STDCALL placeholder_fmi3SetBinary(fmi3InstanceHandle *instance,
                                      const fmi3ValueReference valueReferences[],
                                      size_t nValueReferences,
                                      const size_t valueSizes[],
@@ -1346,7 +1346,7 @@ fmi3Status STDCALL placeholder_fmi3SetBinary(fmi3Instance instance,
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3SetClock(fmi3Instance instance,
+fmi3Status STDCALL placeholder_fmi3SetClock(fmi3InstanceHandle *instance,
                                     const fmi3ValueReference valueReferences[],
                                     size_t nValueReferences,
                                     const fmi3Clock values[]) {
@@ -1358,7 +1358,7 @@ fmi3Status STDCALL placeholder_fmi3SetClock(fmi3Instance instance,
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3GetNumberOfVariableDependencies(fmi3Instance instance,
+fmi3Status STDCALL placeholder_fmi3GetNumberOfVariableDependencies(fmi3InstanceHandle *instance,
                                                            fmi3ValueReference valueReference,
                                                            size_t* nDependencies) {
     UNUSED(instance);
@@ -1368,7 +1368,7 @@ fmi3Status STDCALL placeholder_fmi3GetNumberOfVariableDependencies(fmi3Instance 
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3GetVariableDependencies(fmi3Instance instance,
+fmi3Status STDCALL placeholder_fmi3GetVariableDependencies(fmi3InstanceHandle *instance,
                                                    fmi3ValueReference dependent,
                                                    size_t elementIndicesOfDependent[],
                                                    fmi3ValueReference independents[],
@@ -1386,7 +1386,7 @@ fmi3Status STDCALL placeholder_fmi3GetVariableDependencies(fmi3Instance instance
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3GetFMUState(fmi3Instance instance,
+fmi3Status STDCALL placeholder_fmi3GetFMUState(fmi3InstanceHandle *instance,
                                        fmi3FMUState* FMUState) {
     UNUSED(instance);
     UNUSED(FMUState);
@@ -1394,7 +1394,7 @@ fmi3Status STDCALL placeholder_fmi3GetFMUState(fmi3Instance instance,
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3SetFMUState(fmi3Instance instance,
+fmi3Status STDCALL placeholder_fmi3SetFMUState(fmi3InstanceHandle *instance,
                                        fmi3FMUState FMUState) {
     UNUSED(instance);
     UNUSED(FMUState);
@@ -1402,7 +1402,7 @@ fmi3Status STDCALL placeholder_fmi3SetFMUState(fmi3Instance instance,
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3FreeFMUState(fmi3Instance instance,
+fmi3Status STDCALL placeholder_fmi3FreeFMUState(fmi3InstanceHandle *instance,
                                         fmi3FMUState* FMUState) {
     UNUSED(instance);
     UNUSED(FMUState);
@@ -1410,7 +1410,7 @@ fmi3Status STDCALL placeholder_fmi3FreeFMUState(fmi3Instance instance,
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3SerializedFMUStateSize(fmi3Instance instance,
+fmi3Status STDCALL placeholder_fmi3SerializedFMUStateSize(fmi3InstanceHandle *instance,
                                                   fmi3FMUState FMUState,
                                                   size_t* size) {
     UNUSED(instance);
@@ -1420,7 +1420,7 @@ fmi3Status STDCALL placeholder_fmi3SerializedFMUStateSize(fmi3Instance instance,
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3SerializeFMUState(fmi3Instance instance,
+fmi3Status STDCALL placeholder_fmi3SerializeFMUState(fmi3InstanceHandle *instance,
                                              fmi3FMUState FMUState,
                                              fmi3Byte serializedState[],
                                              size_t size) {
@@ -1432,7 +1432,7 @@ fmi3Status STDCALL placeholder_fmi3SerializeFMUState(fmi3Instance instance,
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3DeserializeFMUState(fmi3Instance instance,
+fmi3Status STDCALL placeholder_fmi3DeserializeFMUState(fmi3InstanceHandle *instance,
                                                const fmi3Byte serializedState[],
                                                size_t size,
                                                fmi3FMUState* FMUState) {
@@ -1444,7 +1444,7 @@ fmi3Status STDCALL placeholder_fmi3DeserializeFMUState(fmi3Instance instance,
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3GetDirectionalDerivative(fmi3Instance instance,
+fmi3Status STDCALL placeholder_fmi3GetDirectionalDerivative(fmi3InstanceHandle *instance,
                                                     const fmi3ValueReference unknowns[],
                                                     size_t nUnknowns,
                                                     const fmi3ValueReference knowns[],
@@ -1466,7 +1466,7 @@ fmi3Status STDCALL placeholder_fmi3GetDirectionalDerivative(fmi3Instance instanc
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3GetAdjointDerivative(fmi3Instance instance,
+fmi3Status STDCALL placeholder_fmi3GetAdjointDerivative(fmi3InstanceHandle *instance,
                                                 const fmi3ValueReference unknowns[],
                                                 size_t nUnknowns,
                                                 const fmi3ValueReference knowns[],
@@ -1488,19 +1488,19 @@ fmi3Status STDCALL placeholder_fmi3GetAdjointDerivative(fmi3Instance instance,
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3EnterConfigurationMode(fmi3Instance instance) {
+fmi3Status STDCALL placeholder_fmi3EnterConfigurationMode(fmi3InstanceHandle *instance) {
     UNUSED(instance);
     NOT_IMPLEMENTED(fmi3EnterConfigurationMode);
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3ExitConfigurationMode(fmi3Instance instance) {
+fmi3Status STDCALL placeholder_fmi3ExitConfigurationMode(fmi3InstanceHandle *instance) {
     UNUSED(instance);
     NOT_IMPLEMENTED(fmi3ExitConfigurationMode);
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3GetIntervalDecimal(fmi3Instance instance,
+fmi3Status STDCALL placeholder_fmi3GetIntervalDecimal(fmi3InstanceHandle *instance,
                                               const fmi3ValueReference valueReferences[],
                                               size_t nValueReferences,
                                               fmi3Float64 intervals[],
@@ -1514,7 +1514,7 @@ fmi3Status STDCALL placeholder_fmi3GetIntervalDecimal(fmi3Instance instance,
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3GetIntervalFraction(fmi3Instance instance,
+fmi3Status STDCALL placeholder_fmi3GetIntervalFraction(fmi3InstanceHandle *instance,
                                                const fmi3ValueReference valueReferences[],
                                                size_t nValueReferences,
                                                fmi3UInt64 intervalCounters[],
@@ -1530,7 +1530,7 @@ fmi3Status STDCALL placeholder_fmi3GetIntervalFraction(fmi3Instance instance,
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3GetShiftDecimal(fmi3Instance instance,
+fmi3Status STDCALL placeholder_fmi3GetShiftDecimal(fmi3InstanceHandle *instance,
                                            const fmi3ValueReference valueReferences[],
                                            size_t nValueReferences,
                                            fmi3Float64 shifts[]) {
@@ -1542,7 +1542,7 @@ fmi3Status STDCALL placeholder_fmi3GetShiftDecimal(fmi3Instance instance,
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3GetShiftFraction(fmi3Instance instance,
+fmi3Status STDCALL placeholder_fmi3GetShiftFraction(fmi3InstanceHandle *instance,
                                             const fmi3ValueReference valueReferences[],
                                             size_t nValueReferences,
                                             fmi3UInt64 shiftCounters[],
@@ -1556,7 +1556,7 @@ fmi3Status STDCALL placeholder_fmi3GetShiftFraction(fmi3Instance instance,
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3SetIntervalDecimal(fmi3Instance instance,
+fmi3Status STDCALL placeholder_fmi3SetIntervalDecimal(fmi3InstanceHandle *instance,
                                               const fmi3ValueReference valueReferences[],
                                               size_t nValueReferences,
                                               const fmi3Float64 intervals[]) {
@@ -1568,7 +1568,7 @@ fmi3Status STDCALL placeholder_fmi3SetIntervalDecimal(fmi3Instance instance,
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3SetIntervalFraction(fmi3Instance instance,
+fmi3Status STDCALL placeholder_fmi3SetIntervalFraction(fmi3InstanceHandle *instance,
                                                const fmi3ValueReference valueReferences[],
                                                size_t nValueReferences,
                                                const fmi3UInt64 intervalCounters[],
@@ -1582,7 +1582,7 @@ fmi3Status STDCALL placeholder_fmi3SetIntervalFraction(fmi3Instance instance,
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3SetShiftDecimal(fmi3Instance instance,
+fmi3Status STDCALL placeholder_fmi3SetShiftDecimal(fmi3InstanceHandle *instance,
                                            const fmi3ValueReference valueReferences[],
                                            size_t nValueReferences,
                                            const fmi3Float64 shifts[]) {
@@ -1594,7 +1594,7 @@ fmi3Status STDCALL placeholder_fmi3SetShiftDecimal(fmi3Instance instance,
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3SetShiftFraction(fmi3Instance instance,
+fmi3Status STDCALL placeholder_fmi3SetShiftFraction(fmi3InstanceHandle *instance,
                                             const fmi3ValueReference valueReferences[],
                                             size_t nValueReferences,
                                             const fmi3UInt64 counters[],
@@ -1609,13 +1609,13 @@ fmi3Status STDCALL placeholder_fmi3SetShiftFraction(fmi3Instance instance,
 }
 
 
-fmi3Status STDCALL placeholder_fmi3EvaluateDiscreteStates(fmi3Instance instance) {
+fmi3Status STDCALL placeholder_fmi3EvaluateDiscreteStates(fmi3InstanceHandle *instance) {
     UNUSED(instance);
     NOT_IMPLEMENTED(fmi3EvaluateDiscreteStates);
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3UpdateDiscreteStates(fmi3Instance instance,
+fmi3Status STDCALL placeholder_fmi3UpdateDiscreteStates(fmi3InstanceHandle *instance,
                                                 fmi3Boolean* discreteStatesNeedUpdate,
                                                 fmi3Boolean* terminateSimulation,
                                                 fmi3Boolean* nominalsOfContinuousStatesChanged,
@@ -1633,13 +1633,13 @@ fmi3Status STDCALL placeholder_fmi3UpdateDiscreteStates(fmi3Instance instance,
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3EnterContinuousTimeMode(fmi3Instance instance) {
+fmi3Status STDCALL placeholder_fmi3EnterContinuousTimeMode(fmi3InstanceHandle *instance) {
     UNUSED(instance);
     NOT_IMPLEMENTED(fmi3EnterContinuousTimeMode);
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3CompletedIntegratorStep(fmi3Instance instance,
+fmi3Status STDCALL placeholder_fmi3CompletedIntegratorStep(fmi3InstanceHandle *instance,
                                                    fmi3Boolean noSetFMUStatePriorToCurrentPoint,
                                                    fmi3Boolean* enterEventMode,
                                                    fmi3Boolean* terminateSimulation) {
@@ -1651,7 +1651,7 @@ fmi3Status STDCALL placeholder_fmi3CompletedIntegratorStep(fmi3Instance instance
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3SetTime(fmi3Instance instance,
+fmi3Status STDCALL placeholder_fmi3SetTime(fmi3InstanceHandle *instance,
                                    fmi3Float64 time) {
     UNUSED(instance);
     UNUSED(time);
@@ -1659,7 +1659,7 @@ fmi3Status STDCALL placeholder_fmi3SetTime(fmi3Instance instance,
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3SetContinuousStates(fmi3Instance instance,
+fmi3Status STDCALL placeholder_fmi3SetContinuousStates(fmi3InstanceHandle *instance,
                                                const fmi3Float64 continuousStates[],
                                                size_t nContinuousStates) {
     UNUSED(instance);
@@ -1669,7 +1669,7 @@ fmi3Status STDCALL placeholder_fmi3SetContinuousStates(fmi3Instance instance,
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3GetContinuousStateDerivatives(fmi3Instance instance,
+fmi3Status STDCALL placeholder_fmi3GetContinuousStateDerivatives(fmi3InstanceHandle *instance,
                                                          fmi3Float64 derivatives[],
                                                          size_t nContinuousStates) {
     UNUSED(instance);
@@ -1679,7 +1679,7 @@ fmi3Status STDCALL placeholder_fmi3GetContinuousStateDerivatives(fmi3Instance in
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3GetEventIndicators(fmi3Instance instance,
+fmi3Status STDCALL placeholder_fmi3GetEventIndicators(fmi3InstanceHandle *instance,
                                               fmi3Float64 eventIndicators[],
                                               size_t nEventIndicators) {
     UNUSED(instance);
@@ -1689,7 +1689,7 @@ fmi3Status STDCALL placeholder_fmi3GetEventIndicators(fmi3Instance instance,
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3GetContinuousStates(fmi3Instance instance,
+fmi3Status STDCALL placeholder_fmi3GetContinuousStates(fmi3InstanceHandle *instance,
                                                fmi3Float64 continuousStates[],
                                                size_t nContinuousStates) {
     UNUSED(instance);
@@ -1699,7 +1699,7 @@ fmi3Status STDCALL placeholder_fmi3GetContinuousStates(fmi3Instance instance,
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3GetNominalsOfContinuousStates(fmi3Instance instance,
+fmi3Status STDCALL placeholder_fmi3GetNominalsOfContinuousStates(fmi3InstanceHandle *instance,
                                                          fmi3Float64 nominals[],
                                                          size_t nContinuousStates) {
     UNUSED(instance);
@@ -1709,7 +1709,7 @@ fmi3Status STDCALL placeholder_fmi3GetNominalsOfContinuousStates(fmi3Instance in
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3GetNumberOfEventIndicators(fmi3Instance instance,
+fmi3Status STDCALL placeholder_fmi3GetNumberOfEventIndicators(fmi3InstanceHandle *instance,
                                                       size_t* nEventIndicators) {
     UNUSED(instance);
     UNUSED(nEventIndicators);
@@ -1717,7 +1717,7 @@ fmi3Status STDCALL placeholder_fmi3GetNumberOfEventIndicators(fmi3Instance insta
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3GetNumberOfContinuousStates(fmi3Instance instance,
+fmi3Status STDCALL placeholder_fmi3GetNumberOfContinuousStates(fmi3InstanceHandle *instance,
                                                        size_t* nContinuousStates) {
     UNUSED(instance);
     UNUSED(nContinuousStates);
@@ -1725,13 +1725,13 @@ fmi3Status STDCALL placeholder_fmi3GetNumberOfContinuousStates(fmi3Instance inst
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3EnterStepMode(fmi3Instance instance) {
+fmi3Status STDCALL placeholder_fmi3EnterStepMode(fmi3InstanceHandle *instance) {
     UNUSED(instance);
     NOT_IMPLEMENTED(fmi3EnterStepMode);
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3GetOutputDerivatives(fmi3Instance instance,
+fmi3Status STDCALL placeholder_fmi3GetOutputDerivatives(fmi3InstanceHandle *instance,
                                                 const fmi3ValueReference valueReferences[],
                                                 size_t nValueReferences,
                                                 const fmi3Int32 orders[],
@@ -1747,7 +1747,7 @@ fmi3Status STDCALL placeholder_fmi3GetOutputDerivatives(fmi3Instance instance,
     return fmi3Error;
 }
 
-fmi3Status STDCALL placeholder_fmi3ActivateModelPartition(fmi3Instance instance,
+fmi3Status STDCALL placeholder_fmi3ActivateModelPartition(fmi3InstanceHandle *instance,
                                                   fmi3ValueReference clockReference,
                                                   fmi3Float64 activationTime) {
     UNUSED(instance);

--- a/src/fmi4c_private.h
+++ b/src/fmi4c_private.h
@@ -236,7 +236,7 @@ typedef struct {
 
     fmi1Type type;
 
-    fmi1Component_t component;
+    fmi1Component component;
 
     fmi1CallbackFunctionsCoSimulation callbacksCoSimulation;
     fmi1CallbackFunctionsModelExchange callbacksModelExchange;

--- a/src/fmi4c_private.h
+++ b/src/fmi4c_private.h
@@ -678,7 +678,7 @@ typedef struct {
     fmi3VariableHandle *variables;
     int variablesSize;
 
-    fmi3Instance fmi3Instance;
+    fmi3InstanceHandle fmi3Instance;
     fmi3GetVersion_t getVersion;
     fmi3SetDebugLogging_t setDebugLogging;
     fmi3InstantiateModelExchange_t instantiateModelExchange;

--- a/src/fmi4c_private.h
+++ b/src/fmi4c_private.h
@@ -372,8 +372,6 @@ typedef struct {
 
     fmi2ModelStructureData_t modelStructure;
 
-    fmi2Component component;
-
     fmi2GetTypesPlatform_t getTypesPlatform;
     fmi2GetVersion_t getVersion;
     fmi2SetDebugLogging_t setDebugLogging;

--- a/src/fmi4c_private.h
+++ b/src/fmi4c_private.h
@@ -796,7 +796,7 @@ typedef struct {
 } fmi3Data_t;
 
 
-typedef struct {
+struct fmuHandle {
     fmiVersion_t version;
     bool unzippedLocationIsTemporary;
     const char* unzippedLocation;
@@ -814,14 +814,15 @@ typedef struct {
 
     void** allocatedPointers;
     int numAllocatedPointers;
-} fmiHandle;
+};
+typedef struct fmuHandle fmuHandle;
 
-bool parseModelDescriptionFmi1(fmiHandle *fmuFile);
-bool parseModelDescriptionFmi2(fmiHandle *fmuFile);
-bool parseModelDescriptionFmi3(fmiHandle *fmuFile);
+bool parseModelDescriptionFmi1(fmuHandle *fmuFile);
+bool parseModelDescriptionFmi2(fmuHandle *fmuFile);
+bool parseModelDescriptionFmi3(fmuHandle *fmuFile);
 
-bool loadFunctionsFmi1(fmiHandle *contents);
-bool loadFunctionsFmi2(fmiHandle *contents, fmi2Type fmuType);
-bool loadFunctionsFmi3(fmiHandle *contents, fmi3Type fmuType);
+bool loadFunctionsFmi1(fmuHandle *contents);
+bool loadFunctionsFmi2(fmuHandle *contents, fmi2Type fmuType);
+bool loadFunctionsFmi3(fmuHandle *contents, fmi3Type fmuType);
 
 #endif // FMIC_PRIVATE_H

--- a/src/fmi4c_utils.c
+++ b/src/fmi4c_utils.c
@@ -21,21 +21,21 @@
 #endif
 
 
-void rememberPointer(fmiHandle *fmu, void* ptr)
+void rememberPointer(fmuHandle *fmu, void* ptr)
 {
     fmu->numAllocatedPointers++;
     fmu->allocatedPointers = realloc(fmu->allocatedPointers, fmu->numAllocatedPointers * sizeof(void*));
     fmu->allocatedPointers[fmu->numAllocatedPointers-1] = ptr;
 }
 
-void* mallocAndRememberPointer(fmiHandle *fmu, size_t size)
+void* mallocAndRememberPointer(fmuHandle *fmu, size_t size)
 {
     void* ptr = malloc(size);
     rememberPointer(fmu, ptr);
     return ptr;
 }
 
-void *reallocAndRememberPointer(fmiHandle *fmu, void *org, size_t size)
+void *reallocAndRememberPointer(fmuHandle *fmu, void *org, size_t size)
 {
     int i=0;
     while (i < fmu->numAllocatedPointers && org != fmu->allocatedPointers[i])
@@ -48,7 +48,7 @@ void *reallocAndRememberPointer(fmiHandle *fmu, void *org, size_t size)
     return ptr;
 }
 
-char* duplicateAndRememberString(fmiHandle *fmu, const char* str)
+char* duplicateAndRememberString(fmuHandle *fmu, const char* str)
 {
     char* ret = _strdup(str);
     rememberPointer(fmu, (void*)ret);
@@ -77,7 +77,7 @@ const char* getFunctionName(const char* modelName, const char* functionName, cha
 //! @param attributeName Attribute name
 //! @param target Pointer to target variable
 //! @returns True if attribute was found, else false
-bool parseStringAttributeEzXmlAndRememberPointer(ezxml_t element, const char *attributeName, const char **target, fmiHandle *fmu)
+bool parseStringAttributeEzXmlAndRememberPointer(ezxml_t element, const char *attributeName, const char **target, fmuHandle *fmu)
 {
     if(ezxml_attr(element, attributeName)) {
         (*target) = duplicateAndRememberString(fmu, ezxml_attr(element, attributeName));
@@ -249,7 +249,7 @@ bool parseUInt8AttributeEzXml(ezxml_t element, const char *attributeName, uint8_
     return false;
 }
 
-bool parseModelStructureElementFmi2(fmiHandle *fmu, fmi2ModelStructureHandle *output, ezxml_t *element)
+bool parseModelStructureElementFmi2(fmuHandle *fmu, fmi2ModelStructureHandle *output, ezxml_t *element)
 {
     parseInt32AttributeEzXml(*element, "index", &output->index);
 
@@ -350,7 +350,7 @@ bool parseModelStructureElementFmi2(fmiHandle *fmu, fmi2ModelStructureHandle *ou
     return true;
 }
 
-bool parseModelStructureElementFmi3(fmiHandle *fmu, fmi3ModelStructureHandle *output, ezxml_t *element)
+bool parseModelStructureElementFmi3(fmuHandle *fmu, fmi3ModelStructureHandle *output, ezxml_t *element)
 {
     parseUInt32AttributeEzXml(*element, "valueReference", &output->valueReference);
 

--- a/src/fmi4c_utils.h
+++ b/src/fmi4c_utils.h
@@ -6,16 +6,16 @@
 #include "ezxml/ezxml.h"
 #include "fmi4c_private.h"
 
-void rememberPointer(fmiHandle *fmu, void* ptr);
-void* mallocAndRememberPointer(fmiHandle *fmu, size_t size);
-void* reallocAndRememberPointer(fmiHandle *fmu, void* org, size_t size);
-char* duplicateAndRememberString(fmiHandle *fmu, const char* str);
+void rememberPointer(fmuHandle *fmu, void* ptr);
+void* mallocAndRememberPointer(fmuHandle *fmu, size_t size);
+void* reallocAndRememberPointer(fmuHandle *fmu, void* org, size_t size);
+char* duplicateAndRememberString(fmuHandle *fmu, const char* str);
 
 const char* getFunctionName(const char* modelName, const char* functionName, char* concatBuffer);
 
 int removeDirectoryRecursively(const char* rootDirPath, const char* expectedDirNamePrefix);
 
-bool parseStringAttributeEzXmlAndRememberPointer(ezxml_t element, const char* attributeName, const char** target, fmiHandle *fmu);
+bool parseStringAttributeEzXmlAndRememberPointer(ezxml_t element, const char* attributeName, const char** target, fmuHandle *fmu);
 bool parseStringAttributeEzXml(ezxml_t element, const char* attributeName, const char** target);
 bool parseBooleanAttributeEzXml(ezxml_t element, const char* attributeName, bool* target);
 bool parseFloat64AttributeEzXml(ezxml_t element, const char* attributeName, double* target);
@@ -29,8 +29,8 @@ bool parseUInt32AttributeEzXml(ezxml_t element, const char* attributeName, uint3
 bool parseUInt16AttributeEzXml(ezxml_t element, const char *attributeName, uint16_t* target);
 bool parseUInt8AttributeEzXml(ezxml_t element, const char *attributeName, uint8_t *target);
 
-bool parseModelStructureElementFmi2(fmiHandle *fmu, fmi2ModelStructureHandle *output, ezxml_t *element);
-bool parseModelStructureElementFmi3(fmiHandle *fmu, fmi3ModelStructureHandle *output, ezxml_t *element);
+bool parseModelStructureElementFmi2(fmuHandle *fmu, fmi2ModelStructureHandle *output, ezxml_t *element);
+bool parseModelStructureElementFmi3(fmuHandle *fmu, fmi3ModelStructureHandle *output, ezxml_t *element);
 
 
 #endif // FMIC_UTILS_H

--- a/test/fmi4c_test.c
+++ b/test/fmi4c_test.c
@@ -235,7 +235,7 @@ int main(int argc, char *argv[])
     }
 
     fmi4c_setMessageFunction(&messageCallback);
-    fmiHandle *fmu = fmi4c_loadFmu(fmuPath, "testfmu");
+    fmuHandle *fmu = fmi4c_loadFmu(fmuPath, "testfmu");
 
     if(fmu == NULL) {
         printf("Failed to load FMU\n");
@@ -294,7 +294,7 @@ int main(int argc, char *argv[])
         }
 
         //Load second FMU
-        fmiHandle *fmu2 = fmi4c_loadFmu(fmuPath2, "testfmu2");
+        fmuHandle *fmu2 = fmi4c_loadFmu(fmuPath2, "testfmu2");
 
         if(fmu2 == NULL) {
             printf("Failed to load second FMU\n");

--- a/test/fmi4c_test_fmi1.c
+++ b/test/fmi4c_test_fmi1.c
@@ -34,7 +34,7 @@ void loggerFmi1(fmi1Component_t component,
     va_end(args);
 }
 
-int testFMI1ME(fmiHandle *fmu, bool overrideStopTime, double stopTimeOverride, bool overrideTimeStep, double timeStepOverride) {
+int testFMI1ME(fmuHandle *fmu, bool overrideStopTime, double stopTimeOverride, bool overrideTimeStep, double timeStepOverride) {
     //Instantiate FMU
     if(!fmi1_instantiateModel(fmu, loggerFmi1, calloc, free, fmi1True)) {
         printf("  fmi2Instantiate() failed\n");
@@ -245,7 +245,7 @@ int testFMI1ME(fmiHandle *fmu, bool overrideStopTime, double stopTimeOverride, b
 }
 
 
-int testfmi1_cS(fmiHandle *fmu, bool overrideStopTime, double stopTimeOverride, bool overrideTimeStep, double timeStepOverride)
+int testfmi1_cS(fmuHandle *fmu, bool overrideStopTime, double stopTimeOverride, bool overrideTimeStep, double timeStepOverride)
 {
     //Instantiate FMU
     if(!fmi1_instantiateSlave(fmu, "application/x-fmu-sharedlibrary", 1000, fmi1False, fmi1False, loggerFmi1, calloc, free, NULL, fmi1True)) {
@@ -340,7 +340,7 @@ int testfmi1_cS(fmiHandle *fmu, bool overrideStopTime, double stopTimeOverride, 
 }
 
 
-int testFMI1(fmiHandle *fmu, bool forceModelExchange, bool forceCosimulation, bool overrideStopTime, double stopTimeOverride, bool overrideTimeStep, double timeStepOverride)
+int testFMI1(fmuHandle *fmu, bool forceModelExchange, bool forceCosimulation, bool overrideStopTime, double stopTimeOverride, bool overrideTimeStep, double timeStepOverride)
 {
     //Loop through variables in FMU
     for(size_t i=0; i<fmi1_getNumberOfVariables(fmu); ++i)

--- a/test/fmi4c_test_fmi1.c
+++ b/test/fmi4c_test_fmi1.c
@@ -5,7 +5,7 @@
 #include "fmi4c_test.h"
 #include "fmi4c_test_fmi1.h"
 
-void loggerFmi1(fmi1Component_t component,
+void loggerFmi1(fmi1Component *component,
                 fmi1String instanceName,
                 fmi1Status status,
                 fmi1String category,

--- a/test/fmi4c_test_fmi1.h
+++ b/test/fmi4c_test_fmi1.h
@@ -11,6 +11,6 @@ void loggerFmi1(fmi1Component_t component,
                 fmi1String message,
                 ...);
 
-int testFMI1(fmiHandle *fmu, bool forceModelExchange, bool forceCosimulation, bool overrideStopTime, double stopTimeOverride, bool overrideTimeStep, double timeStepOverride);
+int testFMI1(fmuHandle *fmu, bool forceModelExchange, bool forceCosimulation, bool overrideStopTime, double stopTimeOverride, bool overrideTimeStep, double timeStepOverride);
 
 #endif //FMIC_TEST_FMI1_H

--- a/test/fmi4c_test_fmi1.h
+++ b/test/fmi4c_test_fmi1.h
@@ -4,7 +4,7 @@
 #include "fmi4c_types_fmi1.h"
 #include <stdbool.h>
 
-void loggerFmi1(fmi1Component_t component,
+void loggerFmi1(fmi1Component *component,
                 fmi1String instanceName,
                 fmi1Status status,
                 fmi1String category,

--- a/test/fmi4c_test_fmi2.h
+++ b/test/fmi4c_test_fmi2.h
@@ -11,6 +11,6 @@ void loggerFmi2(fmi2ComponentEnvironment componentEnvironment,
                 fmi2String message,
                 ...);
 
-int testFMI2(fmiHandle *fmu, bool forceModelExchange, bool forceCosimulation, bool overrideStopTime, double stopTimeOverride, bool overrideTimeStep, double timeStepOverride);
+int testFMI2(fmuHandle *fmu, bool forceModelExchange, bool forceCosimulation, bool overrideStopTime, double stopTimeOverride, bool overrideTimeStep, double timeStepOverride);
 
 #endif //FMIC_TEST_FMI2_H

--- a/test/fmi4c_test_fmi3.c
+++ b/test/fmi4c_test_fmi3.c
@@ -45,7 +45,7 @@ void intermediateUpdate(
         double value;
         fprintf(outputFile,"%f",intermediateUpdateTime);
         for(int i=0; i<numOutputs; ++i) {
-            fmi3_getFloat64((fmiHandle *)instanceEnvironment, &outputRefs[i], 1, &value, 1);
+            fmi3_getFloat64((fmuHandle *)instanceEnvironment, &outputRefs[i], 1, &value, 1);
             fprintf(outputFile,",%f",value);
         }
         fprintf(outputFile,"\n");
@@ -53,7 +53,7 @@ void intermediateUpdate(
 }
 
 
-int testFMI3CS(fmiHandle *fmu, bool overrideStopTime, double stopTimeOverride, bool overrideTimeStep, double timeStepOverride)
+int testFMI3CS(fmuHandle *fmu, bool overrideStopTime, double stopTimeOverride, bool overrideTimeStep, double timeStepOverride)
 {
     fmi3Status status;
 
@@ -158,7 +158,7 @@ int testFMI3CS(fmiHandle *fmu, bool overrideStopTime, double stopTimeOverride, b
 }
 
 
-int testFMI3ME(fmiHandle *fmu, bool overrideStopTime, double stopTimeOverride, bool overrideTimeStep, double timeStepOverride) {
+int testFMI3ME(fmuHandle *fmu, bool overrideStopTime, double stopTimeOverride, bool overrideTimeStep, double timeStepOverride) {
     //Instantiate FMU
     if(!fmi3_instantiateModelExchange(fmu, fmi2False, fmi2True, NULL, loggerFmi3)) {
         printf("  fmi2Instantiate() failed\n");
@@ -387,7 +387,7 @@ int testFMI3ME(fmiHandle *fmu, bool overrideStopTime, double stopTimeOverride, b
 }
 
 
-int testFMI3(fmiHandle *fmu, bool forceModelExchange, bool forceCosimulation, bool overrideStopTime, double stopTimeOverride, bool overrideTimeStep, double timeStepOverride)
+int testFMI3(fmuHandle *fmu, bool forceModelExchange, bool forceCosimulation, bool overrideStopTime, double stopTimeOverride, bool overrideTimeStep, double timeStepOverride)
 {
     //Loop through variables in FMU
     for(size_t i=0; i<fmi3_getNumberOfVariables(fmu); ++i)

--- a/test/fmi4c_test_fmi3.c
+++ b/test/fmi4c_test_fmi3.c
@@ -45,7 +45,7 @@ void intermediateUpdate(
         double value;
         fprintf(outputFile,"%f",intermediateUpdateTime);
         for(int i=0; i<numOutputs; ++i) {
-            fmi3_getFloat64((fmuHandle *)instanceEnvironment, &outputRefs[i], 1, &value, 1);
+            fmi3_getFloat64((fmi3InstanceHandle *)instanceEnvironment, &outputRefs[i], 1, &value, 1);
             fprintf(outputFile,",%f",value);
         }
         fprintf(outputFile,"\n");

--- a/test/fmi4c_test_fmi3.c
+++ b/test/fmi4c_test_fmi3.c
@@ -58,7 +58,9 @@ int testFMI3CS(fmuHandle *fmu, bool overrideStopTime, double stopTimeOverride, b
     fmi3Status status;
 
     int nRequiredIntermediateVariables = 0;
-    if(!fmi3_instantiateCoSimulation(fmu, fmi3False, fmi3True, fmi3False, fmi3False, NULL, nRequiredIntermediateVariables, fmu, loggerFmi3, intermediateUpdate)) {
+    fmi3InstanceHandle *instance = fmi3_instantiateCoSimulation(fmu, fmi3False, fmi3True, fmi3False, fmi3False, NULL, nRequiredIntermediateVariables, fmu, loggerFmi3, intermediateUpdate);
+
+    if(instance == NULL) {
         printf("fmi3InstantiateCoSimulation() failed\n");
         exit(1);
     }
@@ -86,14 +88,14 @@ int testFMI3CS(fmuHandle *fmu, bool overrideStopTime, double stopTimeOverride, b
 
     //Enter initialization mode
     double tstop = 10;
-    status = fmi3_enterInitializationMode(fmu, fmi3False, 0, startTime, fmi3True, tstop);
+    status = fmi3_enterInitializationMode(instance, fmi3False, 0, startTime, fmi3True, tstop);
     if(status != fmi3OK) {
         printf("  fmi3EnterInitializationMode() failed\n");
         exit(1);
     }
 
     //Exit initialization mode
-    status = fmi3_exitInitializationMode(fmu);
+    status = fmi3_exitInitializationMode(instance);
     if(status != fmi3OK) {
         printf("  fmi3ExitInitializationMode() failed\n");
         exit(1);
@@ -118,13 +120,13 @@ int testFMI3CS(fmuHandle *fmu, bool overrideStopTime, double stopTimeOverride, b
             fmi3VariableHandle *var = fmi3_getVariableByName(fmu, interpolationData[i].name);
             fmi3Float64 value = interpolate(&interpolationData[0], &interpolationData[i], time, dataSize);
             fmi3ValueReference vr = fmi3_getVariableValueReference(var);
-            fmi3_setFloat64(fmu, &vr, 1, &value, 1);
+            fmi3_setFloat64(instance, &vr, 1, &value, 1);
         }
 
         //Take a step
         bool eventEncountered, terminateSimulation, earlyReturn;
         double lastT;
-        status = fmi3_doStep(fmu,  time, stepSize, fmi3True, &eventEncountered, &terminateSimulation, &earlyReturn, &lastT);
+        status = fmi3_doStep(instance,  time, stepSize, fmi3True, &eventEncountered, &terminateSimulation, &earlyReturn, &lastT);
         if(status != fmi3OK) {
             printf("fmi3DoStep failed\n");
             exit(1);
@@ -135,7 +137,7 @@ int testFMI3CS(fmuHandle *fmu, bool overrideStopTime, double stopTimeOverride, b
         if(outputFile != NULL) {
             fprintf(outputFile,"%f",time);
             for(int i=0; i<numOutputs; ++i) {
-                fmi3_getFloat64(fmu, &outputRefs[i], 1, &value, 1);
+                fmi3_getFloat64(instance, &outputRefs[i], 1, &value, 1);
                 fprintf(outputFile,",%f",value);
             }
             fprintf(outputFile,"\n");
@@ -148,11 +150,11 @@ int testFMI3CS(fmuHandle *fmu, bool overrideStopTime, double stopTimeOverride, b
 
     printf("  Simulation finished.\n");
 
-    fmi3_terminate(fmu);
+    fmi3_terminate(instance);
 
     printf("  FMU successfully terminated.\n");
 
-    fmi3_freeInstance(fmu);
+    fmi3_freeInstance(instance);
 
     return 0;
 }
@@ -160,7 +162,8 @@ int testFMI3CS(fmuHandle *fmu, bool overrideStopTime, double stopTimeOverride, b
 
 int testFMI3ME(fmuHandle *fmu, bool overrideStopTime, double stopTimeOverride, bool overrideTimeStep, double timeStepOverride) {
     //Instantiate FMU
-    if(!fmi3_instantiateModelExchange(fmu, fmi2False, fmi2True, NULL, loggerFmi3)) {
+    fmi3InstanceHandle *instance = fmi3_instantiateModelExchange(fmu, fmi2False, fmi2True, NULL, loggerFmi3);
+    if(instance == NULL) {
         printf("  fmi2Instantiate() failed\n");
         exit(1);
     }
@@ -193,7 +196,7 @@ int testFMI3ME(fmuHandle *fmu, bool overrideStopTime, double stopTimeOverride, b
     fmi3Status status;
 
     //Enter initialization mode
-    status = fmi3_enterInitializationMode(fmu,
+    status = fmi3_enterInitializationMode(instance,
                                          fmi3_defaultToleranceDefined(fmu), tolerance,
                                          startTime,
                                          fmi3_defaultStopTimeDefined(fmu), stopTime);
@@ -203,7 +206,7 @@ int testFMI3ME(fmuHandle *fmu, bool overrideStopTime, double stopTimeOverride, b
     }
 
     //Exit initialization mode
-    status = fmi3_exitInitializationMode(fmu);
+    status = fmi3_exitInitializationMode(instance);
     if(status != fmi3OK) {
         printf("  fmi3ExitInitializationMode() failed\n");
         exit(1);
@@ -228,12 +231,12 @@ int testFMI3ME(fmuHandle *fmu, bool overrideStopTime, double stopTimeOverride, b
     fmi3Boolean stepEvent = fmi3False;
     fmi3Int32* rootsFound;
 
-    status = fmi3_getNumberOfContinuousStates(fmu, &nStates);
+    status = fmi3_getNumberOfContinuousStates(instance, &nStates);
     if(status != fmi3OK) {
         printf("  fmi3GetNumberOfContinuousStates() failed\n");
         exit(1);
     }
-    status = fmi3_getNumberOfEventIndicators(fmu, &nEventIndicators);
+    status = fmi3_getNumberOfEventIndicators(instance, &nEventIndicators);
     if(status != fmi3OK) {
         printf("  fmi3GetNumberOfEventIndicators() failed\n");
         exit(1);
@@ -252,7 +255,7 @@ int testFMI3ME(fmuHandle *fmu, bool overrideStopTime, double stopTimeOverride, b
     }
 
     while (discreteStatesNeedUpdate) {
-        fmi3_updateDiscreteStates(fmu,
+        fmi3_updateDiscreteStates(instance,
                                  &discreteStatesNeedUpdate,
                                  &terminateSimulation,
                                  &nominalsOfContinuousStatesChanged,
@@ -265,19 +268,19 @@ int testFMI3ME(fmuHandle *fmu, bool overrideStopTime, double stopTimeOverride, b
         }
     }
 
-    fmi3_enterContinuousTimeMode(fmu);
+    fmi3_enterContinuousTimeMode(instance);
 
-    status = fmi3_getContinuousStates(fmu, states, nStates);
+    status = fmi3_getContinuousStates(instance, states, nStates);
     if(status != fmi3OK) {
         printf("  fmi3GetContinuousStates() failed\n");
         exit(1);
     }
-    status = fmi3_getNominalsOfContinuousStates(fmu, nominalStates, nStates);
+    status = fmi3_getNominalsOfContinuousStates(instance, nominalStates, nStates);
     if(status != fmi3OK) {
         printf("  fmi3GetNominalsOfContinuousStates() failed\n");
         exit(1);
     }
-    status = fmi3_getEventIndicators(fmu, eventIndicators, nEventIndicators);
+    status = fmi3_getEventIndicators(instance, eventIndicators, nEventIndicators);
     if(status != fmi3OK) {
         printf("  fmi3GetEventIndicators() failed\n");
         exit(1);
@@ -303,9 +306,9 @@ int testFMI3ME(fmuHandle *fmu, bool overrideStopTime, double stopTimeOverride, b
             break;
         }
 
-        fmi3_getContinuousStateDerivatives(fmu, derivatives, nStates);
+        fmi3_getContinuousStateDerivatives(instance, derivatives, nStates);
 
-        fmi3_setTime(fmu, time);
+        fmi3_setTime(instance, time);
 
         //Interpolate inputs from CSV file
         for(int i=1; i<nInterpolators; ++i) {
@@ -322,7 +325,7 @@ int testFMI3ME(fmuHandle *fmu, bool overrideStopTime, double stopTimeOverride, b
             }
             fmi3Float64 value = interpolate(&interpolationData[0], &interpolationData[i], time, dataSize);
             fmi3ValueReference vr = fmi3_getVariableValueReference(var);
-            fmi3_setFloat64(fmu, &vr, 1, &value, 1);
+            fmi3_setFloat64(instance, &vr, 1, &value, 1);
         }
 
         //Integrate one step
@@ -330,10 +333,10 @@ int testFMI3ME(fmuHandle *fmu, bool overrideStopTime, double stopTimeOverride, b
             states[i] += stepSize*derivatives[i]; // forward Euler method
         }
 
-        fmi3_setContinuousStates(fmu, states, nStates);
+        fmi3_setContinuousStates(instance, states, nStates);
 
         // get event indicators at t = time
-        fmi3_getEventIndicators(fmu, eventIndicators, nEventIndicators);
+        fmi3_getEventIndicators(instance, eventIndicators, nEventIndicators);
 
         stateEvent = fmi3False;
 
@@ -359,13 +362,13 @@ int testFMI3ME(fmuHandle *fmu, bool overrideStopTime, double stopTimeOverride, b
         if(outputFile != NULL) {
             fprintf(outputFile,"%f",time);
             for(int i=0; i<numOutputs; ++i) {
-                fmi3_getFloat64(fmu, &outputRefs[i], 1, &value, 1 );
+                fmi3_getFloat64(instance, &outputRefs[i], 1, &value, 1 );
                 fprintf(outputFile,",%f",value);
             }
             fprintf(outputFile,"\n");
         }
 
-        fmi3_completedIntegratorStep(fmu, fmi3True, &stepEvent, &terminateSimulation);
+        fmi3_completedIntegratorStep(instance, fmi3True, &stepEvent, &terminateSimulation);
 
         time+=stepSize;
     }
@@ -377,11 +380,11 @@ int testFMI3ME(fmuHandle *fmu, bool overrideStopTime, double stopTimeOverride, b
     free(eventIndicators);
     printf("  Simulation finished.\n");
 
-    fmi3_terminate(fmu);
+    fmi3_terminate(instance);
 
     printf("  FMU successfully terminated.\n");
 
-    fmi3_freeInstance(fmu);
+    fmi3_freeInstance(instance);
 
     return 0;
 }

--- a/test/fmi4c_test_fmi3.h
+++ b/test/fmi4c_test_fmi3.h
@@ -8,6 +8,6 @@ void loggerFmi3(fmi3InstanceEnvironment instanceEnvironment,
                 fmi3String category,
                 fmi3String message);
 
-int testFMI3(fmiHandle *fmu, bool forceModelExchange, bool forceCosimulation, bool overrideStopTime, double stopTimeOverride, bool overrideTimeStep, double timeStepOverride);
+int testFMI3(fmuHandle *fmu, bool forceModelExchange, bool forceCosimulation, bool overrideStopTime, double stopTimeOverride, bool overrideTimeStep, double timeStepOverride);
 
 #endif //FMIC_TEST_FMI3_H

--- a/test/fmi4c_test_tlm.c
+++ b/test/fmi4c_test_tlm.c
@@ -21,12 +21,12 @@ pthread_mutex_t mutex1 = PTHREAD_MUTEX_INITIALIZER;
 pthread_mutex_t mutex2 = PTHREAD_MUTEX_INITIALIZER;
 
 typedef struct {
-    fmiHandle *fmu1;
+    fmuHandle *fmu1;
     double table1[2][TABLE_SIZE];
     size_t table1start;
     size_t table1end;
 
-    fmiHandle *fmu2;
+    fmuHandle *fmu2;
     double table2[2][TABLE_SIZE];
     size_t table2start;
     size_t table2end;
@@ -121,7 +121,7 @@ void intermediateUpdateTLM(
     fmi3ValueReference vr_v = 0;    //Connection velocity (output)
     fmi3ValueReference vr_f = 1;    //Connection force (input)
 
-    fmiHandle *fmu = (fmiHandle*)instanceEnvironment;
+    fmuHandle *fmu = (fmuHandle*)instanceEnvironment;
     if(intermediateVariableGetAllowed) {
         double v;
         fmi3_getFloat64(fmu, &vr_v, 1, &v, 1);
@@ -176,7 +176,7 @@ void intermediateUpdateTLM(
 
 //Argument struct for doStep thread
 struct doStepArgs {
-    fmiHandle *fmu;
+    fmuHandle *fmu;
     fmi3Float64 tcur;
     fmi3Float64 tstep;
 };
@@ -193,7 +193,7 @@ void* doStepInThread(void* argsptr)
 }
 
 
-int testFMI3TLM(fmiHandle *fmua, fmiHandle *fmub, bool overrideStopTime, double stopTimeOverride, bool overrideTimeStep, double timeStepOverride)
+int testFMI3TLM(fmuHandle *fmua, fmuHandle *fmub, bool overrideStopTime, double stopTimeOverride, bool overrideTimeStep, double timeStepOverride)
 {
     //TLM coupling parameters
     fmi3Float64 mtlm = 1;       //Distributed inertia [kg]

--- a/test/fmi4c_test_tlm.h
+++ b/test/fmi4c_test_tlm.h
@@ -3,6 +3,6 @@
 
 #include "fmi4c.h"
 
-int testFMI3TLM(fmiHandle *fmua, fmiHandle *fmub, bool overrideStopTime, double stopTimeOverride, bool overrideTimeStep, double timeStepOverride);
+int testFMI3TLM(fmuHandle *fmua, fmuHandle *fmub, bool overrideStopTime, double stopTimeOverride, bool overrideTimeStep, double timeStepOverride);
 
 #endif //FMIC_TEST_TLM_H

--- a/test/pytest.py
+++ b/test/pytest.py
@@ -209,31 +209,32 @@ verify("typesPlatform", typesPlatform)
 version = f.fmi1_getVersion()
 verify("version", version)
 
-instantiateSuccess = f.fmi1_instantiateSlave(b"application/x-fmu-sharedlibrary", 1.0, False, False, False)
-verify("instantiateSuccess", instantiateSuccess)
+instance = 0   
+instance = instantiateSuccess = f.fmi1_instantiateSlave(b"application/x-fmu-sharedlibrary", 1.0, False, False, False)
+verify("instantiateSuccess", instance != 0)
 
-setDebugLoggingSuccess = f.fmi1_setDebugLogging(True)
+setDebugLoggingSuccess = f.fmi1_setDebugLogging(instance, True)
 verify("setDebugLoggingSuccess", setDebugLoggingSuccess) 
 
-initializeSuccess = f.fmi1_initializeSlave(0, True, 1)
+initializeSuccess = f.fmi1_initializeSlave(instance, 0, True, 1)
 verify("initializeSuccess", initializeSuccess)
     
-setRealSuccess = f.fmi1_setReal([1], 1, [5])
+setRealSuccess = f.fmi1_setReal(instance, [1], 1, [5])
 verify("setRealSuccess", setRealSuccess)
 
-doStepSuccess = f.fmi1_doStep(0,0.1,True)
+doStepSuccess = f.fmi1_doStep(instance, 0,0.1,True)
 verify("doStepSuccess", doStepSuccess)
 
-getRealResults = f.fmi1_getReal([1, 2],2)
+getRealResults = f.fmi1_getReal(instance, [1, 2],2)
 verify("getRealResults", getRealResults)
     
-terminateSuccess = f.fmi1_terminateSlave()
+terminateSuccess = f.fmi1_terminateSlave(instance)
 verify("terminateSuccess", terminateSuccess)
 
-resetSuccess = f.fmi1_resetSlave()
+resetSuccess = f.fmi1_resetSlave(instance)
 verify("resetSuccess", resetSuccess)
 
-f.fmi1_freeSlaveInstance()
+f.fmi1_freeSlaveInstance(instance)
 
 f.fmi4c_freeFmu()
 
@@ -442,42 +443,43 @@ verify("typesPlatform", typesPlatform)
 version = f.fmi1_getVersion()
 verify("version", version)
 
-instantiateSuccess = f.fmi1_instantiateModel(False)
-verify("instantiateSuccess", instantiateSuccess)
+instance = 0
+instance = f.fmi1_instantiateModel(False)
+verify("instantiateSuccess", instance != 0)
 
-setDebugLoggingSuccess = f.fmi1_setDebugLogging(False)
+setDebugLoggingSuccess = f.fmi1_setDebugLogging(instance, False)
 verify("setDebugLoggingSuccess", setDebugLoggingSuccess) 
 
-initializeSuccess = f.fmi1_initialize(False, 0, ct.pointer(eventInfo))
+initializeSuccess = f.fmi1_initialize(instance, False, 0, ct.pointer(eventInfo))
 verify("initializeSuccess", initializeSuccess)
 
 #
 
-setTimeSuccess = f.fmi1_setTime(0.5)
+setTimeSuccess = f.fmi1_setTime(instance, 0.5)
 verify("setTimeSuccess", setTimeSuccess)
 
-getDerivativesSuccess = f.fmi1_getDerivatives(1)
+getDerivativesSuccess = f.fmi1_getDerivatives(instance, 1)
 verify("getDerivativesSuccess", getDerivativesSuccess)
 
-getStateValueReferencesSuccess = f.fmi1_getStateValueReferences(1)
+getStateValueReferencesSuccess = f.fmi1_getStateValueReferences(instance, 1)
 verify("getStateValueReferencesSuccess", getStateValueReferencesSuccess)
 
-getNominalContinuousStatesSuccess = f.fmi1_getNominalContinuousStates(1)
+getNominalContinuousStatesSuccess = f.fmi1_getNominalContinuousStates(instance, 1)
 verify("getNominalContinuousStatesSuccess", getNominalContinuousStatesSuccess)
 
-setContinuousStatesSuccess = f.fmi1_setContinuousStates([42], 1)
+setContinuousStatesSuccess = f.fmi1_setContinuousStates(instance, [42], 1)
 verify("setContinuousStatesSuccess", setContinuousStatesSuccess)
 
-getContinuousStatesSuccess = f.fmi1_getContinuousStates(1)
+getContinuousStatesSuccess = f.fmi1_getContinuousStates(instance, 1)
 verify("getContinuousStatesSuccess", getContinuousStatesSuccess)
 
-completedIntegratorStepSuccess = f.fmi1_completedIntegratorStep(False)
+completedIntegratorStepSuccess = f.fmi1_completedIntegratorStep(instance, False)
 verify("completedIntegratorStepSuccess", completedIntegratorStepSuccess)
 
-terminateSuccess = f.fmi1_terminate()
+terminateSuccess = f.fmi1_terminate(instance)
 verify("terminateSuccess", terminateSuccess)
 
-f.fmi1_freeModelInstance()
+f.fmi1_freeModelInstance(instance)
 
 f.fmi4c_freeFmu()
      

--- a/test/pytest.py
+++ b/test/pytest.py
@@ -858,37 +858,38 @@ verify("getRealResults", f.fmi2_getReal(comp, [1, 2],2))
 
 verify("resetSuccess", f.fmi2_reset(comp))
 
-comp = 0
-comp = f.fmi2_instantiate(0, False, False)    #1 = model exchange
-verify("instantiateSuccess", comp != 0)
+comp2 = 0
+comp2 = f.fmi2_instantiate(0, False, False)    #1 = model exchange
+verify("instantiateSuccess", comp2 != 0)
 
-verify("enterInitializationModeSuccess", f.fmi2_enterInitializationMode(comp))
-verify("exitInitializationModeSuccess", f.fmi2_exitInitializationMode(comp))
+verify("enterInitializationModeSuccess", f.fmi2_enterInitializationMode(comp2))
+verify("exitInitializationModeSuccess", f.fmi2_exitInitializationMode(comp2))
 
-setTimeSuccess = f.fmi2_setTime(comp, 0.5)
+setTimeSuccess = f.fmi2_setTime(comp2, 0.5)
 verify("setTimeSuccess", setTimeSuccess)
 
-getDerivativesSuccess = f.fmi2_getDerivatives(comp, 1)
+getDerivativesSuccess = f.fmi2_getDerivatives(comp2, 1)
 verify("getDerivativesSuccess", getDerivativesSuccess)
 
 #getStateValueReferencesSuccess = f.fmi2_getStateValueReferences(1)
 #verify("getStateValueReferencesSuccess", getStateValueReferencesSuccess)
 
-getNominalsOfContinuousStatesSuccess = f.fmi2_getNominalsOfContinuousStates(comp, 1)
+getNominalsOfContinuousStatesSuccess = f.fmi2_getNominalsOfContinuousStates(comp2, 1)
 verify("getNominalsOfContinuousStatesSuccess", getNominalsOfContinuousStatesSuccess)
 
-setContinuousStatesSuccess = f.fmi2_setContinuousStates(comp, [42], 1)
+setContinuousStatesSuccess = f.fmi2_setContinuousStates(comp2, [42], 1)
 verify("setContinuousStatesSuccess", setContinuousStatesSuccess)
 
-getContinuousStatesSuccess = f.fmi2_getContinuousStates(comp, 1)
+getContinuousStatesSuccess = f.fmi2_getContinuousStates(comp2, 1)
 verify("getContinuousStatesSuccess", getContinuousStatesSuccess)
 
-completedIntegratorStepSuccess = f.fmi2_completedIntegratorStep(comp, False)
+completedIntegratorStepSuccess = f.fmi2_completedIntegratorStep(comp2, False)
 verify("completedIntegratorStepSuccess", completedIntegratorStepSuccess)
 
-terminateSuccess = f.fmi2_terminate(comp)
+terminateSuccess = f.fmi2_terminate(comp2)
 verify("terminateSuccess", terminateSuccess)
 
+f.fmi2_freeInstance(comp2)
 f.fmi2_freeInstance(comp)
 
 f.fmi4c_freeFmu()

--- a/test/pytest.py
+++ b/test/pytest.py
@@ -63,7 +63,7 @@ def verify(name, value):
     print(name+": "+str(value)+" -", end=" ")
     if value != verificationDict[name]:
         print("ERROR! Expected: "+str(verificationDict[name]))
-        print(f.fmi4c_getErrorMessages())
+        #print(f.fmi4c_getErrorMessages())
         exit(1)
     print("ok!")
 
@@ -75,7 +75,7 @@ import os
 success = f.fmi4c_loadFmu(os.path.dirname(os.path.abspath(__file__))+"/fmi1cs.fmu", "testfmu")
 if not success:
     print("Failed to load fmi1cs.fmu")
-    print(f.fmi4c_getErrorMessages())
+    #print(f.fmi4c_getErrorMessages())
     exit(1)
 else:
     print("Successfully loaded fmi1cs.fmu")
@@ -307,7 +307,7 @@ verificationDict =	{
 success = f.fmi4c_loadFmu(os.path.dirname(os.path.abspath(__file__))+"/fmi1me.fmu", "testfmu")
 if not success:
     print("Failed to load fmi1me.fmu")
-    print(f.fmi4c_getErrorMessages())
+    #print(f.fmi4c_getErrorMessages())
     exit(1)
 else:
     print("Successfully loaded fmi1me.fmu")
@@ -585,7 +585,7 @@ verificationDict =	{
 success = f.fmi4c_loadFmu(os.path.dirname(os.path.abspath(__file__))+"/fmi2.fmu", "testfmu")
 if not success:
     print("Failed to load fmi2.fmu")
-    print(f.fmi4c_getErrorMessages())
+    #print(f.fmi4c_getErrorMessages())
     exit(1)
 else:
     print("Successfully loaded fmi2.fmu")
@@ -832,8 +832,9 @@ verify("modelStructureDependencies", modelStructureDependencies)
 verify("modelStructureDependencyKindsDefined", modelStructureDependencyKindsDefined)
 verify("modelStructureDependencyKinds", modelStructureDependencyKinds)
    
-instantiateSuccess = f.fmi2_instantiate(1, False, False)    # 1 = co-simulation
-verify("instantiateSuccess", instantiateSuccess)
+comp = 0   
+comp = f.fmi2_instantiate(1, False, False)    # 1 = co-simulation
+verify("instantiateSuccess", comp != 0)
 
 typesPlatform = f.fmi2_getTypesPlatform()
 verify("typesPlatform", typesPlatform)
@@ -841,53 +842,54 @@ verify("typesPlatform", typesPlatform)
 version = f.fmi2_getVersion()
 verify("version", version)
 
-setDebugLoggingSuccess = f.fmi2_setDebugLogging(False, 0, None)
+setDebugLoggingSuccess = f.fmi2_setDebugLogging(comp, False, 0, None)
 verify("setDebugLoggingSuccess", setDebugLoggingSuccess) 
 
-verify("setupExperimentSuccess", f.fmi2_setupExperiment(True, 1e-5, 0, True, 2))
+verify("setupExperimentSuccess", f.fmi2_setupExperiment(comp, True, 1e-5, 0, True, 2))
 
-verify("enterInitializationModeSuccess", f.fmi2_enterInitializationMode())
-verify("exitInitializationModeSuccess", f.fmi2_exitInitializationMode())
+verify("enterInitializationModeSuccess", f.fmi2_enterInitializationMode(comp))
+verify("exitInitializationModeSuccess", f.fmi2_exitInitializationMode(comp))
 
-verify("setRealSuccess", f.fmi2_setReal([1], 1, [5]))
+verify("setRealSuccess", f.fmi2_setReal(comp, [1], 1, [5]))
 
-verify("doStepSuccess", f.fmi2_doStep(0,0.1,True))
+verify("doStepSuccess", f.fmi2_doStep(comp, 0,0.1,True))
 
-verify("getRealResults", f.fmi2_getReal([1, 2],2))
+verify("getRealResults", f.fmi2_getReal(comp, [1, 2],2))
 
-verify("resetSuccess", f.fmi2_reset())
+verify("resetSuccess", f.fmi2_reset(comp))
 
-instantiateSuccess = f.fmi2_instantiate(0, False, False)    #1 = model exchange
-verify("instantiateSuccess", instantiateSuccess)
+comp = 0
+comp = f.fmi2_instantiate(0, False, False)    #1 = model exchange
+verify("instantiateSuccess", comp != 0)
 
-verify("enterInitializationModeSuccess", f.fmi2_enterInitializationMode())
-verify("exitInitializationModeSuccess", f.fmi2_exitInitializationMode())
+verify("enterInitializationModeSuccess", f.fmi2_enterInitializationMode(comp))
+verify("exitInitializationModeSuccess", f.fmi2_exitInitializationMode(comp))
 
-setTimeSuccess = f.fmi2_setTime(0.5)
+setTimeSuccess = f.fmi2_setTime(comp, 0.5)
 verify("setTimeSuccess", setTimeSuccess)
 
-getDerivativesSuccess = f.fmi2_getDerivatives(1)
+getDerivativesSuccess = f.fmi2_getDerivatives(comp, 1)
 verify("getDerivativesSuccess", getDerivativesSuccess)
 
 #getStateValueReferencesSuccess = f.fmi2_getStateValueReferences(1)
 #verify("getStateValueReferencesSuccess", getStateValueReferencesSuccess)
 
-getNominalsOfContinuousStatesSuccess = f.fmi2_getNominalsOfContinuousStates(1)
+getNominalsOfContinuousStatesSuccess = f.fmi2_getNominalsOfContinuousStates(comp, 1)
 verify("getNominalsOfContinuousStatesSuccess", getNominalsOfContinuousStatesSuccess)
 
-setContinuousStatesSuccess = f.fmi2_setContinuousStates([42], 1)
+setContinuousStatesSuccess = f.fmi2_setContinuousStates(comp, [42], 1)
 verify("setContinuousStatesSuccess", setContinuousStatesSuccess)
 
-getContinuousStatesSuccess = f.fmi2_getContinuousStates(1)
+getContinuousStatesSuccess = f.fmi2_getContinuousStates(comp, 1)
 verify("getContinuousStatesSuccess", getContinuousStatesSuccess)
 
-completedIntegratorStepSuccess = f.fmi2_completedIntegratorStep(False)
+completedIntegratorStepSuccess = f.fmi2_completedIntegratorStep(comp, False)
 verify("completedIntegratorStepSuccess", completedIntegratorStepSuccess)
 
-terminateSuccess = f.fmi2_terminate()
+terminateSuccess = f.fmi2_terminate(comp)
 verify("terminateSuccess", terminateSuccess)
 
-f.fmi2_freeInstance()
+f.fmi2_freeInstance(comp)
 
 f.fmi4c_freeFmu()
 
@@ -1032,7 +1034,7 @@ verificationDict =	{
 success = f.fmi4c_loadFmu(os.path.dirname(os.path.abspath(__file__))+"/fmi3.fmu", "testfmu")
 if not success:
     print("Failed to load fmi3.fmu")
-    print(f.fmi4c_getErrorMessages())
+    #print(f.fmi4c_getErrorMessages())
     exit(1)
 else:
     print("Successfully loaded fmi3.fmu")

--- a/test/pytest.py
+++ b/test/pytest.py
@@ -1295,34 +1295,38 @@ verify("providesAdjointDerivatives", f.fmi3se_getProvidesAdjointDerivatives())
 verify("providesPerElementDependencies", f.fmi3se_getProvidesPerElementDependencies())
 
 #Test co-simualtion
-verify("instantiateSuccess", f.fmi3_instantiateCoSimulation(False, False, False, False, [], 0))
+instance = 0
+instance = f.fmi3_instantiateCoSimulation(False, False, False, False, [], 0)
+verify("instantiateSuccess", instance != 0)
 verify("fmiVersionNumber", f.fmi3_getVersion())
 verify("version", f.fmi3_version())
-verify("setDebugLoggingSuccess", f.fmi3_setDebugLogging(True, 0, None))
-verify("enterInitializationModeSuccess", f.fmi3_enterInitializationMode(True, 1e-5, 0, True, 2))
-verify("exitInitializationModeSuccess", f.fmi3_exitInitializationMode())
-verify("setFloat64Success", f.fmi3_setFloat64([1], 1, [5], 1))
-verify("doStepResults", f.fmi3_doStep(0, 0.001, True))
-verify("getFloat64Results", f.fmi3_getFloat64([1, 2],2,2))
-verify("resetSuccess", f.fmi3_reset())
+verify("setDebugLoggingSuccess", f.fmi3_setDebugLogging(instance, True, 0, None))
+verify("enterInitializationModeSuccess", f.fmi3_enterInitializationMode(instance, True, 1e-5, 0, True, 2))
+verify("exitInitializationModeSuccess", f.fmi3_exitInitializationMode(instance))
+verify("setFloat64Success", f.fmi3_setFloat64(instance, [1], 1, [5], 1))
+verify("doStepResults", f.fmi3_doStep(instance, 0, 0.001, True))
+verify("getFloat64Results", f.fmi3_getFloat64(instance, [1, 2],2,2))
+verify("resetSuccess", f.fmi3_reset(instance))
 
 #Test model exchange
-verify("instantiateSuccess", f.fmi3_instantiateModelExchange(False, False))
-verify("setTimeSuccess", f.fmi3_setTime(0.5))
-verify("numberOfEventIndicators", f.fmi3_getNumberOfEventIndicators()[1])
-numberOfContinuousStates = f.fmi3_getNumberOfContinuousStates()[1]
+instance = 0
+instance = f.fmi3_instantiateModelExchange(False, False)
+verify("instantiateSuccess", instance != 0)
+verify("setTimeSuccess", f.fmi3_setTime(instance, 0.5))
+verify("numberOfEventIndicators", f.fmi3_getNumberOfEventIndicators(instance)[1])
+numberOfContinuousStates = f.fmi3_getNumberOfContinuousStates(instance)[1]
 verify("numberOfContinuousStates", numberOfContinuousStates)
-verify("getContinousStateDerivativesSuccess", f.fmi3_getContinuousStateDerivatives(numberOfContinuousStates))
-verify("getNominalsOfContinuousStatesSuccess", f.fmi3_getNominalsOfContinuousStates(numberOfContinuousStates))
-verify("setContinuousStatesSuccess", f.fmi3_setContinuousStates([42], numberOfContinuousStates))
-verify("getContinuousStatesSuccess", f.fmi3_getContinuousStates(numberOfContinuousStates))
-verify("completedIntegratorStepSuccess", f.fmi3_completedIntegratorStep(False))
-verify("enterStepModeSuccess", f.fmi3_enterStepMode())
-verify("enterContinuousTimeModeSuccess", f.fmi3_enterContinuousTimeMode())
+verify("getContinousStateDerivativesSuccess", f.fmi3_getContinuousStateDerivatives(instance, numberOfContinuousStates))
+verify("getNominalsOfContinuousStatesSuccess", f.fmi3_getNominalsOfContinuousStates(instance, numberOfContinuousStates))
+verify("setContinuousStatesSuccess", f.fmi3_setContinuousStates(instance, [42], numberOfContinuousStates))
+verify("getContinuousStatesSuccess", f.fmi3_getContinuousStates(instance, numberOfContinuousStates))
+verify("completedIntegratorStepSuccess", f.fmi3_completedIntegratorStep(instance, False))
+verify("enterStepModeSuccess", f.fmi3_enterStepMode(instance))
+verify("enterContinuousTimeModeSuccess", f.fmi3_enterContinuousTimeMode(instance))
 
-verify("terminateSuccess", f.fmi3_terminate())
+verify("terminateSuccess", f.fmi3_terminate(instance))
 
-f.fmi3_freeInstance()
+f.fmi3_freeInstance(instance)
 
 f.fmi4c_freeFmu()
 

--- a/test/pytest.py
+++ b/test/pytest.py
@@ -213,8 +213,17 @@ instance = 0
 instance = instantiateSuccess = f.fmi1_instantiateSlave(b"application/x-fmu-sharedlibrary", 1.0, False, False, False)
 verify("instantiateSuccess", instance != 0)
 
+instance2 = 0   
+instance2 = instantiateSuccess = f.fmi1_instantiateSlave(b"application/x-fmu-sharedlibrary", 1.0, False, False, False)
+verify("instantiateSuccess", instance2 != 0)
+
 setDebugLoggingSuccess = f.fmi1_setDebugLogging(instance, True)
 verify("setDebugLoggingSuccess", setDebugLoggingSuccess) 
+
+setDebugLoggingSuccess = f.fmi1_setDebugLogging(instance2, True)
+verify("setDebugLoggingSuccess", setDebugLoggingSuccess) 
+
+f.fmi1_freeSlaveInstance(instance2)
 
 initializeSuccess = f.fmi1_initializeSlave(instance, 0, True, 1)
 verify("initializeSuccess", initializeSuccess)
@@ -447,13 +456,20 @@ instance = 0
 instance = f.fmi1_instantiateModel(False)
 verify("instantiateSuccess", instance != 0)
 
+instance2 = 0
+instance2 = f.fmi1_instantiateModel(False)
+verify("instantiateSuccess", instance2 != 0)
+
 setDebugLoggingSuccess = f.fmi1_setDebugLogging(instance, False)
 verify("setDebugLoggingSuccess", setDebugLoggingSuccess) 
 
+setDebugLoggingSuccess = f.fmi1_setDebugLogging(instance2, False)
+verify("setDebugLoggingSuccess", setDebugLoggingSuccess) 
+
+f.fmi1_freeModelInstance(instance2)
+
 initializeSuccess = f.fmi1_initialize(instance, False, 0, ct.pointer(eventInfo))
 verify("initializeSuccess", initializeSuccess)
-
-#
 
 setTimeSuccess = f.fmi1_setTime(instance, 0.5)
 verify("setTimeSuccess", setTimeSuccess)
@@ -1296,23 +1312,32 @@ verify("providesPerElementDependencies", f.fmi3se_getProvidesPerElementDependenc
 
 #Test co-simualtion
 instance = 0
+instance2 = 0
 instance = f.fmi3_instantiateCoSimulation(False, False, False, False, [], 0)
+instance2 = f.fmi3_instantiateCoSimulation(False, False, False, False, [], 0)
 verify("instantiateSuccess", instance != 0)
+verify("instantiateSuccess", instance2 != 0)
 verify("fmiVersionNumber", f.fmi3_getVersion())
 verify("version", f.fmi3_version())
 verify("setDebugLoggingSuccess", f.fmi3_setDebugLogging(instance, True, 0, None))
+verify("setDebugLoggingSuccess", f.fmi3_setDebugLogging(instance2, True, 0, None))
 verify("enterInitializationModeSuccess", f.fmi3_enterInitializationMode(instance, True, 1e-5, 0, True, 2))
 verify("exitInitializationModeSuccess", f.fmi3_exitInitializationMode(instance))
 verify("setFloat64Success", f.fmi3_setFloat64(instance, [1], 1, [5], 1))
 verify("doStepResults", f.fmi3_doStep(instance, 0, 0.001, True))
 verify("getFloat64Results", f.fmi3_getFloat64(instance, [1, 2],2,2))
 verify("resetSuccess", f.fmi3_reset(instance))
+f.fmi3_freeInstance(instance2)
 
 #Test model exchange
 instance = 0
+instance2 = 0
 instance = f.fmi3_instantiateModelExchange(False, False)
+instance2 = f.fmi3_instantiateModelExchange(False, False)
 verify("instantiateSuccess", instance != 0)
+verify("instantiateSuccess", instance2 != 0)
 verify("setTimeSuccess", f.fmi3_setTime(instance, 0.5))
+verify("setTimeSuccess", f.fmi3_setTime(instance2, 1.5))
 verify("numberOfEventIndicators", f.fmi3_getNumberOfEventIndicators(instance)[1])
 numberOfContinuousStates = f.fmi3_getNumberOfContinuousStates(instance)[1]
 verify("numberOfContinuousStates", numberOfContinuousStates)
@@ -1327,6 +1352,7 @@ verify("enterContinuousTimeModeSuccess", f.fmi3_enterContinuousTimeMode(instance
 verify("terminateSuccess", f.fmi3_terminate(instance))
 
 f.fmi3_freeInstance(instance)
+f.fmi3_freeInstance(instance2)
 
 f.fmi4c_freeFmu()
 


### PR DESCRIPTION
Separe the handle for the loaded FMU (fmiHandle, allocated by importing tool) from the handle to the FMU instance (fmiXComponent, allocated by the FMU). This should make it possible to instantiate multiple instances of the same FMU.

Resolves #85.

- [x] FMI1 support
- [x] FMI2 support
- [x] FMI3 support
- [x] Test for FMI1
- [x] Test for FMI2
- [x] Test for FMI3