### PR TITLE
Fix random seed windows

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -5,7 +5,7 @@ on: [pull_request]
 jobs:
   cmake-mingw:
     timeout-minutes: 5
-    runs-on: windows-2019
+    runs-on: windows-2025
     steps:
       - uses: actions/setup-python@v5
         with:
@@ -39,7 +39,7 @@ jobs:
         
   cmake-msvc2019:
     timeout-minutes: 5
-    runs-on: windows-2019
+    runs-on: windows-2025
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -51,7 +51,7 @@ jobs:
       - name: Configure
         working-directory: fmi4c-build
         shell: cmd
-        run: cmake -DFMI4C_BUILD_TEST=ON -DCMAKE_BUILD_TYPE=Release -G"Visual Studio 16 2019" ..
+        run: cmake -DFMI4C_BUILD_TEST=ON -DCMAKE_BUILD_TYPE=Release -G"Visual Studio 17 2022" ..
 
       - name: Build
         working-directory: fmi4c-build
@@ -99,7 +99,7 @@ jobs:
     steps:
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: '3.11'
           
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -65,7 +65,7 @@ jobs:
         
   cmake-ubuntu:
     timeout-minutes: 5
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/setup-python@v5
         with:
@@ -95,7 +95,7 @@ jobs:
         
   cmake-ubuntu-python:
     timeout-minutes: 5
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/setup-python@v5
         with:

--- a/fmi4c.py
+++ b/fmi4c.py
@@ -168,7 +168,7 @@ class fmi4c:
         self.hdll.fmi1_getModelTypesPlatform.restype = ct.c_char_p
         self.hdll.fmi1_getModelTypesPlatform.argtypes = ct.c_void_p,
         self.hdll.fmi1_instantiateModel.restype = ct.c_void_p
-        self.hdll.fmi1_instantiateModel.argtypes = ct.c_void_p,ct.c_void_p,ct.c_void_p,ct.c_bool,
+        self.hdll.fmi1_instantiateModel.argtypes = ct.c_void_p,ct.c_void_p,ct.c_void_p,ct.c_void_p,ct.c_bool,
         self.hdll.fmi1_freeModelInstance.restype = None
         self.hdll.fmi1_freeModelInstance.argtypes = ct.c_void_p,
         self.hdll.fmi1_setTime.restype = ct.c_int

--- a/src/fmi4c.c
+++ b/src/fmi4c.c
@@ -22,7 +22,6 @@
 #include <dlfcn.h>
 #include <unistd.h>
 #include <sys/stat.h>
-#include <windows.h>
 #endif
 
 #if defined(__x86_64__) || defined(_M_X64)

--- a/src/fmi4c.c
+++ b/src/fmi4c.c
@@ -22,6 +22,7 @@
 #include <dlfcn.h>
 #include <unistd.h>
 #include <sys/stat.h>
+#include <windows.h>
 #endif
 
 #if defined(__x86_64__) || defined(_M_X64)
@@ -4484,7 +4485,16 @@ const char* generateTempPath(const char *instanceName)
 
      // Create a unique name for the temp folder
      char tempFileName[11] = "\0\0\0\0\0\0\0\0\0\0\0";
-     srand(getpid());
+     struct timeval tv;
+     FILETIME ft;
+
+    //Seed the random generator
+     GetSystemTimeAsFileTime(&ft);
+     unsigned long long time64 = (((unsigned long long)ft.dwHighDateTime) << 32) | ft.dwLowDateTime;
+     unsigned int seed = (unsigned int)(time64 ^ GetCurrentProcessId());
+     srand(seed);
+
+     //Append random string
      for(int i=0; i<10; ++i) {
          tempFileName[i] = rand() % 26 + 65;
      }

--- a/test/pytest.py
+++ b/test/pytest.py
@@ -210,11 +210,11 @@ version = f.fmi1_getVersion()
 verify("version", version)
 
 instance = 0   
-instance = instantiateSuccess = f.fmi1_instantiateSlave(b"application/x-fmu-sharedlibrary", 1.0, False, False, False)
+instance = f.fmi1_instantiateSlave(b"application/x-fmu-sharedlibrary", 1.0, False, False, False)
 verify("instantiateSuccess", instance != 0)
 
 instance2 = 0   
-instance2 = instantiateSuccess = f.fmi1_instantiateSlave(b"application/x-fmu-sharedlibrary", 1.0, False, False, False)
+instance2 = f.fmi1_instantiateSlave(b"application/x-fmu-sharedlibrary", 1.0, False, False, False)
 verify("instantiateSuccess", instance2 != 0)
 
 setDebugLoggingSuccess = f.fmi1_setDebugLogging(instance, True)


### PR DESCRIPTION
Use system time instead of process ID to seed random generator. This gives each FMU a (hopefully) unique temp path.